### PR TITLE
Add QCD BTV fragments for RunIIFall14GS pure pythia8

### DIFF
--- a/python/ThirteenTeV/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.15544),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(10.4305),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 1000',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 1000toInf GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.05362),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(469797),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 120',
+			'PhaseSpace:pTHatMax = 170',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 120to170 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00300),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.27319e+09),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 15',
+			'PhaseSpace:pTHatMax = 20',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 15to20 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.07335),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(117989),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 170',
+			'PhaseSpace:pTHatMax = 300',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 170to300 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-20to30_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-20to30_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00530),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(5.58528e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 20',
+			'PhaseSpace:pTHatMax = 30',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 20to30 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00042),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(7.20648e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 20',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(15.,15.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat > 20 GeV, with INCLUSIVE muon preselection (pt(mu) > 15 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.10196),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(7820.25),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 300',
+			'PhaseSpace:pTHatMax = 470',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 300to470 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.01182),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.39803e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 30',
+			'PhaseSpace:pTHatMax = 50',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 30to50 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.12242),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(645.528),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 470',
+			'PhaseSpace:pTHatMax = 600',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 470to600 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.02276),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.92225e+07),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 50',
+			'PhaseSpace:pTHatMax = 80',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 50to80 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.13412),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(187.109),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 600',
+			'PhaseSpace:pTHatMax = 800',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 600to800 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.14552),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(32.3486),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 800',
+			'PhaseSpace:pTHatMax = 1000',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 800to1000 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.03844),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(2.75842e+06),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+            		'ParticleDecays:limitTau0 = off',
+			'ParticleDecays:limitCylinder = on',
+            		'ParticleDecays:xyMax = 2000',
+            		'ParticleDecays:zMax = 4000',
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 80',
+			'PhaseSpace:pTHatMax = 120',
+           		'130:mayDecay = on',
+            		'211:mayDecay = on',
+            		'321:mayDecay = on'
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+
+mugenfilter = cms.EDFilter("MCSmartSingleParticleFilter",
+                           MinPt = cms.untracked.vdouble(5.,5.),
+                           MinEta = cms.untracked.vdouble(-2.5,-2.5),
+                           MaxEta = cms.untracked.vdouble(2.5,2.5),
+                           ParticleID = cms.untracked.vint32(13,-13),
+                           Status = cms.untracked.vint32(1,1),
+                           # Decay cuts are in mm
+                           MaxDecayRadius = cms.untracked.vdouble(2000.,2000.),
+                           MinDecayZ = cms.untracked.vdouble(-4000.,-4000.),
+                           MaxDecayZ = cms.untracked.vdouble(4000.,4000.)
+)
+
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD dijet production, pThat 80to120 GeV, with INCLUSIVE muon preselection (pt(mu) > 5 GeV), 13 TeV, TuneCUETP8M1')
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mugenfilter)

--- a/python/ThirteenTeV/QCD_Pt_1000toInf_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_1000toInf_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(10.4048),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 1000  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 1000toInf GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/python/ThirteenTeV/QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_10to15_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(5.88758e+09),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 10  ',
+			'PhaseSpace:pTHatMax = 15  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 10to15 GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/python/ThirteenTeV/QCD_Pt_15to20_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_15to20_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00020),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.27298e+09),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 15  ',
+			'PhaseSpace:pTHatMax = 20  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 15to20 GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+

--- a/python/ThirteenTeV/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.02492),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(105771),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 170  ',
+			'PhaseSpace:pTHatMax = 250  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 170to250 GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+

--- a/python/ThirteenTeV/QCD_Pt_20to30_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_20to30_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00059),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(5.57627e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 20  ',
+			'PhaseSpace:pTHatMax = 30  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 20to30 GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+

--- a/python/ThirteenTeV/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.03375),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(21094.1),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 250  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 250toInf GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+

--- a/python/ThirteenTeV/QCD_Pt_30to80_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_30to80_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.00255),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(1.59068e+08),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 30  ',
+			'PhaseSpace:pTHatMax = 80  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 30to80 GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+

--- a/python/ThirteenTeV/QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_5to10_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(6.10183e+10),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 5  ',
+			'PhaseSpace:pTHatMax = 10  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 5to10 GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/python/ThirteenTeV/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(0.01183),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(3.221e+06),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 80  ',
+			'PhaseSpace:pTHatMax = 170  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+genParticlesForFilter = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+
+bctoefilter = cms.EDFilter("BCToEFilter",
+                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(10),
+                                                     genParSource = cms.InputTag("genParticlesForFilter")
+                                                     )
+                           )
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('b/c->e filtered QCD pthat 80to170 GeV, 13 TeV, TuneCUETP8M1')
+)
+
+# add your filters to this sequence
+ProductionFilterSequence = cms.Sequence(generator * (genParticlesForFilter + bctoefilter ))
+
+
+


### PR DESCRIPTION
I add here all the fragments assigned to BTV for the pythia8 production (with the exception of the QCD inclusive bins already present that were used for the recent RECODEBUG production for 72X digi-reco): i.e. MuEnriched pThat >20 GeV, ptmu>15 GeV; MuEnriched 12 ptHat bins ptmu>5 GeV; bcToE, eT>10 GeV (this value was not specified in the spreadsheet but it is the one used in previous requests); QCD inclusive (added extra 3 pThat bins).

Cross sections and filter efficiencies have been computed with 100k events. 
