### PR TITLE
Hadronizer for SUSY Madgraph scans using tauola++ instead of tauola

### DIFF
--- a/python/EightTeV/Hadronizer_SMS_Scans_2jets_Qcut44_TuneZ2star_8TeV_madgraph_tauolapp_cff.py
+++ b/python/EightTeV/Hadronizer_SMS_Scans_2jets_Qcut44_TuneZ2star_8TeV_madgraph_tauolapp_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia6HadronizerFilter",
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    comEnergy = cms.double(8000.0),
+    ExternalDecays = cms.PSet(
+        Tauolapp111a = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauolapp111a')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0         ! User defined processes', 
+                        'PMAS(5,1)=4.8   ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+                        'MDCY(C1000022,1)=0  ! stable neutralino',
+			'MSTJ(1)=1       ! Fragmentation/hadronization on or off',
+			'MSTP(61)=1      ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+
+    ),
+    jetMatching = cms.untracked.PSet(
+       scheme = cms.string("Madgraph"),
+       mode = cms.string("auto"),	# soup, or "inclusive" / "exclusive"
+       MEMAIN_nqmatch = cms.int32(5),
+       MEMAIN_etaclmax = cms.double(5),
+       MEMAIN_qcut = cms.double(44),
+       MEMAIN_minjets = cms.int32(0),
+       MEMAIN_maxjets = cms.int32(2),
+       MEMAIN_showerkt = cms.double(0),   
+       MEMAIN_excres = cms.string(""),
+       outTree_flag = cms.int32(0)    
+    )    
+)


### PR DESCRIPTION
New Hadronizer to use with SUSY requests that have taus coming from sparticles. Tauola++ is needed, as there is a bug in tauola for this use case. 
