### PR TITLE
Single top fragments for CompHEP,LVLT,diff. pT filter steps

### DIFF
--- a/python/EightTeV/TToBENu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBENu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBENu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+

--- a/python/EightTeV/TToBENu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBENu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(16)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBENu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+

--- a/python/EightTeV/TToBMuNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBMuNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBMuNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+

--- a/python/EightTeV/TToBMuNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBMuNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(16)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBMuNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+

--- a/python/EightTeV/TToBTauNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBTauNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(15)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBTauNu_tchannel_0010_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+

--- a/python/EightTeV/TToBTauNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
+++ b/python/EightTeV/TToBTauNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.PythiaUEZ2starSettings_cfi import *
+
+generator = cms.EDFilter(
+    "Pythia6HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    comEnergy = cms.double(8000.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythiaUESettingsBlock,
+        processParameters = cms.vstring('MSEL=0 ! User defined processes',
+                        'PMAS(5,1)=4.8 ! b quark mass',
+                        'PMAS(6,1)=172.5 ! t quark mass',
+'MSTJ(1)=1 ! Fragmentation/hadronization on or off',
+'MSTP(61)=1 ! Parton showering on or off'),
+        # This is a vector of ParameterSet names to be read, in this order
+        parameterSets = cms.vstring('pythiaUESettings',
+            'processParameters')
+    ),
+)
+
+singleTopFilter = cms.EDFilter("ComphepSingletopFilter",
+    pTSep = cms.double(18)
+)
+
+ProductionFilterSequence = cms.Sequence(generator * singleTopFilter)
+
+configurationMetadata = cms.untracked.PSet(
+version = cms.untracked.string('$Revision: 1.1 $'),
+name = cms.untracked.string('$Source: /local/reps/CMSSW/CMSSW/Configuration/GenProduction/python/EightTeV/TToBTauNu_tchannel_unphys_LVLT_TuneZ2star_8TeV_comphep_cff.py,v $'),
+annotation = cms.untracked.string('Comphep single top t-channel at 8TeV')
+)
+


### PR DESCRIPTION
Adding Pythia fragments for single top t channel CompHEP files, anomalous coupling (LVLT) at 8 TeV; pT filter for matching was optimized for each lepton flavor separately.
