### PR TITLE
higgs folder and ggH mg5nlo datacards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_MadLoopParams.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_MadLoopParams.dat
@@ -1,0 +1,208 @@
+! This file is for the user to set the different parameters of MadLoop.
+! The name of the variable to define must start with the '#' sign and then
+! the value should be put immediately on the next line.
+
+!     
+#MLReductionLib
+1|4|2
+! Default :: 1|4|3|2
+!     The tensor integral reduction library.The current choices are:
+!     1 | CutTools
+!     2 | PJFry++
+!     3 | IREGI
+!     4 | Golem95
+!     One can use the combinations to reduce integral,e.g.
+!     1|2|3 means first use CutTools, if it is not stable, use PJFry++, 
+!     if it is still unstable, use IREGI. If it failed, use QP of CutTools.
+!  
+
+!     =================================================================================
+!     The parameters below set the parameters for IREGI
+!     =================================================================================
+
+#IREGIMODE
+2
+! Default :: 2
+!     IMODE=0, IBP reduction
+!     IMODE=1, PaVe reduction
+!     IMODE=2, PaVe reduction with stablility improved by IBP reduction
+
+#IREGIRECY
+.TRUE.
+! Default :: .TRUE.
+!     Use RECYCLING OR NOT IN IREGI
+!
+
+!     =================================================================================
+!     The parameters below set the stability checks of MadLoop at run time
+!     =================================================================================
+
+!     Decide in which mode to set CutTools at runtime.
+!     The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable
+!      -1   | Special mode, see below for the negative ones.
+!     
+!     Due to the architecture of the program, you are better off
+!     rerunning the full PS point in quadruple precision than just a single loop 
+!     because the two things would almost take the same time. So '-1' is always
+!     very recommended.
+#CTModeRun
+-1
+! Default :: -1
+!     In the negative mode -1, MadLoop first evaluates each PS points in modes 1 and 2,
+!     yielding results Res1 and Res2, and then check if:
+!                    (Res1-Res2)/(2*(Res1+Res2)< MLStabThres
+!     If it is not the case, MadLoop evaluates again the PS point in modes 4 and 5,
+!     yielding results Res4 and Res5, and then check if:
+!                    (Res4-Res5)/(2*(Res4+Res5)< MLStabThres
+!     If it is the case then the unstable phase-space point could be cured. If it is
+!     not the case, MadLoop outputs a warning. 
+!     Notice that MLStabThres is used only when CTModeRun is negative.
+#MLStabThres
+1.0d-3
+! Default :: 1.0d-3
+!     You can add other evaluation method to check for the stability in DP and QP.
+!     Below you can chose if you want to use zero, one or two rotations of the PS point 
+!     in QP.
+#NRotations_DP
+1
+! Default :: 1
+#NRotations_QP
+0
+! Default :: 0
+
+!     By default, MadLoop is allowed to slightly deform the Phase-Space point in input
+!     so to insure perfect onshellness of the external particles and perfect energy-momentum
+!     conservation. The deformation is minimal and such that it leaves the input PS point 
+!     unchanged if it already satisfies the physical condiditions mentioned above.
+!     This integer values select what is the method to be employed preferably to restore this
+!     precision. It can take the following values:
+!
+!     -1 :: No method is used for double precision computations, and method 2 will be used
+!           preferentially when quadruple precision (for which this precision improvement
+!           is mandatory, otherwise quadruple precision is pointless)
+!      1 :: This methods imitates what is done in PSMC, namely 
+!           a) Set the space-like momentum of the last external particle to be the
+!              opposite of the sum of the others (with a minus sign for the initial states).
+!           b) Rescale all final state space-like momenta by a fixed value x computed such
+!              that energy is conserved when particles are put exactly onshell. This value 
+!              is determined numericaly via Ralph-Newton's method.
+!           c) Set all energies to have particles exactly onshell.           
+!      2  :: This method applies a shift to the energy and the x and y components of the first 
+!            initial state momentum in order to restore exact energy momentum conservation after
+!            particles have been put exactly onshell via a shift of the z component of their 
+!            momenta.
+#ImprovePSPoint
+2
+! Default :: 2
+!     =================================================================================
+!     The parameters below set two CutTools internal parameters accessible to the user. 
+!     =================================================================================
+
+!     Choose here what library to chose for CutTools/TIR to compute the scalar loops of the
+!     master integral basis. The choices are as follows:
+!     (Does not apply for Golem95, where OneLOop is always used)
+!     2 | OneLOop
+!     3 | QCDLoop
+#CTLoopLibrary
+2
+! Default :: 2
+
+!     Choose here the stability threshold used within CutTools to decide when to go to
+!     higher precision.
+#CTStabThres
+1.0d-2
+! Default :: 1.0d-2
+
+!     =================================================================================
+!     The parameters below set the general behavior of MadLoop for the initialization
+!     =================================================================================
+
+!     Decide in which mode to set CutTools when performing MadLoop's initialization of
+!     the helicity (and possibly loop) filter. The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable                               
+!
+#CTModeInit
+1
+! Default :: 0
+
+!     CheckCycle sets on how many PS points trials the initialization filters must be 
+!     obtained. As long as MadLoop does not find that many consecutive PS points for 
+!     which the filters are the same, it will start over but only a maximum of
+!     MaxAttempts times.
+#CheckCycle
+3
+! Default :: 3
+#MaxAttempts
+10
+! Default :: 10
+
+!     Setting the threshold for deciding wether a numerical contribution is analytically 
+!     zero or not.
+#ZeroThres
+1.0d-9
+! Default :: 1.0d-9
+
+!     Setting the on-shell threshold for deciding whether the invariant variables
+! of external momenta are on-shell or not. It will only be used in constructing
+! s-matrix in Golem95.
+#OSThres
+1.0d-8
+! Default :: 1.0d-8
+
+!     The setting below is recommended to be on as it allows to systematically used the 
+!     first PS point thrown at ML5 to be used for making sure that the helicity filter
+!     read from HelFilter.dat is consistent as it might be no longer up to date with
+!     certain changes of the paramaters by the user.
+#DoubleCheckHelicityFilter
+.TRUE.
+! Default :: .TRUE.
+
+!     This decides whether to write out the helicity and loop filters to the files 
+!     HelFilters.dat and LoopFilters.dat to save them for future runs. It usually
+!     preferable but sometimes not desired because of the need of threadlocks in the
+!     context of mpi parallelization. So it can be turned off here in such cases.
+#WriteOutFilters
+.TRUE.
+! Default :: .TRUE.
+
+!     Some loop contributions may be zero for some helicities which are however
+!     contributing. In order to save their computing time, you can chose here to try
+!     to filter them out. The gain is typically minimal, so it is turned off by default.
+#UseLoopFilter
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides whether consecutive consistency for the loop filtering setup is also 
+!     required.
+#LoopInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides wether consecutive consistency for the helicity filtering setup is also 
+!     required. Better to set it to false as it can cause problems for unstable processes.
+#HelInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+/* End of param file */

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 120.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_120 -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_120/ggh012j_5f_NLO_FXFX_120_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_MadLoopParams.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_MadLoopParams.dat
@@ -1,0 +1,208 @@
+! This file is for the user to set the different parameters of MadLoop.
+! The name of the variable to define must start with the '#' sign and then
+! the value should be put immediately on the next line.
+
+!     
+#MLReductionLib
+1|4|2
+! Default :: 1|4|3|2
+!     The tensor integral reduction library.The current choices are:
+!     1 | CutTools
+!     2 | PJFry++
+!     3 | IREGI
+!     4 | Golem95
+!     One can use the combinations to reduce integral,e.g.
+!     1|2|3 means first use CutTools, if it is not stable, use PJFry++, 
+!     if it is still unstable, use IREGI. If it failed, use QP of CutTools.
+!  
+
+!     =================================================================================
+!     The parameters below set the parameters for IREGI
+!     =================================================================================
+
+#IREGIMODE
+2
+! Default :: 2
+!     IMODE=0, IBP reduction
+!     IMODE=1, PaVe reduction
+!     IMODE=2, PaVe reduction with stablility improved by IBP reduction
+
+#IREGIRECY
+.TRUE.
+! Default :: .TRUE.
+!     Use RECYCLING OR NOT IN IREGI
+!
+
+!     =================================================================================
+!     The parameters below set the stability checks of MadLoop at run time
+!     =================================================================================
+
+!     Decide in which mode to set CutTools at runtime.
+!     The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable
+!      -1   | Special mode, see below for the negative ones.
+!     
+!     Due to the architecture of the program, you are better off
+!     rerunning the full PS point in quadruple precision than just a single loop 
+!     because the two things would almost take the same time. So '-1' is always
+!     very recommended.
+#CTModeRun
+-1
+! Default :: -1
+!     In the negative mode -1, MadLoop first evaluates each PS points in modes 1 and 2,
+!     yielding results Res1 and Res2, and then check if:
+!                    (Res1-Res2)/(2*(Res1+Res2)< MLStabThres
+!     If it is not the case, MadLoop evaluates again the PS point in modes 4 and 5,
+!     yielding results Res4 and Res5, and then check if:
+!                    (Res4-Res5)/(2*(Res4+Res5)< MLStabThres
+!     If it is the case then the unstable phase-space point could be cured. If it is
+!     not the case, MadLoop outputs a warning. 
+!     Notice that MLStabThres is used only when CTModeRun is negative.
+#MLStabThres
+1.0d-3
+! Default :: 1.0d-3
+!     You can add other evaluation method to check for the stability in DP and QP.
+!     Below you can chose if you want to use zero, one or two rotations of the PS point 
+!     in QP.
+#NRotations_DP
+1
+! Default :: 1
+#NRotations_QP
+0
+! Default :: 0
+
+!     By default, MadLoop is allowed to slightly deform the Phase-Space point in input
+!     so to insure perfect onshellness of the external particles and perfect energy-momentum
+!     conservation. The deformation is minimal and such that it leaves the input PS point 
+!     unchanged if it already satisfies the physical condiditions mentioned above.
+!     This integer values select what is the method to be employed preferably to restore this
+!     precision. It can take the following values:
+!
+!     -1 :: No method is used for double precision computations, and method 2 will be used
+!           preferentially when quadruple precision (for which this precision improvement
+!           is mandatory, otherwise quadruple precision is pointless)
+!      1 :: This methods imitates what is done in PSMC, namely 
+!           a) Set the space-like momentum of the last external particle to be the
+!              opposite of the sum of the others (with a minus sign for the initial states).
+!           b) Rescale all final state space-like momenta by a fixed value x computed such
+!              that energy is conserved when particles are put exactly onshell. This value 
+!              is determined numericaly via Ralph-Newton's method.
+!           c) Set all energies to have particles exactly onshell.           
+!      2  :: This method applies a shift to the energy and the x and y components of the first 
+!            initial state momentum in order to restore exact energy momentum conservation after
+!            particles have been put exactly onshell via a shift of the z component of their 
+!            momenta.
+#ImprovePSPoint
+2
+! Default :: 2
+!     =================================================================================
+!     The parameters below set two CutTools internal parameters accessible to the user. 
+!     =================================================================================
+
+!     Choose here what library to chose for CutTools/TIR to compute the scalar loops of the
+!     master integral basis. The choices are as follows:
+!     (Does not apply for Golem95, where OneLOop is always used)
+!     2 | OneLOop
+!     3 | QCDLoop
+#CTLoopLibrary
+2
+! Default :: 2
+
+!     Choose here the stability threshold used within CutTools to decide when to go to
+!     higher precision.
+#CTStabThres
+1.0d-2
+! Default :: 1.0d-2
+
+!     =================================================================================
+!     The parameters below set the general behavior of MadLoop for the initialization
+!     =================================================================================
+
+!     Decide in which mode to set CutTools when performing MadLoop's initialization of
+!     the helicity (and possibly loop) filter. The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable                               
+!
+#CTModeInit
+1
+! Default :: 0
+
+!     CheckCycle sets on how many PS points trials the initialization filters must be 
+!     obtained. As long as MadLoop does not find that many consecutive PS points for 
+!     which the filters are the same, it will start over but only a maximum of
+!     MaxAttempts times.
+#CheckCycle
+3
+! Default :: 3
+#MaxAttempts
+10
+! Default :: 10
+
+!     Setting the threshold for deciding wether a numerical contribution is analytically 
+!     zero or not.
+#ZeroThres
+1.0d-9
+! Default :: 1.0d-9
+
+!     Setting the on-shell threshold for deciding whether the invariant variables
+! of external momenta are on-shell or not. It will only be used in constructing
+! s-matrix in Golem95.
+#OSThres
+1.0d-8
+! Default :: 1.0d-8
+
+!     The setting below is recommended to be on as it allows to systematically used the 
+!     first PS point thrown at ML5 to be used for making sure that the helicity filter
+!     read from HelFilter.dat is consistent as it might be no longer up to date with
+!     certain changes of the paramaters by the user.
+#DoubleCheckHelicityFilter
+.TRUE.
+! Default :: .TRUE.
+
+!     This decides whether to write out the helicity and loop filters to the files 
+!     HelFilters.dat and LoopFilters.dat to save them for future runs. It usually
+!     preferable but sometimes not desired because of the need of threadlocks in the
+!     context of mpi parallelization. So it can be turned off here in such cases.
+#WriteOutFilters
+.TRUE.
+! Default :: .TRUE.
+
+!     Some loop contributions may be zero for some helicities which are however
+!     contributing. In order to save their computing time, you can chose here to try
+!     to filter them out. The gain is typically minimal, so it is turned off by default.
+#UseLoopFilter
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides whether consecutive consistency for the loop filtering setup is also 
+!     required.
+#LoopInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides wether consecutive consistency for the helicity filtering setup is also 
+!     required. Better to set it to false as it can cause problems for unstable processes.
+#HelInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+/* End of param file */

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 124.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_124 -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_124/ggh012j_5f_NLO_FXFX_124_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_MadLoopParams.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_MadLoopParams.dat
@@ -1,0 +1,208 @@
+! This file is for the user to set the different parameters of MadLoop.
+! The name of the variable to define must start with the '#' sign and then
+! the value should be put immediately on the next line.
+
+!     
+#MLReductionLib
+1|4|2
+! Default :: 1|4|3|2
+!     The tensor integral reduction library.The current choices are:
+!     1 | CutTools
+!     2 | PJFry++
+!     3 | IREGI
+!     4 | Golem95
+!     One can use the combinations to reduce integral,e.g.
+!     1|2|3 means first use CutTools, if it is not stable, use PJFry++, 
+!     if it is still unstable, use IREGI. If it failed, use QP of CutTools.
+!  
+
+!     =================================================================================
+!     The parameters below set the parameters for IREGI
+!     =================================================================================
+
+#IREGIMODE
+2
+! Default :: 2
+!     IMODE=0, IBP reduction
+!     IMODE=1, PaVe reduction
+!     IMODE=2, PaVe reduction with stablility improved by IBP reduction
+
+#IREGIRECY
+.TRUE.
+! Default :: .TRUE.
+!     Use RECYCLING OR NOT IN IREGI
+!
+
+!     =================================================================================
+!     The parameters below set the stability checks of MadLoop at run time
+!     =================================================================================
+
+!     Decide in which mode to set CutTools at runtime.
+!     The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable
+!      -1   | Special mode, see below for the negative ones.
+!     
+!     Due to the architecture of the program, you are better off
+!     rerunning the full PS point in quadruple precision than just a single loop 
+!     because the two things would almost take the same time. So '-1' is always
+!     very recommended.
+#CTModeRun
+-1
+! Default :: -1
+!     In the negative mode -1, MadLoop first evaluates each PS points in modes 1 and 2,
+!     yielding results Res1 and Res2, and then check if:
+!                    (Res1-Res2)/(2*(Res1+Res2)< MLStabThres
+!     If it is not the case, MadLoop evaluates again the PS point in modes 4 and 5,
+!     yielding results Res4 and Res5, and then check if:
+!                    (Res4-Res5)/(2*(Res4+Res5)< MLStabThres
+!     If it is the case then the unstable phase-space point could be cured. If it is
+!     not the case, MadLoop outputs a warning. 
+!     Notice that MLStabThres is used only when CTModeRun is negative.
+#MLStabThres
+1.0d-3
+! Default :: 1.0d-3
+!     You can add other evaluation method to check for the stability in DP and QP.
+!     Below you can chose if you want to use zero, one or two rotations of the PS point 
+!     in QP.
+#NRotations_DP
+1
+! Default :: 1
+#NRotations_QP
+0
+! Default :: 0
+
+!     By default, MadLoop is allowed to slightly deform the Phase-Space point in input
+!     so to insure perfect onshellness of the external particles and perfect energy-momentum
+!     conservation. The deformation is minimal and such that it leaves the input PS point 
+!     unchanged if it already satisfies the physical condiditions mentioned above.
+!     This integer values select what is the method to be employed preferably to restore this
+!     precision. It can take the following values:
+!
+!     -1 :: No method is used for double precision computations, and method 2 will be used
+!           preferentially when quadruple precision (for which this precision improvement
+!           is mandatory, otherwise quadruple precision is pointless)
+!      1 :: This methods imitates what is done in PSMC, namely 
+!           a) Set the space-like momentum of the last external particle to be the
+!              opposite of the sum of the others (with a minus sign for the initial states).
+!           b) Rescale all final state space-like momenta by a fixed value x computed such
+!              that energy is conserved when particles are put exactly onshell. This value 
+!              is determined numericaly via Ralph-Newton's method.
+!           c) Set all energies to have particles exactly onshell.           
+!      2  :: This method applies a shift to the energy and the x and y components of the first 
+!            initial state momentum in order to restore exact energy momentum conservation after
+!            particles have been put exactly onshell via a shift of the z component of their 
+!            momenta.
+#ImprovePSPoint
+2
+! Default :: 2
+!     =================================================================================
+!     The parameters below set two CutTools internal parameters accessible to the user. 
+!     =================================================================================
+
+!     Choose here what library to chose for CutTools/TIR to compute the scalar loops of the
+!     master integral basis. The choices are as follows:
+!     (Does not apply for Golem95, where OneLOop is always used)
+!     2 | OneLOop
+!     3 | QCDLoop
+#CTLoopLibrary
+2
+! Default :: 2
+
+!     Choose here the stability threshold used within CutTools to decide when to go to
+!     higher precision.
+#CTStabThres
+1.0d-2
+! Default :: 1.0d-2
+
+!     =================================================================================
+!     The parameters below set the general behavior of MadLoop for the initialization
+!     =================================================================================
+
+!     Decide in which mode to set CutTools when performing MadLoop's initialization of
+!     the helicity (and possibly loop) filter. The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable                               
+!
+#CTModeInit
+1
+! Default :: 0
+
+!     CheckCycle sets on how many PS points trials the initialization filters must be 
+!     obtained. As long as MadLoop does not find that many consecutive PS points for 
+!     which the filters are the same, it will start over but only a maximum of
+!     MaxAttempts times.
+#CheckCycle
+3
+! Default :: 3
+#MaxAttempts
+10
+! Default :: 10
+
+!     Setting the threshold for deciding wether a numerical contribution is analytically 
+!     zero or not.
+#ZeroThres
+1.0d-9
+! Default :: 1.0d-9
+
+!     Setting the on-shell threshold for deciding whether the invariant variables
+! of external momenta are on-shell or not. It will only be used in constructing
+! s-matrix in Golem95.
+#OSThres
+1.0d-8
+! Default :: 1.0d-8
+
+!     The setting below is recommended to be on as it allows to systematically used the 
+!     first PS point thrown at ML5 to be used for making sure that the helicity filter
+!     read from HelFilter.dat is consistent as it might be no longer up to date with
+!     certain changes of the paramaters by the user.
+#DoubleCheckHelicityFilter
+.TRUE.
+! Default :: .TRUE.
+
+!     This decides whether to write out the helicity and loop filters to the files 
+!     HelFilters.dat and LoopFilters.dat to save them for future runs. It usually
+!     preferable but sometimes not desired because of the need of threadlocks in the
+!     context of mpi parallelization. So it can be turned off here in such cases.
+#WriteOutFilters
+.TRUE.
+! Default :: .TRUE.
+
+!     Some loop contributions may be zero for some helicities which are however
+!     contributing. In order to save their computing time, you can chose here to try
+!     to filter them out. The gain is typically minimal, so it is turned off by default.
+#UseLoopFilter
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides whether consecutive consistency for the loop filtering setup is also 
+!     required.
+#LoopInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides wether consecutive consistency for the helicity filtering setup is also 
+!     required. Better to set it to false as it can cause problems for unstable processes.
+#HelInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+/* End of param file */

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_125 -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_125/ggh012j_5f_NLO_FXFX_125_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_MadLoopParams.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_MadLoopParams.dat
@@ -1,0 +1,208 @@
+! This file is for the user to set the different parameters of MadLoop.
+! The name of the variable to define must start with the '#' sign and then
+! the value should be put immediately on the next line.
+
+!     
+#MLReductionLib
+1|4|2
+! Default :: 1|4|3|2
+!     The tensor integral reduction library.The current choices are:
+!     1 | CutTools
+!     2 | PJFry++
+!     3 | IREGI
+!     4 | Golem95
+!     One can use the combinations to reduce integral,e.g.
+!     1|2|3 means first use CutTools, if it is not stable, use PJFry++, 
+!     if it is still unstable, use IREGI. If it failed, use QP of CutTools.
+!  
+
+!     =================================================================================
+!     The parameters below set the parameters for IREGI
+!     =================================================================================
+
+#IREGIMODE
+2
+! Default :: 2
+!     IMODE=0, IBP reduction
+!     IMODE=1, PaVe reduction
+!     IMODE=2, PaVe reduction with stablility improved by IBP reduction
+
+#IREGIRECY
+.TRUE.
+! Default :: .TRUE.
+!     Use RECYCLING OR NOT IN IREGI
+!
+
+!     =================================================================================
+!     The parameters below set the stability checks of MadLoop at run time
+!     =================================================================================
+
+!     Decide in which mode to set CutTools at runtime.
+!     The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable
+!      -1   | Special mode, see below for the negative ones.
+!     
+!     Due to the architecture of the program, you are better off
+!     rerunning the full PS point in quadruple precision than just a single loop 
+!     because the two things would almost take the same time. So '-1' is always
+!     very recommended.
+#CTModeRun
+-1
+! Default :: -1
+!     In the negative mode -1, MadLoop first evaluates each PS points in modes 1 and 2,
+!     yielding results Res1 and Res2, and then check if:
+!                    (Res1-Res2)/(2*(Res1+Res2)< MLStabThres
+!     If it is not the case, MadLoop evaluates again the PS point in modes 4 and 5,
+!     yielding results Res4 and Res5, and then check if:
+!                    (Res4-Res5)/(2*(Res4+Res5)< MLStabThres
+!     If it is the case then the unstable phase-space point could be cured. If it is
+!     not the case, MadLoop outputs a warning. 
+!     Notice that MLStabThres is used only when CTModeRun is negative.
+#MLStabThres
+1.0d-3
+! Default :: 1.0d-3
+!     You can add other evaluation method to check for the stability in DP and QP.
+!     Below you can chose if you want to use zero, one or two rotations of the PS point 
+!     in QP.
+#NRotations_DP
+1
+! Default :: 1
+#NRotations_QP
+0
+! Default :: 0
+
+!     By default, MadLoop is allowed to slightly deform the Phase-Space point in input
+!     so to insure perfect onshellness of the external particles and perfect energy-momentum
+!     conservation. The deformation is minimal and such that it leaves the input PS point 
+!     unchanged if it already satisfies the physical condiditions mentioned above.
+!     This integer values select what is the method to be employed preferably to restore this
+!     precision. It can take the following values:
+!
+!     -1 :: No method is used for double precision computations, and method 2 will be used
+!           preferentially when quadruple precision (for which this precision improvement
+!           is mandatory, otherwise quadruple precision is pointless)
+!      1 :: This methods imitates what is done in PSMC, namely 
+!           a) Set the space-like momentum of the last external particle to be the
+!              opposite of the sum of the others (with a minus sign for the initial states).
+!           b) Rescale all final state space-like momenta by a fixed value x computed such
+!              that energy is conserved when particles are put exactly onshell. This value 
+!              is determined numericaly via Ralph-Newton's method.
+!           c) Set all energies to have particles exactly onshell.           
+!      2  :: This method applies a shift to the energy and the x and y components of the first 
+!            initial state momentum in order to restore exact energy momentum conservation after
+!            particles have been put exactly onshell via a shift of the z component of their 
+!            momenta.
+#ImprovePSPoint
+2
+! Default :: 2
+!     =================================================================================
+!     The parameters below set two CutTools internal parameters accessible to the user. 
+!     =================================================================================
+
+!     Choose here what library to chose for CutTools/TIR to compute the scalar loops of the
+!     master integral basis. The choices are as follows:
+!     (Does not apply for Golem95, where OneLOop is always used)
+!     2 | OneLOop
+!     3 | QCDLoop
+#CTLoopLibrary
+2
+! Default :: 2
+
+!     Choose here the stability threshold used within CutTools to decide when to go to
+!     higher precision.
+#CTStabThres
+1.0d-2
+! Default :: 1.0d-2
+
+!     =================================================================================
+!     The parameters below set the general behavior of MadLoop for the initialization
+!     =================================================================================
+
+!     Decide in which mode to set CutTools when performing MadLoop's initialization of
+!     the helicity (and possibly loop) filter. The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable                               
+!
+#CTModeInit
+1
+! Default :: 0
+
+!     CheckCycle sets on how many PS points trials the initialization filters must be 
+!     obtained. As long as MadLoop does not find that many consecutive PS points for 
+!     which the filters are the same, it will start over but only a maximum of
+!     MaxAttempts times.
+#CheckCycle
+3
+! Default :: 3
+#MaxAttempts
+10
+! Default :: 10
+
+!     Setting the threshold for deciding wether a numerical contribution is analytically 
+!     zero or not.
+#ZeroThres
+1.0d-9
+! Default :: 1.0d-9
+
+!     Setting the on-shell threshold for deciding whether the invariant variables
+! of external momenta are on-shell or not. It will only be used in constructing
+! s-matrix in Golem95.
+#OSThres
+1.0d-8
+! Default :: 1.0d-8
+
+!     The setting below is recommended to be on as it allows to systematically used the 
+!     first PS point thrown at ML5 to be used for making sure that the helicity filter
+!     read from HelFilter.dat is consistent as it might be no longer up to date with
+!     certain changes of the paramaters by the user.
+#DoubleCheckHelicityFilter
+.TRUE.
+! Default :: .TRUE.
+
+!     This decides whether to write out the helicity and loop filters to the files 
+!     HelFilters.dat and LoopFilters.dat to save them for future runs. It usually
+!     preferable but sometimes not desired because of the need of threadlocks in the
+!     context of mpi parallelization. So it can be turned off here in such cases.
+#WriteOutFilters
+.TRUE.
+! Default :: .TRUE.
+
+!     Some loop contributions may be zero for some helicities which are however
+!     contributing. In order to save their computing time, you can chose here to try
+!     to filter them out. The gain is typically minimal, so it is turned off by default.
+#UseLoopFilter
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides whether consecutive consistency for the loop filtering setup is also 
+!     required.
+#LoopInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides wether consecutive consistency for the helicity filtering setup is also 
+!     required. Better to set it to false as it can cause problems for unstable processes.
+#HelInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+/* End of param file */

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 126.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_126 -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_126/ggh012j_5f_NLO_FXFX_126_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_MadLoopParams.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_MadLoopParams.dat
@@ -1,0 +1,208 @@
+! This file is for the user to set the different parameters of MadLoop.
+! The name of the variable to define must start with the '#' sign and then
+! the value should be put immediately on the next line.
+
+!     
+#MLReductionLib
+1|4|2
+! Default :: 1|4|3|2
+!     The tensor integral reduction library.The current choices are:
+!     1 | CutTools
+!     2 | PJFry++
+!     3 | IREGI
+!     4 | Golem95
+!     One can use the combinations to reduce integral,e.g.
+!     1|2|3 means first use CutTools, if it is not stable, use PJFry++, 
+!     if it is still unstable, use IREGI. If it failed, use QP of CutTools.
+!  
+
+!     =================================================================================
+!     The parameters below set the parameters for IREGI
+!     =================================================================================
+
+#IREGIMODE
+2
+! Default :: 2
+!     IMODE=0, IBP reduction
+!     IMODE=1, PaVe reduction
+!     IMODE=2, PaVe reduction with stablility improved by IBP reduction
+
+#IREGIRECY
+.TRUE.
+! Default :: .TRUE.
+!     Use RECYCLING OR NOT IN IREGI
+!
+
+!     =================================================================================
+!     The parameters below set the stability checks of MadLoop at run time
+!     =================================================================================
+
+!     Decide in which mode to set CutTools at runtime.
+!     The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable
+!      -1   | Special mode, see below for the negative ones.
+!     
+!     Due to the architecture of the program, you are better off
+!     rerunning the full PS point in quadruple precision than just a single loop 
+!     because the two things would almost take the same time. So '-1' is always
+!     very recommended.
+#CTModeRun
+-1
+! Default :: -1
+!     In the negative mode -1, MadLoop first evaluates each PS points in modes 1 and 2,
+!     yielding results Res1 and Res2, and then check if:
+!                    (Res1-Res2)/(2*(Res1+Res2)< MLStabThres
+!     If it is not the case, MadLoop evaluates again the PS point in modes 4 and 5,
+!     yielding results Res4 and Res5, and then check if:
+!                    (Res4-Res5)/(2*(Res4+Res5)< MLStabThres
+!     If it is the case then the unstable phase-space point could be cured. If it is
+!     not the case, MadLoop outputs a warning. 
+!     Notice that MLStabThres is used only when CTModeRun is negative.
+#MLStabThres
+1.0d-3
+! Default :: 1.0d-3
+!     You can add other evaluation method to check for the stability in DP and QP.
+!     Below you can chose if you want to use zero, one or two rotations of the PS point 
+!     in QP.
+#NRotations_DP
+1
+! Default :: 1
+#NRotations_QP
+0
+! Default :: 0
+
+!     By default, MadLoop is allowed to slightly deform the Phase-Space point in input
+!     so to insure perfect onshellness of the external particles and perfect energy-momentum
+!     conservation. The deformation is minimal and such that it leaves the input PS point 
+!     unchanged if it already satisfies the physical condiditions mentioned above.
+!     This integer values select what is the method to be employed preferably to restore this
+!     precision. It can take the following values:
+!
+!     -1 :: No method is used for double precision computations, and method 2 will be used
+!           preferentially when quadruple precision (for which this precision improvement
+!           is mandatory, otherwise quadruple precision is pointless)
+!      1 :: This methods imitates what is done in PSMC, namely 
+!           a) Set the space-like momentum of the last external particle to be the
+!              opposite of the sum of the others (with a minus sign for the initial states).
+!           b) Rescale all final state space-like momenta by a fixed value x computed such
+!              that energy is conserved when particles are put exactly onshell. This value 
+!              is determined numericaly via Ralph-Newton's method.
+!           c) Set all energies to have particles exactly onshell.           
+!      2  :: This method applies a shift to the energy and the x and y components of the first 
+!            initial state momentum in order to restore exact energy momentum conservation after
+!            particles have been put exactly onshell via a shift of the z component of their 
+!            momenta.
+#ImprovePSPoint
+2
+! Default :: 2
+!     =================================================================================
+!     The parameters below set two CutTools internal parameters accessible to the user. 
+!     =================================================================================
+
+!     Choose here what library to chose for CutTools/TIR to compute the scalar loops of the
+!     master integral basis. The choices are as follows:
+!     (Does not apply for Golem95, where OneLOop is always used)
+!     2 | OneLOop
+!     3 | QCDLoop
+#CTLoopLibrary
+2
+! Default :: 2
+
+!     Choose here the stability threshold used within CutTools to decide when to go to
+!     higher precision.
+#CTStabThres
+1.0d-2
+! Default :: 1.0d-2
+
+!     =================================================================================
+!     The parameters below set the general behavior of MadLoop for the initialization
+!     =================================================================================
+
+!     Decide in which mode to set CutTools when performing MadLoop's initialization of
+!     the helicity (and possibly loop) filter. The possible modes are:
+!
+!     imode:|  actions performed by ctsxcut:                                     
+!           |                                                                    
+!      	0   | (dp_dir,dp_inv)-> dp_Atest -> stable -> (only if stable=.false.) ->
+!	        | (mp_dir,mp_inv)-> mp_Atest -> stable                                
+!       1   | (dp_dir)       -> dp_Ntest -> stable                               
+!       2   | (dp_inv)       -> dp_Ntest -> stable                               
+!       3   | (dp_dir,dp_inv)-> dp_Atest -> stable                               
+!       4   | (mp_dir)       -> mp_Ntest -> stable                                 
+!       5   | (mp_inv)       -> mp_Ntest -> stable                                
+!       6   | (mp_dir,mp_inv)-> mp_Atest -> stable                               
+!
+#CTModeInit
+1
+! Default :: 0
+
+!     CheckCycle sets on how many PS points trials the initialization filters must be 
+!     obtained. As long as MadLoop does not find that many consecutive PS points for 
+!     which the filters are the same, it will start over but only a maximum of
+!     MaxAttempts times.
+#CheckCycle
+3
+! Default :: 3
+#MaxAttempts
+10
+! Default :: 10
+
+!     Setting the threshold for deciding wether a numerical contribution is analytically 
+!     zero or not.
+#ZeroThres
+1.0d-9
+! Default :: 1.0d-9
+
+!     Setting the on-shell threshold for deciding whether the invariant variables
+! of external momenta are on-shell or not. It will only be used in constructing
+! s-matrix in Golem95.
+#OSThres
+1.0d-8
+! Default :: 1.0d-8
+
+!     The setting below is recommended to be on as it allows to systematically used the 
+!     first PS point thrown at ML5 to be used for making sure that the helicity filter
+!     read from HelFilter.dat is consistent as it might be no longer up to date with
+!     certain changes of the paramaters by the user.
+#DoubleCheckHelicityFilter
+.TRUE.
+! Default :: .TRUE.
+
+!     This decides whether to write out the helicity and loop filters to the files 
+!     HelFilters.dat and LoopFilters.dat to save them for future runs. It usually
+!     preferable but sometimes not desired because of the need of threadlocks in the
+!     context of mpi parallelization. So it can be turned off here in such cases.
+#WriteOutFilters
+.TRUE.
+! Default :: .TRUE.
+
+!     Some loop contributions may be zero for some helicities which are however
+!     contributing. In order to save their computing time, you can chose here to try
+!     to filter them out. The gain is typically minimal, so it is turned off by default.
+#UseLoopFilter
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides whether consecutive consistency for the loop filtering setup is also 
+!     required.
+#LoopInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+!     This decides wether consecutive consistency for the helicity filtering setup is also 
+!     required. Better to set it to false as it can cause problems for unstable processes.
+#HelInitStartOver
+.FALSE.
+! Default :: .FALSE.
+
+/* End of param file */

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 130.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_130 -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/ggh012j_5f_NLO_FXFX_130/ggh012j_5f_NLO_FXFX_130_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************


### PR DESCRIPTION
- added a higgs folder for the higgs signals in cards/production/13TeV for the mg5nlo
- added the cards used to produce the gridpacks for 5 mass points: 120, 124, 125, 126, 130
- all the gridpacks run successfully and ready to be copied in the eos location
- small set of events produced, would like to run the gem-only asap to check distributions with reasonable nb of events after hadronization and parton shower