### PR TITLE
Additional high pThat QCD bins

### DIFF
--- a/python/ThirteenTeV/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(0.114943),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 1800  ',
+			'PhaseSpace:pTHatMax = 2400  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 1800to2400 GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/python/ThirteenTeV/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(0.00682981),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 2400  ',
+			'PhaseSpace:pTHatMax = 3200  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 2400to3200 GeV, 13 TeV, TuneCUETP8M1')
+)

--- a/python/ThirteenTeV/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.0),
+
+	crossSection = cms.untracked.double(0.000165445),
+
+	PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CUEP8M1SettingsBlock,
+	    processParameters = cms.vstring(
+			'HardQCD:all = on',
+			'PhaseSpace:pTHatMin = 3200  ',
+	    ),
+            parameterSets = cms.vstring('pythia8CommonSettings',
+                                        'pythia8CUEP8M1Settings',
+                                        'processParameters',
+                                        )
+	)
+)
+
+configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('\$Revision$'),
+    name = cms.untracked.string('\$Source$'),
+    annotation = cms.untracked.string('QCD pthat 3200toInf GeV, 13 TeV, TuneCUETP8M1')
+)


### PR DESCRIPTION
Including as agreed 3 additional QCD hight pThat bins for the RunIIFall14GS campaign (the other 2 extra bins: 1000to1400 and 1400to1800 were already present due to the RECODEBUG for 72X digi-reco production).
