### PR TITLE
[Madgraph5_aMC@NLO] Fix a typo in exo diboson VBF cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1000/Wprime_VBF_WZ_inclu_narrow_M1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1000/Wprime_VBF_WZ_inclu_narrow_M1000_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M1000 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1200/Wprime_VBF_WZ_inclu_narrow_M1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1200/Wprime_VBF_WZ_inclu_narrow_M1200_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M1200 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1400/Wprime_VBF_WZ_inclu_narrow_M1400_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1400/Wprime_VBF_WZ_inclu_narrow_M1400_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M1400 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1600/Wprime_VBF_WZ_inclu_narrow_M1600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1600/Wprime_VBF_WZ_inclu_narrow_M1600_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M1600 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1800/Wprime_VBF_WZ_inclu_narrow_M1800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1800/Wprime_VBF_WZ_inclu_narrow_M1800_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M1800 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2000/Wprime_VBF_WZ_inclu_narrow_M2000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2000/Wprime_VBF_WZ_inclu_narrow_M2000_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M2000 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2500/Wprime_VBF_WZ_inclu_narrow_M2500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2500/Wprime_VBF_WZ_inclu_narrow_M2500_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M2500 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3000/Wprime_VBF_WZ_inclu_narrow_M3000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3000/Wprime_VBF_WZ_inclu_narrow_M3000_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M3000 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3500/Wprime_VBF_WZ_inclu_narrow_M3500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3500/Wprime_VBF_WZ_inclu_narrow_M3500_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M3500 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4000/Wprime_VBF_WZ_inclu_narrow_M4000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4000/Wprime_VBF_WZ_inclu_narrow_M4000_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M4000 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4500/Wprime_VBF_WZ_inclu_narrow_M4500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4500/Wprime_VBF_WZ_inclu_narrow_M4500_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M4500 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M600/Wprime_VBF_WZ_inclu_narrow_M600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M600/Wprime_VBF_WZ_inclu_narrow_M600_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M600 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M800/Wprime_VBF_WZ_inclu_narrow_M800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M800/Wprime_VBF_WZ_inclu_narrow_M800_proc_card.dat
@@ -10,6 +10,6 @@ define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
 define vc = vc+ vc-
 define vw = w+ w-
-generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z ferm ferm )
+generate p p > vc j j $$ z w+ w- / g a h , ( vc > z vw , vw > ferm ferm , z > ferm ferm )
 output Wprime_VBF_WZ_inclu_narrow_M800 -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1000/Zprime_VBF_WW_inclu_narrow_M1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1000/Zprime_VBF_WW_inclu_narrow_M1000_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1200/Zprime_VBF_WW_inclu_narrow_M1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1200/Zprime_VBF_WW_inclu_narrow_M1200_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1400/Zprime_VBF_WW_inclu_narrow_M1400_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1400/Zprime_VBF_WW_inclu_narrow_M1400_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M1400 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1600/Zprime_VBF_WW_inclu_narrow_M1600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1600/Zprime_VBF_WW_inclu_narrow_M1600_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M1600 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1800/Zprime_VBF_WW_inclu_narrow_M1800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1800/Zprime_VBF_WW_inclu_narrow_M1800_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M1800 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2000/Zprime_VBF_WW_inclu_narrow_M2000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2000/Zprime_VBF_WW_inclu_narrow_M2000_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M2000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2500/Zprime_VBF_WW_inclu_narrow_M2500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2500/Zprime_VBF_WW_inclu_narrow_M2500_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M2500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3000/Zprime_VBF_WW_inclu_narrow_M3000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3000/Zprime_VBF_WW_inclu_narrow_M3000_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M3000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3500/Zprime_VBF_WW_inclu_narrow_M3500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3500/Zprime_VBF_WW_inclu_narrow_M3500_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M3500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4000/Zprime_VBF_WW_inclu_narrow_M4000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4000/Zprime_VBF_WW_inclu_narrow_M4000_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M4000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4500/Zprime_VBF_WW_inclu_narrow_M4500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4500/Zprime_VBF_WW_inclu_narrow_M4500_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M4500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M600/Zprime_VBF_WW_inclu_narrow_M600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M600/Zprime_VBF_WW_inclu_narrow_M600_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M600 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M800/Zprime_VBF_WW_inclu_narrow_M800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M800/Zprime_VBF_WW_inclu_narrow_M800_proc_card.dat
@@ -1,4 +1,4 @@
-set group_subprocesses Auto
+B1;2cset group_subprocesses Auto
 set ignore_six_quark_processes False
 set gauge unitary
 set complex_mass_scheme False
@@ -8,5 +8,5 @@ define j = p
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define ferm = u c d s b u~ c~ d~ s~ b~ e- mu- ta- e+ mu+ ta+ vl vl~
-generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- ferm ferm )
+generate p p > vz j j $$ z w+ w- / g a h , ( vz > w+ w- , w+ > ferm ferm , w- > ferm ferm )
 output Zprime_VBF_WW_inclu_narrow_M800 -nojpeg


### PR DESCRIPTION
fix a typo in the decay chain z > ferm ferm and w > ferm ferm

The two decay modes fixed are 
Zprime_VBF_WW_inclu and Wprime_VBF_WZ_inclu