### PR TITLE
Update release?

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -83,7 +83,7 @@ cd $AFS_GEN_FOLDER
 # export RELEASE=CMSSW_5_3_21
 
 export SCRAM_ARCH=slc6_amd64_gcc481
-export RELEASE=CMSSW_7_3_X_2014-10-03-0200
+export RELEASE=CMSSW_7_3_0_pre1
 
 #################################
 #Clean the area the working area#


### PR DESCRIPTION
The nightly build is not present anymore on lxplus, the CMSSW_7_3_0_pre1 release seems to work fine.
