### PR TITLE
aMC@NLO Patches for sysCalc and reweight card from Olivier

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/multiple_pdf.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/multiple_pdf.patch
@@ -1,0 +1,70 @@
+=== modified file 'include/SysCalc.h'
+--- old/include/SysCalc.h	2014-03-10 02:55:31 +0000
++++ new/include/SysCalc.h	2015-01-12 13:23:06 +0000
+@@ -111,7 +111,7 @@
+   // alpha_s emission scale cross-section (ratio)
+   vector<double> _alpsxsec;
+   // PDF cross-section (ratio)
+-  vector<double> _pdfxsec;
++  vector< vector<double> > _pdfxsec;
+   // QCUT cross-section (ratio)
+   vector<double> _matchxsec;
+ 
+
+=== modified file 'src/SysCalc.cc'
+--- old/src/SysCalc.cc	2014-03-13 16:16:14 +0000
++++ new/src/SysCalc.cc	2015-01-12 13:22:49 +0000
+@@ -43,6 +43,7 @@
+ 
+ void SysCalc::write_xsec(){
+ 	double min,max;
++	double one_set_min, one_set_max;
+ 	//min = 0.;
+ 	//max = 0.;
+ 	  for (int i=0; i < _scalexsec.size(); i++) {
+@@ -61,12 +62,21 @@
+   	//  	  	cout << "min/max:"<< min<< " " << max << endl;
+   	  	min=0.;
+   	  	max =0.;
+-  	  	  	  	  for (int i=0; i < _pdfxsec.size(); i++) {
+-  	  	  	  	  	  	  cout <<"pdf reweighted cross-section  :"<< i <<" "<< _pdfxsec[i] <<endl;
+-	  	  	  	  	  	  if (min == 0. or _pdfxsec[i] < min) min =  _pdfxsec[i];
+-	  	  	  	  	  	  if (max == 0. or _pdfxsec[i] > max) max =  _pdfxsec[i];
++		int weight_id = 0;
++		for (int i=0; i < _pdfxsec.size(); i++){
++		  one_set_min = 0.;
++		  one_set_max = 0.;
++		  for (int j=0; j < _pdfxsec[i].size(); j++) {
++  	  	  	  	  	  	  cout <<"pdf reweighted cross-section  :"<< weight_id++ <<" "<< _pdfxsec[i][j] <<endl;
++	  	  	  	  	  	  if (min == 0. or _pdfxsec[i][j] < min) min =  _pdfxsec[i][j];
++	  	  	  	  	  	  if (max == 0. or _pdfxsec[i][j] > max) max =  _pdfxsec[i][j];
++	  	  	  	  	  	  if (one_set_min == 0. or _pdfxsec[i][j] < one_set_min) one_set_min =  _pdfxsec[i][j];
++	  	  	  	  	  	  if (one_set_max == 0. or _pdfxsec[i][j] > one_set_max) one_set_max =  _pdfxsec[i][j];
+     	  	  	  	  	  }
+-  	  	  	  	cout << "min/max:"<< min<< " " << max << endl;
++  	  	  	  	cout << "min/max for the set:"<< one_set_min<< " " << one_set_max << endl;
++		  }
++		if(_pdfxsec.size() >1) 	cout << "min/max for all set:"<< min<< " " << max << endl;
++
+ 	  for (int i=0; i < _matchxsec.size(); i++) {
+ 	    cout <<"nb of event for qcut :"<< i <<" " << _matchscales[i] <<" "<< _matchxsec[i] <<endl;
+ 	//  	  	  	  	  	  if (min == 0. or _scalexsec[i] < min) min =  _scalexsec[i];
+@@ -725,10 +735,14 @@
+       if (DEBUG) cout << "Total PDF factor: " << pdf_fact << endl;
+       pdffacts->push_back(pdf_fact/org_weight * _event_weight);
+       if (DEBUG) cout << "PDF weight: " << (*pdffacts)[pdffacts->size()-1] << endl;
+-      if (pdffacts->size() -1 == _pdfxsec.size()){
+-         	_pdfxsec.push_back(pdf_fact/org_weight * _event_weight);
++      if (_pdfxsec.size() == i){
++	vector<double> tmp; 
++	_pdfxsec.push_back(tmp);
++      }
++      if (pdffacts->size() -1 == _pdfxsec[i].size()){
++         	_pdfxsec[i].push_back(pdf_fact/org_weight * _event_weight);
+       }else{
+-         	_pdfxsec[pdffacts->size() -1] += pdf_fact/org_weight * _event_weight;
++         	_pdfxsec[i][pdffacts->size() -1] += pdf_fact/org_weight * _event_weight;
+       }
+ 
+ 
+

--- a/bin/MadGraph5_aMCatNLO/patches/reweight.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/reweight.patch
@@ -1,0 +1,13 @@
+=== modified file 'madgraph/various/lhe_parser.py'
+--- madgraph/various/lhe_parser.py 2014-12-10 18:36:11 +0000
++++ madgraph/various/lhe_parser.py 2015-01-29 16:27:25 +0000
+@@ -227,8 +227,8 @@
+         self.reweight_order = []
+         start, stop = self.tag.find('<rwgt>'), self.tag.find('</rwgt>')
+         if start != -1 != stop :
+-            pattern = re.compile(r'''<\s*wgt id=\'(?P<id>[^\']+)\'\s*>\s*(?P<val>[\ded+-.]*)\s*</wgt>''')
++            pattern = re.compile(r'''<\s*wgt id=(?:\'|\")(?P<id>[^\'\"]+)(?:\'|\")\s*>\s*(?P<val>[\ded+-.]*)\s*</wgt>''')
+             data = pattern.findall(self.tag)
+             try:
+                 self.reweight_data = dict([(pid, float(value)) for (pid, value) in data
+                                            if not self.reweight_order.append(pid)])


### PR DESCRIPTION
multiple_pdf.patch fixes the output of PDF weighted cross section in sysCalc

reweight.patch fixes the erasing of scale/PDF weights if we run sysCalc first and run bin/madevent reweight second.