### PR TITLE
[Powheg] fix of bquark mass for ttH, update of ttH and ggHZ example cards

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -148,6 +148,7 @@ if [ "$process" = "ttJ" ]; then
 fi
 if [ "$process" = "ttH" ]; then
     sed -i 's/O2/O0/g' Makefile
+    sed -i 's/4.5d0/4.75d0/g' init_couplings.f
 fi
 if [ "$process" = "gg_H_MSSM" ]; then 
   mv nloreal.F nloreal.F.orig

--- a/bin/Powheg/examples/V2/ggHZ_ggHee_NNPDF30_13TeV/ggHZ_ggHee_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ggHZ_ggHee_NNPDF30_13TeV/ggHZ_ggHee_NNPDF30_13TeV.input
@@ -33,8 +33,8 @@ pdfreweight 1
 ! 19170 cteq4l
 ! 10050 cteq6m
 ! 21100 MSTW 2008 (NLO central)
-lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
-lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+lhans1  263000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  263000         ! pdf set for hadron 2 (LHA numbering)	
 ! To be set only if using different pdf sets for the two incoming hadrons
 #QCDLambda5  0.25 ! for not equal pdf sets 
 

--- a/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ttH_NNPDF30_13TeV/ttH_NNPDF30_13TeV.input
@@ -31,8 +31,7 @@ use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound
 
 ncall1  500000  ! number of calls for initializing the integration grid
 itmx1    2     ! number of iterations for initializing the integration grid
-#ncall2  500000  ! number of calls for computing the integral and finding upper bound
-ncall2   0  ! number of calls for computing the integral and finding upper bound
+ncall2  500000  ! number of calls for computing the integral and finding upper bound
 itmx2    1     ! number of iterations for computing the integral and finding upper bound
 foldcsi   1    ! number of folds on csi integration
 foldy      1    ! number of folds on  y  integration


### PR DESCRIPTION
Update includes:

1) create_powheg_tarball.sh: replace the bquark mass in init_couplings.f with 4.75 GeV
2) ggHZ example card: use LO NNPDF 3.0 PDF (263000) 
3) ttH example card: make ncall2=500000