### PR TITLE
[Madgraph5_aMC@NLO]  Exo-diboson: fix the customizecards.dat of BulkGraviton->ZZ->ZhadZinv

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1000/BulkGraviton_ZZ_ZhadZinv_narrow_M1000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1000/BulkGraviton_ZZ_ZhadZinv_narrow_M1000_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 1000
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1200/BulkGraviton_ZZ_ZhadZinv_narrow_M1200_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1200/BulkGraviton_ZZ_ZhadZinv_narrow_M1200_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 1200
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1400/BulkGraviton_ZZ_ZhadZinv_narrow_M1400_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1400/BulkGraviton_ZZ_ZhadZinv_narrow_M1400_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 1400
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1600/BulkGraviton_ZZ_ZhadZinv_narrow_M1600_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1600/BulkGraviton_ZZ_ZhadZinv_narrow_M1600_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 1600
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1800/BulkGraviton_ZZ_ZhadZinv_narrow_M1800_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1800/BulkGraviton_ZZ_ZhadZinv_narrow_M1800_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 1800
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2000/BulkGraviton_ZZ_ZhadZinv_narrow_M2000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2000/BulkGraviton_ZZ_ZhadZinv_narrow_M2000_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 2000
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2500/BulkGraviton_ZZ_ZhadZinv_narrow_M2500_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2500/BulkGraviton_ZZ_ZhadZinv_narrow_M2500_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 2500
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3000/BulkGraviton_ZZ_ZhadZinv_narrow_M3000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3000/BulkGraviton_ZZ_ZhadZinv_narrow_M3000_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 3000
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3500/BulkGraviton_ZZ_ZhadZinv_narrow_M3500_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3500/BulkGraviton_ZZ_ZhadZinv_narrow_M3500_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 3500
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4000/BulkGraviton_ZZ_ZhadZinv_narrow_M4000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4000/BulkGraviton_ZZ_ZhadZinv_narrow_M4000_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 4000
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4500/BulkGraviton_ZZ_ZhadZinv_narrow_M4500_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4500/BulkGraviton_ZZ_ZhadZinv_narrow_M4500_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 4500
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M600/BulkGraviton_ZZ_ZhadZinv_narrow_M600_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M600/BulkGraviton_ZZ_ZhadZinv_narrow_M600_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 600
+set param_card decay 39 1.000000e-03
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M800/BulkGraviton_ZZ_ZhadZinv_narrow_M800_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M800/BulkGraviton_ZZ_ZhadZinv_narrow_M800_customizecards.dat
@@ -1,10 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
-import model RS_bulk_ktilda
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define q = u c d s b u~ c~ d~ s~ b~
-generate p p > y, ( y > z z > q q vl vl~)
-output BulkGraviton_ZZ_ZhadZinv
+set param_card mass 39 800
+set param_card decay 39 1.000000e-03
+


### PR DESCRIPTION
In my last commit of the cards for the mode BulkGraviton->ZZ->ZhadZinv, 
by accident, the process cards were copied to the customizecards.dat.

In this commit, the customizecards.dat has been fixed for all 13 mass points.

