### PR TITLE
Updated getSherpack modification

### DIFF
--- a/python/getSherpack.py
+++ b/python/getSherpack.py
@@ -2,12 +2,12 @@ import FWCore.ParameterSet.Config as cms
 import os
 
 def customise(process):
-  os.system("echo 'Start directory'; pwd;
-             cd $CMSSW_BASE/..;
-             fn-fileget -c `cmsGetFnConnect frontier://smallfiles` slc5_ia32_gcc434/sherpa/1.3.0-cms/sherpa_DYToLL_10to50_MASTER_v2.tgz;
-             tar -xzf sherpa_DYToLL_10to50_MASTER_v2.tgz;
-             echo 'CmsRun directory:'; pwd;
-             ls *;
-             cd -;
+  os.system("echo 'Start directory'; pwd;\
+             cd $CMSSW_BASE/..;\
+             fn-fileget -c `cmsGetFnConnect frontier://smallfiles` slc5_ia32_gcc434/sherpa/1.3.0-cms/sherpa_DYToLL_10to50_MASTER_v2.tgz;\
+             tar -xzf sherpa_DYToLL_10to50_MASTER_v2.tgz;\
+             echo 'CmsRun directory:'; pwd;\
+             ls *;\
+             cd -;\
              echo 'Back to original directory:'; pwd")
   return(process)


### PR DESCRIPTION
Should always unpack in the top directory (above CMSSW_BASE), where cmsRun is executed
