### PR TITLE
Pythia8 fragments for ttH+0/1jet, H->bb and ttH+0/1jet, H->Nonbb samples

### DIFF
--- a/python/ThirteenTeV/ttHJetToNonbb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 120.0',
   '25:onMode = on', 	# Allow all higgs decays 
   '25:offIfAny = 5 5',    # Switch decays of b quarks off
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToNonbb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 120.0',
+  '25:onMode = on', 	# Allow all higgs decays 
+  '25:offIfAny = 5 5',    # Switch decays of b quarks off
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)

--- a/python/ThirteenTeV/ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 125.0',
+  '25:onMode = on', 	# Allow all higgs decays 
+  '25:offIfAny = 5 5',    # Switch decays of b quarks off
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)

--- a/python/ThirteenTeV/ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 125.0',
   '25:onMode = on', 	# Allow all higgs decays 
   '25:offIfAny = 5 5',    # Switch decays of b quarks off
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToNonbb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 130.0',
   '25:onMode = on', 	# Allow all higgs decays 
   '25:offIfAny = 5 5',    # Switch decays of b quarks off
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToNonbb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToNonbb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 130.0',
+  '25:onMode = on', 	# Allow all higgs decays 
+  '25:offIfAny = 5 5',    # Switch decays of b quarks off
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)

--- a/python/ThirteenTeV/ttHJetTobb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 120.0',
+  '25:onMode = off', 
+  '25:onIfAny = 5 5',    # Decay only higgs to bb
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttHJetTobb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 120.0',
   '25:onMode = off', 
   '25:onIfAny = 5 5',    # Decay only higgs to bb
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 125.0',
+  '25:onMode = off', 
+  '25:onIfAny = 5 5',    # Decay only higgs to bb
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 125.0',
   '25:onMode = off', 
   '25:onIfAny = 5 5',    # Decay only higgs to bb
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetTobb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -29,8 +29,6 @@ pythia8aMCatNLOSettingsBlock,
   '25:m0 = 130.0',
   '25:onMode = off', 
   '25:onIfAny = 5 5',    # Decay only higgs to bb
-  'Higgs:clipWings = off',  # Do not clip higgs width
-  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetTobb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetTobb_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 130.0',
+  '25:onMode = off', 
+  '25:onIfAny = 5 5',    # Decay only higgs to bb
+  'Higgs:clipWings = off',  # Do not clip higgs width
+  'HiggsSM:NLOWidths = on' # On by default, mentioned for documentation
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttbb_4FS_ckm_amcatnlo_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttbb_4FS_ckm_amcatnlo_madspin_pythia8_cff.py
@@ -1,3 +1,4 @@
+
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
@@ -12,21 +13,9 @@ PythiaParameters = cms.PSet(
 pythia8CommonSettingsBlock,
 pythia8CUEP8M1SettingsBlock,
 pythia8aMCatNLOSettingsBlock,
-  processParameters = cms.vstring(
-  'JetMatching:setMad = off',
-  'JetMatching:scheme = 1',
-  'JetMatching:merge = on',
-  'JetMatching:jetAlgorithm = 2',
-  'JetMatching:etaJetMax = 999.',
-  'JetMatching:coneRadius = 1.',
-  'JetMatching:slowJetPower = 1',
-  'JetMatching:qCut = 40.', #this is the actual merging scale
-  'JetMatching:doFxFx = on',
-  'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
-  'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
-  'JetMatching:nJetMax = 0', #number of partons in born matrix element for highest multiplicity, only tt+bb is produced on lhe level
-  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
-  ),
+processParameters = cms.vstring(
+'TimeShower:nPartonsInBorn = 4', #number of coloured particles (before resonance decays) in born matrix element
+),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',
 'pythia8aMCatNLOSettings',

--- a/python/ThirteenTeV/ttbb_4FS_ckm_amcatnlo_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttbb_4FS_ckm_amcatnlo_madspin_pythia8_cff.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 0', #number of partons in born matrix element for highest multiplicity, only tt+bb is produced on lhe level
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hello, 

I have added the pythia8 fragments for the ttH+0/1jet, H->bb and ttH+0/1jet, H->nonbb samples.

One question in this regard: In former times I had to add some TimeShower and other options for FxFx merging, e.g. see https://github.com/cms-sw/genproductions/blob/master/python/ThirteenTeV/Hadronizer_Tune4C_13TeV_aMCatNLO_FXFX_4f_1j_max1j_LHE_pythia8_cff.py

I have now used the following gen fragment as described in the SWGuideSubgroupMC https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max1j_max1p_LHE_pythia8_cff.py

Here the TimeShower options are missing, is this correct?