### PR TITLE
Update of bin/Powheg: patch Roberto's fixes of PDF weights limitation on the fly

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -103,6 +103,7 @@ fi
 wget --no-check-certificate http://cms-project-generators.web.cern.ch/cms-project-generators/${repo}/${name}.tar.gz  -O ${name}.tar.gz || fail_exit "Failed to get powheg tar ball " ${name}
 tar xzf ${name}.tar.gz
 #
+patch -l -p0 -i ${WORKDIR}/patches/pdfweights.patch
 cd POWHEG-BOX/${process}
 
 # This is just to please gcc 4.8.1

--- a/bin/Powheg/patches/pdfweights.patch
+++ b/bin/Powheg/patches/pdfweights.patch
@@ -1,5 +1,5 @@
 --- POWHEG-BOX/include/pwhg_lhrwgt.h	2015-01-30 09:54:31.845227920 +0100
-+++ ../roberto_powheg/POWHEG-BOX/include/pwhg_lhrwgt.h	2015-02-16 18:33:36.000000000 +0100
++++ ../roberto/POWHEG-BOX/include/pwhg_lhrwgt.h	2015-02-18 14:29:12.772549580 +0100
 @@ -2,7 +2,7 @@
  
  c Maximum number of weights
@@ -9,55 +9,9 @@
        integer  lhrwgt_max_header_columns
        parameter ( lhrwgt_max_header_columns=200)
        character * (lhrwgt_max_header_columns)
-@@ -11,28 +11,6 @@
-      1     lhrwgt_group_combine
-       integer lhrwgt_nheader
-       character * 400 lhrwgt_descr
--
--      integer maxgroups
--      parameter (maxgroups=20)
--      integer maxids
--      parameter (maxids=200)
--      integer lhrwgt_ngroups,lhrwgt_nids
--      character * 100 lhrwgt_group_name_arr(maxgroups),
--     1                lhrwgt_group_combine_arr(maxgroups),
--     2                lhrwgt_id_arr(maxids)
--      character * 400 lhrwgt_descr_arr(maxids)
--      real * 8 lhrwgt_weights(maxids)
--      integer lhrwgt_group_ptr(maxids)
--
--
-       common/pwhg_lhrwgt/lhrwgt_nheader,lhrwgt_header,
-      1     lhrwgt_id,lhrwgt_descr,lhrwgt_group_name,
--     2     lhrwgt_group_combine,
--     3     lhrwgt_weights,lhrwgt_ngroups,lhrwgt_nids,
--     4     lhrwgt_group_ptr,lhrwgt_group_name_arr,
--     5     lhrwgt_group_combine_arr,lhrwgt_id_arr,lhrwgt_descr_arr
--
--
--
--
--      
-+     2     lhrwgt_group_combine
 --- POWHEG-BOX/lhefwrite.f	2015-01-30 09:54:34.455177186 +0100
-+++ ../roberto_powheg/POWHEG-BOX/lhefwrite.f	2015-02-10 12:03:58.000000000 +0100
-@@ -60,15 +60,6 @@
-       include 'pwhg_flg.h'
-       include 'pwhg_lhrwgt.h'
-       integer i,j
--      integer, save :: counter=0
--      if(flg_noevents) then
--c do not write events, write only the event count
--         counter = counter + 1
--         if((counter/1000)*1000.eq.counter) then
--            write(nlf,*) counter
--         endif
--         return
--      endif
-       write(nlf,'(a)')'<event>'
-       write(nlf,210) nup,idprup,xwgtup,scalup,aqedup,aqcdup
-       do 200 i=1,nup
-@@ -76,6 +67,7 @@
++++ ../roberto/POWHEG-BOX/lhefwrite.f	2015-02-18 14:25:40.806725996 +0100
+@@ -76,6 +76,7 @@
       & mothup(2,i),icolup(1,i),icolup(2,i),(pup(j,i),j=1,5),
       & vtimup(i),spinup(i)
   200  continue
@@ -65,7 +19,7 @@
        if(flg_reweight) then
           call lhefwriteevrw(nlf)
           if(lhrwgt_id.ne.' ') then
-@@ -84,7 +76,6 @@
+@@ -84,7 +85,6 @@
              write(nlf,'(a)')'</rwgt>'
           endif
        endif

