### PR TITLE
 Pythia cfg files for ZZ->2l2nu in VBF channel

### DIFF
--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M1000GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5    ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    1000d0       ! Higgs boson mass
+hwidth   647d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M400GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000    ! number of calls for initializing the integration grid
+itmx1    7       ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5       ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 175000   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1       ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1        ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0     ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1    ! default 0,
+
+iseed    SEED             ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3              ! initialize random number sequence 
+
+hmass    400d0     ! Higgs boson mass
+hwidth   29.2d0    ! Higgs boson width
+hdecaymode -1      ! -1 no decay
+                   ! 0 all decay channels open
+                   ! 1-6 d dbar, u ubar,..., t tbar
+                   ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                   ! 10  W+W-
+                   ! 11  ZZ
+                   ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M600GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    600d0    ! Higgs boson mass
+hwidth   123d0    ! Higgs boson width
+hdecaymode -1     ! -1 no decay
+                  ! 0 all decay channels open
+                  ! 1-6 d dbar, u ubar,..., t tbar
+                  ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                  ! 10  W+W-
+                  ! 11  ZZ
+                  ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 1d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 1000             ! Higgs boson mass
+hwidth 647D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M400GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 10d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 400             ! Higgs boson mass
+hwidth 29.2D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_NoJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M600GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 5d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 600             ! Higgs boson mass
+hwidth 123D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M1000GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5    ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    1000d0       ! Higgs boson mass
+hwidth   647d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M400GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000    ! number of calls for initializing the integration grid
+itmx1    7       ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5       ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 175000   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1       ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1        ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0     ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1    ! default 0,
+
+iseed    SEED             ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3              ! initialize random number sequence 
+
+hmass    400d0     ! Higgs boson mass
+hwidth   29.2d0    ! Higgs boson width
+hdecaymode -1      ! -1 no decay
+                   ! 0 all decay channels open
+                   ! 1-6 d dbar, u ubar,..., t tbar
+                   ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                   ! 10  W+W-
+                   ! 11  ZZ
+                   ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/VBF_NNPDF30_13TeV_M600GeV.input
@@ -1,0 +1,79 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 125000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    600d0    ! Higgs boson mass
+hwidth   123d0    ! Higgs boson width
+hdecaymode -1     ! -1 no decay
+                  ! 0 all decay channels open
+                  ! 1-6 d dbar, u ubar,..., t tbar
+                  ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                  ! 10  W+W-
+                  ! 11  ZZ
+                  ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 1d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 1000             ! Higgs boson mass
+hwidth 647D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M400GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 10d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 400             ! Higgs boson mass
+hwidth 29.2D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/gg_H_quark-mass-effects_NNPDF30_13TeV_M600GeV.input
@@ -1,0 +1,90 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25  ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1   ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000     ! number of calls for initializing the integration grid
+itmx1  3         ! number of iterations for initializing the integration grid
+ncall2 1000000     ! number of calls for computing the integral and finding upper bound
+itmx2  5         ! number of iterations for computing the integral and finding upper bound
+foldcsi   2      ! number of folds on csi integration
+foldy     5      ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0     ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0       ! (default 0) if 1 do Born only
+#smartsig   0       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0       ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8     ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5     ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0     ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    104.16d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1        ! (default 0, do not test) test Sudakov form factor
+#radregion 1        ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5   ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0   ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 0      ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                    ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0       ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1              ! PDG code for first decay product of the higgs
+masswindow 5d0            !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 600             ! Higgs boson mass
+hwidth 123D0         ! Higgs boson width
+topmass 172.5         ! top quark mass
+bottommass 4.75d0     ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0      ! char quark mass - if defined it enables the charm quark
+
+! Optional
+hdecaywidth 0         ! If equals to 1 read total decay width from HDECAY sm.br2 file (if we want to read the Width from file)
+withnegweights 0
+pdfreweight 1         ! PDF reweighting
+storeinfo_rwgt 1      ! store weight information
+bwshape 3   !  complex-pole scheme according to Passarino et al.

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_LepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_LepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 1000.0'        # Higgs Mass
+            '25:onMode = off',      # turn OFF all h2 decays
+            '25:onIfMatch = 23 23',      # turn ON h2->ZZ
+            '23:onMode = off',      # turn OFF all Z decays
+            '23:onIfAny = 11 13 12 14 16', # turn ON Z->ll
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_NoLepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_NoLepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 1000.0'        # Higgs Mass
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_LepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_LepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 400.0'         # Higgs Mass
+            '25:onMode = off',      # turn OFF all h2 decays
+            '25:onIfMatch = 23 23',      # turn ON h2->ZZ
+            '23:onMode = off',      # turn OFF all Z decays
+            '23:onIfAny = 11 13 12 14 16', # turn ON Z->ll
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_NoLepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_NoLepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 400.0'         # Higgs Mass
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_LepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_LepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 600.0'         # Higgs Mass
+            '25:onMode = off',      # turn OFF all h2 decays
+            '25:onIfMatch = 23 23',      # turn ON h2->ZZ
+            '23:onMode = off',      # turn OFF all Z decays
+            '23:onIfAny = 11 13 12 14 16', # turn ON Z->ll
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_NoLepDECAY_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_NoLepDECAY_LHE_pythia8_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 600.0'         # Higgs Mass
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Hi all,

I added 6 different cfg files to shower powheg lhe files using pythia8 in the case that the higgs boson is decayed by JHUGen or by Pythia8.
There are three different mass point: 400, 600 and 1000 GeV.
The cfg are the following:
1- Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_LepDECAY_LHE_pythia8_cff.py
2-Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M1000GeV_NoLepDECAY_LHE_pythia8_cff.py
3-Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_LepDECAY_LHE_pythia8_cff.py
4-Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M600GeV_NoLepDECAY_LHE_pythia8_cff.py
5-Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_LepDECAY_LHE_pythia8_cff.py
6-Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_3p_H_ZZ_2l2nu_VBF_M400GeV_NoLepDECAY_LHE_pythia8_cff.py

Cheers,
Alessio