### PR TITLE
Update of create_powheg_tarball.sh and runcmsgrid_powheg.sh

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -7,8 +7,8 @@ EXPECTED_ARGS=8
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
-    echo "Usage: `basename $0` source_repository source_tarball_name process card tarballName Nevents RandomSeed"
-    echo "Example: `basename $0` slc6_amd64_gcc481/powheg/V1.0/src powhegboxv1.0_Oct2013 Z slc6_amd64_gcc481/powheg/V1.0/8TeV_Summer12/DYToEE_M-20_8TeV-powheg/v1/DYToEE_M-20_8TeV-powheg.input Z_local 1000 1212" 
+    echo "Usage: `basename $0` source_repository source_tarball_name process card tarballName othercard Nevents RandomSeed"
+    echo "Example: `basename $0` slc6_amd64_gcc481/powheg/V1.0/src powhegboxv1.0_Oct2013 Z slc6_amd64_gcc481/powheg/V1.0/8TeV_Summer12/DYToEE_M-20_8TeV-powheg/v1/DYToEE_M-20_8TeV-powheg.input none Z_local 1000 1212" 
     exit 1
 fi
 
@@ -124,6 +124,10 @@ fi
 if [ "$process" = "trijet" ]; then 
    BOOK_HISTO+=" observables.o"
 fi  
+if [ "$process" = "VBF_HJJJ" ]; then 
+  mv pwhg_analysis-dummy.f pwhg_analysis-dummy.f.orig
+  sed 's/..\/pwhg_book.h/pwhg_book.h/g' pwhg_analysis-dummy.f.orig > pwhg_analysis-dummy.f
+fi  
 
 # Remove ANY kind of analysis with parton shower
 if [ `grep particle_identif pwhg_analysis-dummy.f` = ""]; then
@@ -137,6 +141,12 @@ if [ "$process" = "ttJ" ]; then
   mv Makefile Makefile.interm
   cat Makefile.interm | sed -e "s#_PATH) -L#_PATH) #g" | sed -e "s# -lvirtual#/libvirtual.so.1.0.0#g" > Makefile
 fi
+if [ "$process" = "gg_H_MSSM" ]; then 
+  mv nloreal.F nloreal.F.orig
+  sed 's/leq/le/g' nloreal.F.orig > nloreal.F
+  cp -p ../gg_H_quark-mass-effects/SLHA.h .
+  cp -p ../gg_H_quark-mass-effects/SLHADefs.h .
+fi  
   
 echo "ANALYSIS=none 
 PWHGANAL=$BOOK_HISTO pwhg_analysis-dummy.o

--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -172,6 +172,39 @@ then
 	mv pwgevents-rwgt.lhe pwgevents.lhe
 	mv powheg.input powheg.input.${iteration}
     done
+
+
+
+    echo -e "\ncomputing weights for NNPDF 3.0 alphas=0.117 variation\n"
+    iteration=265000
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+
+
+    echo -e "\ncomputing weights for NNPDF 3.0 alphas=0.119 variation\n"
+    iteration=266000
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+
+
     echo -e "\ncomputing weights for 52+1 CT10 PDF variations\n"
     iteration=10999
     lastfile=11052
@@ -192,9 +225,38 @@ then
 	mv powheg.input powheg.input.${iteration}
     done
 
-    echo -e "\ncomputing weights for 16 CT10 alphas variations\n"
-    iteration=11061
-    lastfile=11077
+    echo -e "\ncomputing weights for CT10 alphas=0.117 variation\n"
+    iteration=11067
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+
+    echo -e "\ncomputing weights for CT10 alphas=0.119 variation\n"
+    iteration=11069
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+ 
+
+    echo -e "\ncomputing weights for 50+1 MMHT2014nlo68clas118 PDF variations\n"
+    iteration=25199
+    lastfile=25250
     counter=4000
     while [ $iteration -lt $lastfile ];
     do
@@ -212,64 +274,26 @@ then
 	mv powheg.input powheg.input.${iteration}
     done
 
-    echo -e "\ncomputing weights for MSTW central values\n"
-    iteration=21100
-    counter=5000
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
+    echo -e "\ncomputing weights for 5 MMHT2014nlo68cl 5 alphas variations\n"
+    iteration=25259
+    lastfile=25264
+    while [ $iteration -lt $lastfile ];
+    do
+	iteration=$(( iteration + 1 ))
+	echo -e "\n PDF set ${iteration}"
+	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	counter=$(( counter + 1 ))
+	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-    echo -e "\ncomputing weights for NNPDF 2.3 central values\n"
-    iteration=244600
-    counter=6000
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+	mv pwgevents-rwgt.lhe pwgevents.lhe
+	mv powheg.input powheg.input.${iteration}
+    done
 
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
-
-
-    echo -e "\ncomputing weights for NNPDF 2.3 two alphas variation\n"
-    iteration=244400
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
-
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
-
-
-    iteration=244800
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
-
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
 
     rm -rf powheg.input*
     sed -e "/#new weight/d" -e "/<wgt id='c'>/d" -e "/<weight id='c'>/d" pwgevents.lhe > pwgevents.lhe.tmp


### PR DESCRIPTION
create_powheg_tarball.sh: in the past, I have fixed some files and added missing files in the VBF_HJJJ and gg_H_MSSM POWHEGBOX V2 packages by creating a source tar ball containing these fixed files. 

In this version, instead of updating the source tar ball, I fix and add files when running the
create_powheg_tarball.sh on the fly.
These changes will make the update of powheg source tar ball easier.

runcmsgrid_powehg.sh: update of PDF sets we use to compute weights