### PR TITLE
[Madgraph5_aMC@NLO] add lines in gridpack_generation.sh to retrieve new models for diboson search

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -104,6 +104,9 @@ SYSCALCSOURCE=https://cms-project-generators.web.cern.ch/cms-project-generators/
 HCNLO=HC_NLO_X0_UFO.zip
 HCNLOSOURCE=https://cms-project-generators.web.cern.ch/cms-project-generators/$HCNLO
 
+## Models for searches of diboson resonances
+VVMODEL=dibosonResonanceModel.tar.gz
+VVSOURCE=https://cms-project-generators.web.cern.ch/cms-project-generators/$VVMODEL
 
 MGBASEDIRORIG=MG5_aMC_v2_2_2
 
@@ -207,6 +210,12 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
   wget --no-check-certificate ${HCNLOSOURCE}
   cd models
   unzip ../${HCNLO}
+  cd ..
+
+  #get Diboson model
+  wget --no-check-certificate ${VVSOURCE}
+  cd models
+  tar xvzf ../${VVMODEL}
   cd ..
   
   cd $WORKDIR


### PR DESCRIPTION
Add lines to retrieve model tar ball for the diboson resonance signals.

Models are already in /afs/cern.ch/cms/generators/www/dibosonResonanceModel.tar.gz

Including:
heft_radion
Vector_Triplet_free_Width_UFO
RS_bulk_ktilda
Vector_Triplet_UFO