--- a/bin/Powheg/patches/pdfweights.patch
+++ b/bin/Powheg/patches/pdfweights.patch
@@ -1,0 +1,75 @@
+--- POWHEG-BOX/include/pwhg_lhrwgt.h	2015-01-30 09:54:31.845227920 +0100
++++ ../roberto_powheg/POWHEG-BOX/include/pwhg_lhrwgt.h	2015-02-16 18:33:36.000000000 +0100
+@@ -2,7 +2,7 @@
+ 
+ c Maximum number of weights
+       integer lhrwgt_maxnheader
+-      parameter (lhrwgt_maxnheader=200)
++      parameter (lhrwgt_maxnheader=300)
+       integer  lhrwgt_max_header_columns
+       parameter ( lhrwgt_max_header_columns=200)
+       character * (lhrwgt_max_header_columns)
+@@ -11,28 +11,6 @@
+      1     lhrwgt_group_combine
+       integer lhrwgt_nheader
+       character * 400 lhrwgt_descr
+-
+-      integer maxgroups
+-      parameter (maxgroups=20)
+-      integer maxids
+-      parameter (maxids=200)
+-      integer lhrwgt_ngroups,lhrwgt_nids
+-      character * 100 lhrwgt_group_name_arr(maxgroups),
+-     1                lhrwgt_group_combine_arr(maxgroups),
+-     2                lhrwgt_id_arr(maxids)
+-      character * 400 lhrwgt_descr_arr(maxids)
+-      real * 8 lhrwgt_weights(maxids)
+-      integer lhrwgt_group_ptr(maxids)
+-
+-
+       common/pwhg_lhrwgt/lhrwgt_nheader,lhrwgt_header,
+      1     lhrwgt_id,lhrwgt_descr,lhrwgt_group_name,
+-     2     lhrwgt_group_combine,
+-     3     lhrwgt_weights,lhrwgt_ngroups,lhrwgt_nids,
+-     4     lhrwgt_group_ptr,lhrwgt_group_name_arr,
+-     5     lhrwgt_group_combine_arr,lhrwgt_id_arr,lhrwgt_descr_arr
+-
+-
+-
+-
+-      
++     2     lhrwgt_group_combine
+--- POWHEG-BOX/lhefwrite.f	2015-01-30 09:54:34.455177186 +0100
++++ ../roberto_powheg/POWHEG-BOX/lhefwrite.f	2015-02-10 12:03:58.000000000 +0100
+@@ -60,15 +60,6 @@
+       include 'pwhg_flg.h'
+       include 'pwhg_lhrwgt.h'
+       integer i,j
+-      integer, save :: counter=0
+-      if(flg_noevents) then
+-c do not write events, write only the event count
+-         counter = counter + 1
+-         if((counter/1000)*1000.eq.counter) then
+-            write(nlf,*) counter
+-         endif
+-         return
+-      endif
+       write(nlf,'(a)')'<event>'
+       write(nlf,210) nup,idprup,xwgtup,scalup,aqedup,aqcdup
+       do 200 i=1,nup
+@@ -76,6 +67,7 @@
+      & mothup(2,i),icolup(1,i),icolup(2,i),(pup(j,i),j=1,5),
+      & vtimup(i),spinup(i)
+  200  continue
++      if(flg_pdfreweight) call lhefwritepdfrw(nlf)
+       if(flg_reweight) then
+          call lhefwriteevrw(nlf)
+          if(lhrwgt_id.ne.' ') then
+@@ -84,7 +76,6 @@
+             write(nlf,'(a)')'</rwgt>'
+          endif
+       endif
+-      if(flg_pdfreweight) call lhefwritepdfrw(nlf)
+       if(flg_debug) call lhefwritextra(nlf)
+       write(nlf,'(a)')'</event>'      
+  210  format(1p,2(1x,i6),4(1x,e12.5))


### PR DESCRIPTION
1. Add one line in create_powheg_tarball.sh to patch the fixes for the two files
  a) POWHEG-BOX/include/pwhg_lhrwgt.h  (max number of weights)
  b) POWHEG-BOX/lhefwrite.f     (output of pdfinfo in the LHE file)

2. add one directory patches that includes the file to patch: pdfweights.patch