### PR TITLE
Some more fixes for QCD HT-binned fragments

### DIFF
--- a/python/ThirteenTeV/QCD_HT_1000ToInf_13TeV_madgraph_cfg.py
+++ b/python/ThirteenTeV/QCD_HT_1000ToInf_13TeV_madgraph_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh"),
-    outputFile = cms.string("events.lhe"),
+    outputFile = cms.string("QCD_HT-1000ToInf_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_amd64_gcc472/13TeV/madgraph/V5_1.5.11/QCD_HT-1000ToInf/v1',
     'QCD_HT-1000ToInf','false','false','qcd','5','75','true','2','4'),

--- a/python/ThirteenTeV/QCD_HT_100To250_13TeV_madgraph_cfg.py
+++ b/python/ThirteenTeV/QCD_HT_100To250_13TeV_madgraph_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh"),
-    outputFile = cms.string("events.lhe"),
+    outputFile = cms.string("QCD_HT-100To250_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_amd64_gcc472/13TeV/madgraph/V5_1.5.11/QCD_HT-100To250/v1',
     'QCD_HT-100To250','false','false','qcd','5','15','true','2','4'),

--- a/python/ThirteenTeV/QCD_HT_250To500_13TeV_madgraph_cfg.py
+++ b/python/ThirteenTeV/QCD_HT_250To500_13TeV_madgraph_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh"),
-    outputFile = cms.string("events.lhe"),
+    outputFile = cms.string("QCD_HT-250To500_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_amd64_gcc472/13TeV/madgraph/V5_1.5.11/QCD_HT-250To500/v1',
     'QCD_HT-250To500','false','false','qcd','5','32','true','2','4'),

--- a/python/ThirteenTeV/QCD_HT_500To1000_13TeV_madgraph_cfg.py
+++ b/python/ThirteenTeV/QCD_HT_500To1000_13TeV_madgraph_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_madgraph_gridpack.sh"),
-    outputFile = cms.string("events.lhe"),
+    outputFile = cms.string("QCD_HT-500To1000_final.lhe"),
     numberOfParameters = cms.uint32(10),
     args = cms.vstring('slc5_amd64_gcc472/13TeV/madgraph/V5_1.5.11/QCD_HT-500To1000/v1',
     'QCD_HT-500To1000','false','false','qcd','5','54','true','2','4'),


### PR DESCRIPTION
They have been confirmed to work in MCM.
