### PR TITLE
Further gridpack fixes/improvements

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/mgfixes.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/mgfixes.patch
@@ -1,15 +1,26 @@
-diff -ur old/MG5_aMC_v2_2_1/madgraph/various/cluster.py ./MG5_aMC_v2_2_1/madgraph/various/cluster.py
---- old/MG5_aMC_v2_2_1/madgraph/various/cluster.py      2014-09-25 16:56:11.000000000 +0200
-+++ ./MG5_aMC_v2_2_1/madgraph/various/cluster.py        2014-09-26 02:09:13.305419805 +0200
-@@ -1304,6 +1304,8 @@
+diff -ur orig/MG5_aMC_v2_2_1/madgraph/various/cluster.py MG5_aMC_v2_2_1/madgraph/various/cluster.py
+--- orig/MG5_aMC_v2_2_1/madgraph/various/cluster.py     2014-09-25 16:56:11.000000000 +0200
++++ MG5_aMC_v2_2_1/madgraph/various/cluster.py  2014-10-05 18:14:52.000000000 +0200
+@@ -213,8 +213,8 @@
+             old_mode = mode
+             nb_iter += 1
+             idle, run, finish, fail = self.control(me_dir)
+-            if fail:
+-                raise ClusterManagmentError('Some Jobs are in a Hold/... state. Please try to investigate or contact the IT team')
++            #if fail:
++                #raise ClusterManagmentError('Some Jobs are in a Hold/... state. Please try to investigate or contact the IT team')
+             if idle + run == 0:
+                 #time.sleep(20) #security to ensure that the file are really written on the disk
+                 logger.info('All jobs finished')
+@@ -1303,6 +1303,8 @@
+             pass
          if log is None:
              log = '/dev/null'
++
++        text += 'if [ -n $CMSSW_BASE ]; then cd $CMSSW_BASE; eval `scramv1 runtime -sh`; cd -; fi;'
          
-+        text += 'if [ -n $CMSSW_BASE ]; then cd $CMSSW_BASE; eval `scramv1 runtime -sh`; cd -; fi;'           
-+        
          text += prog
          if argument:
-             text += ' ' + ' '.join(argument)
 diff -ur old/MG5_aMC_v2_2_1/Template/LO/bin/internal/Gridpack/run.sh ./MG5_aMC_v2_2_1/Template/LO/bin/internal/Gridpack/run.sh
 --- old/MG5_aMC_v2_2_1/Template/LO/bin/internal/Gridpack/run.sh 2014-09-25 16:56:11.000000000 +0200
 +++ ./MG5_aMC_v2_2_1/Template/LO/bin/internal/Gridpack/run.sh   2014-09-26 02:14:50.115432890 +0200


### PR DESCRIPTION
1) Critical fix for LO gridpacks (workaround for problems producing events with python 2.6)

2) Improved handling of failing lsf jobs
