### PR TITLE
Added QCD flat Pt and eta Pythia8 configuration files

### DIFF
--- a/python/EightTeV/QCD_BBbar_Pt_15to500_Tune4C_FlatPtEta_8TeV_pythia8_cff.py
+++ b/python/EightTeV/QCD_BBbar_Pt_15to500_Tune4C_FlatPtEta_8TeV_pythia8_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+       comEnergy = cms.double(8000.0),
+       crossSection = cms.untracked.double(4.468e+06),
+       filterEfficiency = cms.untracked.double(1),
+       maxEventsToPrint = cms.untracked.int32(0),
+       pythiaHepMCVerbosity = cms.untracked.bool(False),
+       pythiaPylistVerbosity = cms.untracked.int32(0),
+       #reweightGen = cms.PSet(),       # flat in Pt
+       #reweightGenRap = cms.PSet(      # flat in eta
+          #yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
+          #yLabPower = cms.double(2.),
+          #yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
+          #yCMPower = cms.double(2.),
+          #pTHatMin = cms.double(15.),
+          #pTHatMax = cms.double(3000.)
+       #),
+       reweightGenPtHatRap = cms.PSet( # flat in Pt and eta
+          yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
+          yLabPower = cms.double(2.),
+          yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
+          yCMPower = cms.double(2.),
+          pTHatMin = cms.double(15.),
+          pTHatMax = cms.double(3000.)
+       ),
+
+       PythiaParameters = cms.PSet(
+              processParameters = cms.vstring(
+                     'Main:timesAllowErrors = 10000',
+                     'ParticleDecays:limitTau0 = on',
+                     'ParticleDecays:tauMax = 10',
+                     'HardQCD:gg2bbbar = on',
+                     'HardQCD:qqbar2bbbar = on',
+                     'PhaseSpace:pTHatMin = 15',
+                     'PhaseSpace:pTHatMax = 500',
+                     'Tune:pp 5',
+                     'Tune:ee 3'
+              ),
+              parameterSets = cms.vstring('processParameters')
+       )
+)
+
+configurationMetadata = cms.untracked.PSet(
+       version = cms.untracked.string('\$Revision$'),
+       name = cms.untracked.string('\$Source$'),
+       annotation = cms.untracked.string('Upgrade TP sample with PYTHIA8: QCD bbbar production, pThat = 15 .. 500 GeV, weighted, Tune4C')
+)

--- a/python/EightTeV/QCD_Pt_15to500_Tune4C_FlatPtEta_8TeV_pythia8_cff.py
+++ b/python/EightTeV/QCD_Pt_15to500_Tune4C_FlatPtEta_8TeV_pythia8_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+       comEnergy = cms.double(8000.0),
+       crossSection = cms.untracked.double(1.242e+09),
+       filterEfficiency = cms.untracked.double(1),
+       maxEventsToPrint = cms.untracked.int32(0),
+       pythiaHepMCVerbosity = cms.untracked.bool(False),
+       pythiaPylistVerbosity = cms.untracked.int32(0),
+       #reweightGen = cms.PSet(),       # flat in Pt
+       #reweightGenRap = cms.PSet(      # flat in eta
+          #yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
+          #yLabPower = cms.double(2.),
+          #yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
+          #yCMPower = cms.double(2.),
+          #pTHatMin = cms.double(15.),
+          #pTHatMax = cms.double(3000.)
+       #),
+       reweightGenPtHatRap = cms.PSet( # flat in Pt and eta
+          yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
+          yLabPower = cms.double(2.),
+          yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
+          yCMPower = cms.double(2.),
+          pTHatMin = cms.double(15.),
+          pTHatMax = cms.double(3000.)
+       ),
+
+       PythiaParameters = cms.PSet(
+              processParameters = cms.vstring(
+                     'Main:timesAllowErrors = 10000',
+                     'ParticleDecays:limitTau0 = on',
+                     'ParticleDecays:tauMax = 10',
+                     'HardQCD:all = on',
+                     'PhaseSpace:pTHatMin = 15',
+                     'PhaseSpace:pTHatMax = 500',
+                     'Tune:pp 5',
+                     'Tune:ee 3'
+              ),
+              parameterSets = cms.vstring('processParameters')
+       )
+)
+
+configurationMetadata = cms.untracked.PSet(
+       version = cms.untracked.string('\$Revision$'),
+       name = cms.untracked.string('\$Source$'),
+       annotation = cms.untracked.string('Upgrade TP sample with PYTHIA8: QCD dijet production, pThat = 15 .. 500 GeV, weighted, Tune4C')
+)


### PR DESCRIPTION
Pythia8 configuration files for QCD samples flat in both Pt and eta. These samples will be used for BTV POG studies for the Phase 2 technical proposal. The config files require updated Pythia8 interface with additional User Hooks implemented. The necessary updates have been included in the following pull requests

https://github.com/cms-sw/cmssw/pull/2984 (pending)
https://github.com/cms-sw/cmssw/pull/3085 (merged)
