### PR TITLE
Pythia8 fragments for additional ttH+0/1jet samples H->Tau Tau and H->Gamma Gamma

### DIFF
--- a/python/ThirteenTeV/ttHJetToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 120.0',
+  '25:onMode = off', 
+  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttHJetToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M120_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -28,7 +28,7 @@ pythia8aMCatNLOSettingsBlock,
   'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
   '25:m0 = 120.0',
   '25:onMode = off', 
-  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  '25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 125.0',
+  '25:onMode = off', 
+  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -28,7 +28,7 @@ pythia8aMCatNLOSettingsBlock,
   'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
   '25:m0 = 125.0',
   '25:onMode = off', 
-  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  '25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -28,7 +28,7 @@ pythia8aMCatNLOSettingsBlock,
   'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
   '25:m0 = 130.0',
   '25:onMode = off', 
-  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  '25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',

--- a/python/ThirteenTeV/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 130.0',
+  '25:onMode = off', 
+  '25:onIfAny = 21 21',    # Decay only higgs to gamma gamma
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+

--- a/python/ThirteenTeV/ttHJetToTT_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/ttHJetToTT_M125_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+maxEventsToPrint = cms.untracked.int32(1),
+pythiaPylistVerbosity = cms.untracked.int32(1),
+filterEfficiency = cms.untracked.double(1.0),
+pythiaHepMCVerbosity = cms.untracked.bool(False),
+comEnergy = cms.double(13000.),
+PythiaParameters = cms.PSet(
+pythia8CommonSettingsBlock,
+pythia8CUEP8M1SettingsBlock,
+pythia8aMCatNLOSettingsBlock,
+  processParameters = cms.vstring(
+  'JetMatching:setMad = off',
+  'JetMatching:scheme = 1',
+  'JetMatching:merge = on',
+  'JetMatching:jetAlgorithm = 2',
+  'JetMatching:etaJetMax = 999.',
+  'JetMatching:coneRadius = 1.',
+  'JetMatching:slowJetPower = 1',
+  'JetMatching:qCut = 40.', #this is the actual merging scale
+  'JetMatching:doFxFx = on',
+  'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  '25:m0 = 125.0',
+  '25:onMode = off', 
+  '25:onIfAny = 15 15',    # Decay only higgs to tau tau
+  ),
+parameterSets = cms.vstring('pythia8CommonSettings',
+'pythia8CUEP8M1Settings',
+'pythia8aMCatNLOSettings',
+'processParameters',
+)
+)
+)
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Py8 fragment for ttH+0/1jet, H->Tau Tau:
* We use now the internal Pythia8 Tau decays.
* Do I have to set any additional Pythia8 option for the tau decay, see
http://home.thep.lu.se/~torbjorn/pythia82html/ParticleDecays.html
?