### PR TITLE
[Powheg] fix the random seed parameter in the example input cards of hvq and ttb_NLO_dec processes

### DIFF
--- a/bin/Powheg/examples/V2/hvq_enubenub_CT10_13TeV/hvq_enubenub_CT10_13TeV.input
+++ b/bin/Powheg/examples/V2/hvq_enubenub_CT10_13TeV/hvq_enubenub_CT10_13TeV.input
@@ -1,4 +1,5 @@
-randomseed SEED ! uncomment to set the random seed to a value of your choice.
+iseed    SEED       ! Start the random number generator with seed iseed 
+#randomseed SEED ! uncomment to set the random seed to a value of your choice.
                    ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
                    ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
                    ! If POWHEG is interfaced to a shower MC, refer to the shower MC

--- a/bin/Powheg/examples/V2/hvq_enubenub_NNPDF30_13TeV/hvq_enubenub_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/hvq_enubenub_NNPDF30_13TeV/hvq_enubenub_NNPDF30_13TeV.input
@@ -1,4 +1,5 @@
-randomseed SEED ! uncomment to set the random seed to a value of your choice.
+iseed    SEED       ! Start the random number generator with seed iseed 
+#randomseed SEED ! uncomment to set the random seed to a value of your choice.
                    ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
                    ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
                    ! If POWHEG is interfaced to a shower MC, refer to the shower MC

--- a/bin/Powheg/examples/V2/ttb_NLO_dec_enubenub_NNPDF30_13TeV/ttb_NLO_dec_enubenub_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ttb_NLO_dec_enubenub_NNPDF30_13TeV/ttb_NLO_dec_enubenub_NNPDF30_13TeV.input
@@ -60,7 +60,7 @@ facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact
      
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
-withnegweights 1 ! default 0, 
+withnegweights 0 ! default 0, 
 
 #pyMEC 0      ! Discussion with Pythia developers has led us to try this
               ! flag if we generate the corrections in decays (our default setting)

--- a/bin/Powheg/examples/V2/ttb_NLO_dec_enubenub_NNPDF30_13TeV/ttb_NLO_dec_enubenub_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/ttb_NLO_dec_enubenub_NNPDF30_13TeV/ttb_NLO_dec_enubenub_NNPDF30_13TeV.input
@@ -41,6 +41,7 @@ xupbound 2d0   ! increase upper bound for radiation generation
 # nlowhich 0    ! default is 0; set to 1 for no NLO corrections in decay
 
 # allrad 1      ! default is 1; set to 0 for standard POWHEG behaviour (see reference paper)
+iseed     SEED    ! initialize random number sequence
 
 
 # hdamp has the same meaning as in POWHEG (old) hvq generator.
@@ -59,7 +60,7 @@ facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact
      
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
-withnegweights 0 ! default 0, 
+withnegweights 1 ! default 0, 
 
 #pyMEC 0      ! Discussion with Pythia developers has led us to try this
               ! flag if we generate the corrections in decays (our default setting)


### PR DESCRIPTION
This pull request updates 3 example input cards. Two for hvq NNPDF and hvq CT10 and one for ttb_NLO_dec NNPDF input cards. 

hvq: previous input cards use the "randomseed" parameter to set seed. But a test shows that this parameter is not used and instead "iseed" (like the other processes) should be used.
Now the current version uses the parameter "iseed" to set the seeds of generation.

ttb_NLO_dec: a line of "iseed SEED" was forgotten. Now this line is inserted.




