### PR TITLE
Wprime and Zprime to muon in Pythia8

### DIFF
--- a/python/ThirteenTeV/WprimeToMuMu_M_5000_Tune4C_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/WprimeToMuMu_M_5000_Tune4C_13TeV_pythia8_cfi.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+source = cms.Source("EmptySource")
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        comEnergy = cms.double(13000.0),
+        crossSection = cms.untracked.double(4.105e-4),
+        filterEfficiency = cms.untracked.double(1),
+        maxEventsToPrint = cms.untracked.int32(0),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        PythiaParameters = cms.PSet(
+                processParameters = cms.vstring(
+                        'Main:timesAllowErrors = 10000',
+                        'ParticleDecays:limitTau0 = on',
+                        'ParticleDecays:tauMax = 10',
+                        'Tune:ee 3',
+                        'Tune:pp 5',
+
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 5000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+
+                ),
+                parameterSets = cms.vstring('processParameters')
+        )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/ZprimeToMuMu_M_5000_Tune4C_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/ZprimeToMuMu_M_5000_Tune4C_13TeV_pythia8_cfi.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+source = cms.Source("EmptySource")
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        comEnergy = cms.double(13000.0),
+        crossSection = cms.untracked.double(5.511e-5),
+        filterEfficiency = cms.untracked.double(1),
+        maxEventsToPrint = cms.untracked.int32(0),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        PythiaParameters = cms.PSet(
+                processParameters = cms.vstring(
+                        'Main:timesAllowErrors = 10000',
+                        'ParticleDecays:limitTau0 = on',
+                        'ParticleDecays:tauMax = 10',
+                        'Tune:ee 3',
+                        'Tune:pp 5',
+
+                        'NewGaugeBoson:ffbar2gmZZprime = on',
+                        'Zprime:gmZmode = 3', # only pure Z' contribution
+                        '32:m0 = 5000',
+                        '32:onMode = off', # switch off all of the Z' decay
+                        '32:onIfAny = 13', # switch on the Z'->mu-mu+
+                ),
+                parameterSets = cms.vstring('processParameters')
+        )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Pythia8 fragment for Z' → mumu and W' → munu with mass=5TeV needed for MUO POG studies.
