### PR TITLE
[Powheg] replace the optimization flag of gfortran for ttH process and add example input cards

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -146,6 +146,9 @@ if [ "$process" = "ttJ" ]; then
   mv Makefile Makefile.interm
   cat Makefile.interm | sed -e "s#_PATH) -L#_PATH) #g" | sed -e "s# -lvirtual#/libvirtual.so.1.0.0#g" > Makefile
 fi
+if [ "$process" = "ttH" ]; then
+    sed -i 's/O2/O0/g' Makefile
+fi
 if [ "$process" = "gg_H_MSSM" ]; then 
   mv nloreal.F nloreal.F.orig
   sed 's/leq/le/g' nloreal.F.orig > nloreal.F

--- a/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
@@ -1,0 +1,73 @@
+numevts NEVENTS    ! number of events to be generated
+
+! Production parameters for ttH production 
+hmass 125.d0      ! mass of the Higgs boson [GeV]
+hwidth 0.00498d0  ! width of the Higgs boson [GeV]
+
+! Higgs decay:
+hdecaymode -1   ! -1 no decay                
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar 
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma     
+
+pythiatune 320	! PYTHIA tune
+
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+lhans1  260000      ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000      ! pdf set for hadron 2 (LHA numbering)
+
+#bornsuppfact 1d0 ! (default 0d0) mass param for Born suppression factor. 
+delta_mttmin 0d0 ! (default 0d0) if not zero, use generation cut on mtt
+
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1  500000  ! number of calls for initializing the integration grid
+itmx1    2     ! number of iterations for initializing the integration grid
+ncall2  500000  ! number of calls for computing the integral and finding upper bound
+itmx2    1     ! number of iterations for computing the integral and finding upper bound
+foldcsi   1    ! number of folds on csi integration
+foldy     1    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+runningscales 1	   ! default 0 (no running scales); 1: use running scales
+renscfact 1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact 1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+
+#bornonly   1      ! (default 0) if 1 do Born only
+fakevirt   1      ! (default 0) if 1 use Born for virtuals
+
+iseed    SEED
+
+# parameters for top decays:
+topdecaymode 20000   ! 0 stable tops
+                    ! 20000 both tops decay into b l v
+zerowidth 0  	    ! if 1, use zero width approximation during decay
+elbranching 1d0  
+    
+# parameters for parallel runs (remove '#' below for parallel runs):
+#manyseeds  1       ! Used to perform multiple runs with different random
+                   ! seeds in the same directory.
+                   ! If set to 1, the program asks for an integer j;
+                   ! The file pwgseeds.dat at line j is read, and the
+                   ! integer at line j is used to initialize the random
+                   ! sequence for the generation of the event.
+                   ! The event file is called pwgevents-'j'.lhe
+
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 0 ! default 0, 
+#xgriditeration 1   ! identifier for grid generation
+#parallelstage  1   ! identifier for parallel running stages

--- a/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
@@ -31,10 +31,11 @@ use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound
 
 ncall1  500000  ! number of calls for initializing the integration grid
 itmx1    2     ! number of iterations for initializing the integration grid
-ncall2  500000  ! number of calls for computing the integral and finding upper bound
+#ncall2  500000  ! number of calls for computing the integral and finding upper bound
+ncall2   0  ! number of calls for computing the integral and finding upper bound
 itmx2    1     ! number of iterations for computing the integral and finding upper bound
 foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
+foldy      1    ! number of folds on  y  integration
 foldphi   1    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds


### PR DESCRIPTION
This update includes 

1) create_powheg_tarball.sh: Under suggestion of ttH authors, add 3 lines to replace the optimization flag with -O0. 
2) Add example input card for the ttH process

