### PR TITLE
[Madgraph5_aMC@NLO] ExoDiboson: change cut_decays to F  = cut_decays

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1000/Radion_VBF_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1000/Radion_VBF_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1200/Radion_VBF_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1200/Radion_VBF_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1400/Radion_VBF_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1400/Radion_VBF_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1600/Radion_VBF_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1600/Radion_VBF_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1800/Radion_VBF_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M1800/Radion_VBF_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M2000/Radion_VBF_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M2000/Radion_VBF_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M2500/Radion_VBF_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M2500/Radion_VBF_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M3000/Radion_VBF_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M3000/Radion_VBF_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M3500/Radion_VBF_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M3500/Radion_VBF_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M4000/Radion_VBF_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M4000/Radion_VBF_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M4500/Radion_VBF_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M4500/Radion_VBF_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M600/Radion_VBF_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M600/Radion_VBF_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M800/Radion_VBF_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow_M800/Radion_VBF_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1000/Radion_VBF_ZZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1000/Radion_VBF_ZZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1200/Radion_VBF_ZZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1200/Radion_VBF_ZZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1400/Radion_VBF_ZZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1400/Radion_VBF_ZZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1600/Radion_VBF_ZZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1600/Radion_VBF_ZZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1800/Radion_VBF_ZZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M1800/Radion_VBF_ZZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M2000/Radion_VBF_ZZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M2000/Radion_VBF_ZZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M2500/Radion_VBF_ZZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M2500/Radion_VBF_ZZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M3000/Radion_VBF_ZZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M3000/Radion_VBF_ZZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M3500/Radion_VBF_ZZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M3500/Radion_VBF_ZZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M4000/Radion_VBF_ZZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M4000/Radion_VBF_ZZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M4500/Radion_VBF_ZZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M4500/Radion_VBF_ZZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M600/Radion_VBF_ZZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M600/Radion_VBF_ZZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M800/Radion_VBF_ZZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow_M800/Radion_VBF_ZZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1000/Radion_WW_WlepWhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1000/Radion_WW_WlepWhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1200/Radion_WW_WlepWhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1200/Radion_WW_WlepWhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1400/Radion_WW_WlepWhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1400/Radion_WW_WlepWhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1600/Radion_WW_WlepWhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1600/Radion_WW_WlepWhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1800/Radion_WW_WlepWhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M1800/Radion_WW_WlepWhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M2000/Radion_WW_WlepWhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M2000/Radion_WW_WlepWhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M2500/Radion_WW_WlepWhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M2500/Radion_WW_WlepWhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M3000/Radion_WW_WlepWhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M3000/Radion_WW_WlepWhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M3500/Radion_WW_WlepWhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M3500/Radion_WW_WlepWhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M4000/Radion_WW_WlepWhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M4000/Radion_WW_WlepWhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M4500/Radion_WW_WlepWhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M4500/Radion_WW_WlepWhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M600/Radion_WW_WlepWhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M600/Radion_WW_WlepWhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M800/Radion_WW_WlepWhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_WlepWhad/Radion_WW_WlepWhad_narrow_M800/Radion_WW_WlepWhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1000/Radion_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1000/Radion_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1200/Radion_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1200/Radion_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1400/Radion_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1400/Radion_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1600/Radion_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1600/Radion_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1800/Radion_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M1800/Radion_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M2000/Radion_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M2000/Radion_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M2500/Radion_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M2500/Radion_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M3000/Radion_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M3000/Radion_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M3500/Radion_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M3500/Radion_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M4000/Radion_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M4000/Radion_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M4500/Radion_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M4500/Radion_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M600/Radion_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M600/Radion_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M800/Radion_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_WW_inclu/Radion_WW_inclu_narrow_M800/Radion_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1000/Radion_ZZ_ZhadZinv_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1000/Radion_ZZ_ZhadZinv_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1200/Radion_ZZ_ZhadZinv_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1200/Radion_ZZ_ZhadZinv_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1400/Radion_ZZ_ZhadZinv_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1400/Radion_ZZ_ZhadZinv_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1600/Radion_ZZ_ZhadZinv_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1600/Radion_ZZ_ZhadZinv_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1800/Radion_ZZ_ZhadZinv_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M1800/Radion_ZZ_ZhadZinv_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M2000/Radion_ZZ_ZhadZinv_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M2000/Radion_ZZ_ZhadZinv_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M2500/Radion_ZZ_ZhadZinv_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M2500/Radion_ZZ_ZhadZinv_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M3000/Radion_ZZ_ZhadZinv_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M3000/Radion_ZZ_ZhadZinv_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M3500/Radion_ZZ_ZhadZinv_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M3500/Radion_ZZ_ZhadZinv_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M4000/Radion_ZZ_ZhadZinv_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M4000/Radion_ZZ_ZhadZinv_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M4500/Radion_ZZ_ZhadZinv_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M4500/Radion_ZZ_ZhadZinv_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M600/Radion_ZZ_ZhadZinv_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M600/Radion_ZZ_ZhadZinv_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M800/Radion_ZZ_ZhadZinv_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZhadZinv/Radion_ZZ_ZhadZinv_narrow_M800/Radion_ZZ_ZhadZinv_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1000/Radion_ZZ_ZlepZhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1000/Radion_ZZ_ZlepZhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1200/Radion_ZZ_ZlepZhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1200/Radion_ZZ_ZlepZhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1400/Radion_ZZ_ZlepZhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1400/Radion_ZZ_ZlepZhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1600/Radion_ZZ_ZlepZhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1600/Radion_ZZ_ZlepZhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1800/Radion_ZZ_ZlepZhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M1800/Radion_ZZ_ZlepZhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M2000/Radion_ZZ_ZlepZhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M2000/Radion_ZZ_ZlepZhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M2500/Radion_ZZ_ZlepZhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M2500/Radion_ZZ_ZlepZhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M3000/Radion_ZZ_ZlepZhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M3000/Radion_ZZ_ZlepZhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M3500/Radion_ZZ_ZlepZhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M3500/Radion_ZZ_ZlepZhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M4000/Radion_ZZ_ZlepZhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M4000/Radion_ZZ_ZlepZhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M4500/Radion_ZZ_ZlepZhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M4500/Radion_ZZ_ZlepZhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M600/Radion_ZZ_ZlepZhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M600/Radion_ZZ_ZlepZhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M800/Radion_ZZ_ZlepZhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZhad/Radion_ZZ_ZlepZhad_narrow_M800/Radion_ZZ_ZlepZhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1000/Radion_ZZ_ZlepZinv_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1000/Radion_ZZ_ZlepZinv_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1200/Radion_ZZ_ZlepZinv_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1200/Radion_ZZ_ZlepZinv_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1400/Radion_ZZ_ZlepZinv_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1400/Radion_ZZ_ZlepZinv_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1600/Radion_ZZ_ZlepZinv_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1600/Radion_ZZ_ZlepZinv_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1800/Radion_ZZ_ZlepZinv_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M1800/Radion_ZZ_ZlepZinv_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M2000/Radion_ZZ_ZlepZinv_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M2000/Radion_ZZ_ZlepZinv_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M2500/Radion_ZZ_ZlepZinv_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M2500/Radion_ZZ_ZlepZinv_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M3000/Radion_ZZ_ZlepZinv_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M3000/Radion_ZZ_ZlepZinv_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M3500/Radion_ZZ_ZlepZinv_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M3500/Radion_ZZ_ZlepZinv_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M4000/Radion_ZZ_ZlepZinv_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M4000/Radion_ZZ_ZlepZinv_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M4500/Radion_ZZ_ZlepZinv_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M4500/Radion_ZZ_ZlepZinv_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M600/Radion_ZZ_ZlepZinv_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M600/Radion_ZZ_ZlepZinv_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M800/Radion_ZZ_ZlepZinv_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_ZlepZinv/Radion_ZZ_ZlepZinv_narrow_M800/Radion_ZZ_ZlepZinv_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1000/Radion_ZZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1000/Radion_ZZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1200/Radion_ZZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1200/Radion_ZZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1400/Radion_ZZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1400/Radion_ZZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1600/Radion_ZZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1600/Radion_ZZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1800/Radion_ZZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M1800/Radion_ZZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M2000/Radion_ZZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M2000/Radion_ZZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M2500/Radion_ZZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M2500/Radion_ZZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M3000/Radion_ZZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M3000/Radion_ZZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M3500/Radion_ZZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M3500/Radion_ZZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M4000/Radion_ZZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M4000/Radion_ZZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M4500/Radion_ZZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M4500/Radion_ZZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M600/Radion_ZZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M600/Radion_ZZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M800/Radion_ZZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_ZZ_inclu/Radion_ZZ_inclu_narrow_M800/Radion_ZZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1000/Radion_hh_hVVhbb_fullLep_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1000/Radion_hh_hVVhbb_fullLep_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1200/Radion_hh_hVVhbb_fullLep_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1200/Radion_hh_hVVhbb_fullLep_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1400/Radion_hh_hVVhbb_fullLep_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1400/Radion_hh_hVVhbb_fullLep_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1600/Radion_hh_hVVhbb_fullLep_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1600/Radion_hh_hVVhbb_fullLep_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1800/Radion_hh_hVVhbb_fullLep_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M1800/Radion_hh_hVVhbb_fullLep_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M2000/Radion_hh_hVVhbb_fullLep_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M2000/Radion_hh_hVVhbb_fullLep_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M2500/Radion_hh_hVVhbb_fullLep_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M2500/Radion_hh_hVVhbb_fullLep_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M260/Radion_hh_hVVhbb_fullLep_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M260/Radion_hh_hVVhbb_fullLep_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M270/Radion_hh_hVVhbb_fullLep_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M270/Radion_hh_hVVhbb_fullLep_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M300/Radion_hh_hVVhbb_fullLep_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M300/Radion_hh_hVVhbb_fullLep_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M3000/Radion_hh_hVVhbb_fullLep_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M3000/Radion_hh_hVVhbb_fullLep_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M350/Radion_hh_hVVhbb_fullLep_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M350/Radion_hh_hVVhbb_fullLep_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M3500/Radion_hh_hVVhbb_fullLep_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M3500/Radion_hh_hVVhbb_fullLep_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M400/Radion_hh_hVVhbb_fullLep_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M400/Radion_hh_hVVhbb_fullLep_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M4000/Radion_hh_hVVhbb_fullLep_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M4000/Radion_hh_hVVhbb_fullLep_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M450/Radion_hh_hVVhbb_fullLep_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M450/Radion_hh_hVVhbb_fullLep_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M4500/Radion_hh_hVVhbb_fullLep_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M4500/Radion_hh_hVVhbb_fullLep_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M500/Radion_hh_hVVhbb_fullLep_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M500/Radion_hh_hVVhbb_fullLep_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M550/Radion_hh_hVVhbb_fullLep_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M550/Radion_hh_hVVhbb_fullLep_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M600/Radion_hh_hVVhbb_fullLep_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M600/Radion_hh_hVVhbb_fullLep_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M650/Radion_hh_hVVhbb_fullLep_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M650/Radion_hh_hVVhbb_fullLep_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M700/Radion_hh_hVVhbb_fullLep_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M700/Radion_hh_hVVhbb_fullLep_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M800/Radion_hh_hVVhbb_fullLep_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M800/Radion_hh_hVVhbb_fullLep_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M900/Radion_hh_hVVhbb_fullLep_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_fullLep/Radion_hh_hVVhbb_fullLep_narrow_M900/Radion_hh_hVVhbb_fullLep_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1000/Radion_hh_hVVhbb_inclusive_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1000/Radion_hh_hVVhbb_inclusive_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1200/Radion_hh_hVVhbb_inclusive_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1200/Radion_hh_hVVhbb_inclusive_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1400/Radion_hh_hVVhbb_inclusive_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1400/Radion_hh_hVVhbb_inclusive_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1600/Radion_hh_hVVhbb_inclusive_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1600/Radion_hh_hVVhbb_inclusive_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1800/Radion_hh_hVVhbb_inclusive_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M1800/Radion_hh_hVVhbb_inclusive_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M2000/Radion_hh_hVVhbb_inclusive_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M2000/Radion_hh_hVVhbb_inclusive_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M2500/Radion_hh_hVVhbb_inclusive_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M2500/Radion_hh_hVVhbb_inclusive_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M260/Radion_hh_hVVhbb_inclusive_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M260/Radion_hh_hVVhbb_inclusive_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M270/Radion_hh_hVVhbb_inclusive_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M270/Radion_hh_hVVhbb_inclusive_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M300/Radion_hh_hVVhbb_inclusive_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M300/Radion_hh_hVVhbb_inclusive_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M3000/Radion_hh_hVVhbb_inclusive_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M3000/Radion_hh_hVVhbb_inclusive_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M350/Radion_hh_hVVhbb_inclusive_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M350/Radion_hh_hVVhbb_inclusive_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M3500/Radion_hh_hVVhbb_inclusive_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M3500/Radion_hh_hVVhbb_inclusive_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M400/Radion_hh_hVVhbb_inclusive_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M400/Radion_hh_hVVhbb_inclusive_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M4000/Radion_hh_hVVhbb_inclusive_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M4000/Radion_hh_hVVhbb_inclusive_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M450/Radion_hh_hVVhbb_inclusive_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M450/Radion_hh_hVVhbb_inclusive_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M4500/Radion_hh_hVVhbb_inclusive_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M4500/Radion_hh_hVVhbb_inclusive_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M500/Radion_hh_hVVhbb_inclusive_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M500/Radion_hh_hVVhbb_inclusive_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M550/Radion_hh_hVVhbb_inclusive_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M550/Radion_hh_hVVhbb_inclusive_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M600/Radion_hh_hVVhbb_inclusive_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M600/Radion_hh_hVVhbb_inclusive_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M650/Radion_hh_hVVhbb_inclusive_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M650/Radion_hh_hVVhbb_inclusive_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M700/Radion_hh_hVVhbb_inclusive_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M700/Radion_hh_hVVhbb_inclusive_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M800/Radion_hh_hVVhbb_inclusive_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M800/Radion_hh_hVVhbb_inclusive_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M900/Radion_hh_hVVhbb_inclusive_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hVVhbb_inclusive/Radion_hh_hVVhbb_inclusive_narrow_M900/Radion_hh_hVVhbb_inclusive_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1000/Radion_hh_haahbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1000/Radion_hh_haahbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1200/Radion_hh_haahbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1200/Radion_hh_haahbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1400/Radion_hh_haahbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1400/Radion_hh_haahbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1600/Radion_hh_haahbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1600/Radion_hh_haahbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1800/Radion_hh_haahbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M1800/Radion_hh_haahbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M2000/Radion_hh_haahbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M2000/Radion_hh_haahbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M250/Radion_hh_haahbb_narrow_M250_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M250/Radion_hh_haahbb_narrow_M250_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M2500/Radion_hh_haahbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M2500/Radion_hh_haahbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M260/Radion_hh_haahbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M260/Radion_hh_haahbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M270/Radion_hh_haahbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M270/Radion_hh_haahbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M280/Radion_hh_haahbb_narrow_M280_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M280/Radion_hh_haahbb_narrow_M280_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M300/Radion_hh_haahbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M300/Radion_hh_haahbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M3000/Radion_hh_haahbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M3000/Radion_hh_haahbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M320/Radion_hh_haahbb_narrow_M320_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M320/Radion_hh_haahbb_narrow_M320_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M340/Radion_hh_haahbb_narrow_M340_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M340/Radion_hh_haahbb_narrow_M340_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M350/Radion_hh_haahbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M350/Radion_hh_haahbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M3500/Radion_hh_haahbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M3500/Radion_hh_haahbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M400/Radion_hh_haahbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M400/Radion_hh_haahbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M4000/Radion_hh_haahbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M4000/Radion_hh_haahbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M450/Radion_hh_haahbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M450/Radion_hh_haahbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M4500/Radion_hh_haahbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M4500/Radion_hh_haahbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M500/Radion_hh_haahbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M500/Radion_hh_haahbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M550/Radion_hh_haahbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M550/Radion_hh_haahbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M600/Radion_hh_haahbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M600/Radion_hh_haahbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M650/Radion_hh_haahbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M650/Radion_hh_haahbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M700/Radion_hh_haahbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M700/Radion_hh_haahbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M800/Radion_hh_haahbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M800/Radion_hh_haahbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M900/Radion_hh_haahbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_haahbb/Radion_hh_haahbb_narrow_M900/Radion_hh_haahbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1000/Radion_hh_hbbhbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1000/Radion_hh_hbbhbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1200/Radion_hh_hbbhbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1200/Radion_hh_hbbhbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1400/Radion_hh_hbbhbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1400/Radion_hh_hbbhbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1600/Radion_hh_hbbhbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1600/Radion_hh_hbbhbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1800/Radion_hh_hbbhbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M1800/Radion_hh_hbbhbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M2000/Radion_hh_hbbhbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M2000/Radion_hh_hbbhbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M2500/Radion_hh_hbbhbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M2500/Radion_hh_hbbhbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M260/Radion_hh_hbbhbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M260/Radion_hh_hbbhbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M270/Radion_hh_hbbhbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M270/Radion_hh_hbbhbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M300/Radion_hh_hbbhbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M300/Radion_hh_hbbhbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M3000/Radion_hh_hbbhbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M3000/Radion_hh_hbbhbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M350/Radion_hh_hbbhbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M350/Radion_hh_hbbhbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M3500/Radion_hh_hbbhbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M3500/Radion_hh_hbbhbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M400/Radion_hh_hbbhbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M400/Radion_hh_hbbhbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M4000/Radion_hh_hbbhbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M4000/Radion_hh_hbbhbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M450/Radion_hh_hbbhbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M450/Radion_hh_hbbhbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M4500/Radion_hh_hbbhbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M4500/Radion_hh_hbbhbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M500/Radion_hh_hbbhbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M500/Radion_hh_hbbhbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M550/Radion_hh_hbbhbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M550/Radion_hh_hbbhbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M600/Radion_hh_hbbhbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M600/Radion_hh_hbbhbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M650/Radion_hh_hbbhbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M650/Radion_hh_hbbhbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M700/Radion_hh_hbbhbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M700/Radion_hh_hbbhbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M800/Radion_hh_hbbhbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M800/Radion_hh_hbbhbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M900/Radion_hh_hbbhbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_hbbhbb/Radion_hh_hbbhbb_narrow_M900/Radion_hh_hbbhbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1000/Radion_hh_htatahbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1000/Radion_hh_htatahbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1200/Radion_hh_htatahbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1200/Radion_hh_htatahbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1400/Radion_hh_htatahbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1400/Radion_hh_htatahbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1600/Radion_hh_htatahbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1600/Radion_hh_htatahbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1800/Radion_hh_htatahbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M1800/Radion_hh_htatahbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M2000/Radion_hh_htatahbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M2000/Radion_hh_htatahbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M250/Radion_hh_htatahbb_narrow_M250_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M250/Radion_hh_htatahbb_narrow_M250_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M2500/Radion_hh_htatahbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M2500/Radion_hh_htatahbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M260/Radion_hh_htatahbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M260/Radion_hh_htatahbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M270/Radion_hh_htatahbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M270/Radion_hh_htatahbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M280/Radion_hh_htatahbb_narrow_M280_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M280/Radion_hh_htatahbb_narrow_M280_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M300/Radion_hh_htatahbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M300/Radion_hh_htatahbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M3000/Radion_hh_htatahbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M3000/Radion_hh_htatahbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M320/Radion_hh_htatahbb_narrow_M320_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M320/Radion_hh_htatahbb_narrow_M320_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M340/Radion_hh_htatahbb_narrow_M340_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M340/Radion_hh_htatahbb_narrow_M340_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M350/Radion_hh_htatahbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M350/Radion_hh_htatahbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M3500/Radion_hh_htatahbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M3500/Radion_hh_htatahbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M400/Radion_hh_htatahbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M400/Radion_hh_htatahbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M4000/Radion_hh_htatahbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M4000/Radion_hh_htatahbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M450/Radion_hh_htatahbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M450/Radion_hh_htatahbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M4500/Radion_hh_htatahbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M4500/Radion_hh_htatahbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M500/Radion_hh_htatahbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M500/Radion_hh_htatahbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M550/Radion_hh_htatahbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M550/Radion_hh_htatahbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M600/Radion_hh_htatahbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M600/Radion_hh_htatahbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M650/Radion_hh_htatahbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M650/Radion_hh_htatahbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M700/Radion_hh_htatahbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M700/Radion_hh_htatahbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M800/Radion_hh_htatahbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M800/Radion_hh_htatahbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M900/Radion_hh_htatahbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_hh_htatahbb/Radion_hh_htatahbb_narrow_M900/Radion_hh_htatahbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1000/Wprime_VBF_WZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1000/Wprime_VBF_WZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1200/Wprime_VBF_WZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1200/Wprime_VBF_WZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1400/Wprime_VBF_WZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1400/Wprime_VBF_WZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1600/Wprime_VBF_WZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1600/Wprime_VBF_WZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1800/Wprime_VBF_WZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M1800/Wprime_VBF_WZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2000/Wprime_VBF_WZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2000/Wprime_VBF_WZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2500/Wprime_VBF_WZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M2500/Wprime_VBF_WZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3000/Wprime_VBF_WZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3000/Wprime_VBF_WZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3500/Wprime_VBF_WZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M3500/Wprime_VBF_WZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4000/Wprime_VBF_WZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4000/Wprime_VBF_WZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4500/Wprime_VBF_WZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M4500/Wprime_VBF_WZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M600/Wprime_VBF_WZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M600/Wprime_VBF_WZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M800/Wprime_VBF_WZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow_M800/Wprime_VBF_WZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1000/Wprime_WZ_WhadZhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1000/Wprime_WZ_WhadZhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1200/Wprime_WZ_WhadZhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1200/Wprime_WZ_WhadZhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1400/Wprime_WZ_WhadZhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1400/Wprime_WZ_WhadZhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1600/Wprime_WZ_WhadZhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1600/Wprime_WZ_WhadZhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1800/Wprime_WZ_WhadZhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M1800/Wprime_WZ_WhadZhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M2000/Wprime_WZ_WhadZhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M2000/Wprime_WZ_WhadZhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M2500/Wprime_WZ_WhadZhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M2500/Wprime_WZ_WhadZhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M3000/Wprime_WZ_WhadZhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M3000/Wprime_WZ_WhadZhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M3500/Wprime_WZ_WhadZhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M3500/Wprime_WZ_WhadZhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M4000/Wprime_WZ_WhadZhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M4000/Wprime_WZ_WhadZhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M4500/Wprime_WZ_WhadZhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M4500/Wprime_WZ_WhadZhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M600/Wprime_WZ_WhadZhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M600/Wprime_WZ_WhadZhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M800/Wprime_WZ_WhadZhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZhad/Wprime_WZ_WhadZhad_narrow_M800/Wprime_WZ_WhadZhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1000/Wprime_WZ_WhadZinv_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1000/Wprime_WZ_WhadZinv_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1200/Wprime_WZ_WhadZinv_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1200/Wprime_WZ_WhadZinv_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1400/Wprime_WZ_WhadZinv_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1400/Wprime_WZ_WhadZinv_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1600/Wprime_WZ_WhadZinv_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1600/Wprime_WZ_WhadZinv_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1800/Wprime_WZ_WhadZinv_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M1800/Wprime_WZ_WhadZinv_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M2000/Wprime_WZ_WhadZinv_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M2000/Wprime_WZ_WhadZinv_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M2500/Wprime_WZ_WhadZinv_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M2500/Wprime_WZ_WhadZinv_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M3000/Wprime_WZ_WhadZinv_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M3000/Wprime_WZ_WhadZinv_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M3500/Wprime_WZ_WhadZinv_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M3500/Wprime_WZ_WhadZinv_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M4000/Wprime_WZ_WhadZinv_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M4000/Wprime_WZ_WhadZinv_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M4500/Wprime_WZ_WhadZinv_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M4500/Wprime_WZ_WhadZinv_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M600/Wprime_WZ_WhadZinv_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M600/Wprime_WZ_WhadZinv_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M800/Wprime_WZ_WhadZinv_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZinv/Wprime_WZ_WhadZinv_narrow_M800/Wprime_WZ_WhadZinv_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1000/Wprime_WZ_WhadZlep_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1000/Wprime_WZ_WhadZlep_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1200/Wprime_WZ_WhadZlep_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1200/Wprime_WZ_WhadZlep_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1400/Wprime_WZ_WhadZlep_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1400/Wprime_WZ_WhadZlep_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1600/Wprime_WZ_WhadZlep_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1600/Wprime_WZ_WhadZlep_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1800/Wprime_WZ_WhadZlep_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M1800/Wprime_WZ_WhadZlep_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M2000/Wprime_WZ_WhadZlep_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M2000/Wprime_WZ_WhadZlep_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M2500/Wprime_WZ_WhadZlep_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M2500/Wprime_WZ_WhadZlep_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M3000/Wprime_WZ_WhadZlep_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M3000/Wprime_WZ_WhadZlep_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M3500/Wprime_WZ_WhadZlep_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M3500/Wprime_WZ_WhadZlep_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M4000/Wprime_WZ_WhadZlep_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M4000/Wprime_WZ_WhadZlep_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M4500/Wprime_WZ_WhadZlep_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M4500/Wprime_WZ_WhadZlep_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M600/Wprime_WZ_WhadZlep_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M600/Wprime_WZ_WhadZlep_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M800/Wprime_WZ_WhadZlep_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WhadZlep/Wprime_WZ_WhadZlep_narrow_M800/Wprime_WZ_WhadZlep_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1000/Wprime_WZ_WlepZhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1000/Wprime_WZ_WlepZhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1200/Wprime_WZ_WlepZhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1200/Wprime_WZ_WlepZhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1400/Wprime_WZ_WlepZhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1400/Wprime_WZ_WlepZhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1600/Wprime_WZ_WlepZhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1600/Wprime_WZ_WlepZhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1800/Wprime_WZ_WlepZhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M1800/Wprime_WZ_WlepZhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M2000/Wprime_WZ_WlepZhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M2000/Wprime_WZ_WlepZhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M2500/Wprime_WZ_WlepZhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M2500/Wprime_WZ_WlepZhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M3000/Wprime_WZ_WlepZhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M3000/Wprime_WZ_WlepZhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M3500/Wprime_WZ_WlepZhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M3500/Wprime_WZ_WlepZhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M4000/Wprime_WZ_WlepZhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M4000/Wprime_WZ_WlepZhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M4500/Wprime_WZ_WlepZhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M4500/Wprime_WZ_WlepZhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M600/Wprime_WZ_WlepZhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M600/Wprime_WZ_WlepZhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M800/Wprime_WZ_WlepZhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZhad/Wprime_WZ_WlepZhad_narrow_M800/Wprime_WZ_WlepZhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1000/Wprime_WZ_WlepZlep_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1000/Wprime_WZ_WlepZlep_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1200/Wprime_WZ_WlepZlep_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1200/Wprime_WZ_WlepZlep_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1400/Wprime_WZ_WlepZlep_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1400/Wprime_WZ_WlepZlep_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1600/Wprime_WZ_WlepZlep_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1600/Wprime_WZ_WlepZlep_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1800/Wprime_WZ_WlepZlep_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M1800/Wprime_WZ_WlepZlep_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M2000/Wprime_WZ_WlepZlep_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M2000/Wprime_WZ_WlepZlep_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M2500/Wprime_WZ_WlepZlep_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M2500/Wprime_WZ_WlepZlep_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M3000/Wprime_WZ_WlepZlep_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M3000/Wprime_WZ_WlepZlep_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M3500/Wprime_WZ_WlepZlep_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M3500/Wprime_WZ_WlepZlep_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M4000/Wprime_WZ_WlepZlep_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M4000/Wprime_WZ_WlepZlep_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M4500/Wprime_WZ_WlepZlep_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M4500/Wprime_WZ_WlepZlep_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M600/Wprime_WZ_WlepZlep_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M600/Wprime_WZ_WlepZlep_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M800/Wprime_WZ_WlepZlep_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_WlepZlep/Wprime_WZ_WlepZlep_narrow_M800/Wprime_WZ_WlepZlep_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1000/Wprime_WZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1000/Wprime_WZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1200/Wprime_WZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1200/Wprime_WZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1400/Wprime_WZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1400/Wprime_WZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1600/Wprime_WZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1600/Wprime_WZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1800/Wprime_WZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M1800/Wprime_WZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M2000/Wprime_WZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M2000/Wprime_WZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M2500/Wprime_WZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M2500/Wprime_WZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M3000/Wprime_WZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M3000/Wprime_WZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M3500/Wprime_WZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M3500/Wprime_WZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M4000/Wprime_WZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M4000/Wprime_WZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M4500/Wprime_WZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M4500/Wprime_WZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M600/Wprime_WZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M600/Wprime_WZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M800/Wprime_WZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_WZ_inclu/Wprime_WZ_inclu_narrow_M800/Wprime_WZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1000/Wprime_Wh_Whadhbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1000/Wprime_Wh_Whadhbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1200/Wprime_Wh_Whadhbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1200/Wprime_Wh_Whadhbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1400/Wprime_Wh_Whadhbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1400/Wprime_Wh_Whadhbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1600/Wprime_Wh_Whadhbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1600/Wprime_Wh_Whadhbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1800/Wprime_Wh_Whadhbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M1800/Wprime_Wh_Whadhbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M2000/Wprime_Wh_Whadhbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M2000/Wprime_Wh_Whadhbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M2500/Wprime_Wh_Whadhbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M2500/Wprime_Wh_Whadhbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M3000/Wprime_Wh_Whadhbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M3000/Wprime_Wh_Whadhbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M3500/Wprime_Wh_Whadhbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M3500/Wprime_Wh_Whadhbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M4000/Wprime_Wh_Whadhbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M4000/Wprime_Wh_Whadhbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M4500/Wprime_Wh_Whadhbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M4500/Wprime_Wh_Whadhbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M600/Wprime_Wh_Whadhbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M600/Wprime_Wh_Whadhbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M800/Wprime_Wh_Whadhbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Whadhbb/Wprime_Wh_Whadhbb_narrow_M800/Wprime_Wh_Whadhbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1000/Wprime_Wh_Wlephbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1000/Wprime_Wh_Wlephbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1200/Wprime_Wh_Wlephbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1200/Wprime_Wh_Wlephbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1400/Wprime_Wh_Wlephbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1400/Wprime_Wh_Wlephbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1600/Wprime_Wh_Wlephbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1600/Wprime_Wh_Wlephbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1800/Wprime_Wh_Wlephbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M1800/Wprime_Wh_Wlephbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M2000/Wprime_Wh_Wlephbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M2000/Wprime_Wh_Wlephbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M2500/Wprime_Wh_Wlephbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M2500/Wprime_Wh_Wlephbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M3000/Wprime_Wh_Wlephbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M3000/Wprime_Wh_Wlephbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M3500/Wprime_Wh_Wlephbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M3500/Wprime_Wh_Wlephbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M4000/Wprime_Wh_Wlephbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M4000/Wprime_Wh_Wlephbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M4500/Wprime_Wh_Wlephbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M4500/Wprime_Wh_Wlephbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M600/Wprime_Wh_Wlephbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M600/Wprime_Wh_Wlephbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M800/Wprime_Wh_Wlephbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Wprime_Wh_Wlephbb/Wprime_Wh_Wlephbb_narrow_M800/Wprime_Wh_Wlephbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1000/Zprime_VBF_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1000/Zprime_VBF_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1200/Zprime_VBF_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1200/Zprime_VBF_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1400/Zprime_VBF_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1400/Zprime_VBF_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1600/Zprime_VBF_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1600/Zprime_VBF_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1800/Zprime_VBF_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M1800/Zprime_VBF_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2000/Zprime_VBF_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2000/Zprime_VBF_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2500/Zprime_VBF_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M2500/Zprime_VBF_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3000/Zprime_VBF_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3000/Zprime_VBF_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3500/Zprime_VBF_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M3500/Zprime_VBF_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4000/Zprime_VBF_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4000/Zprime_VBF_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4500/Zprime_VBF_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M4500/Zprime_VBF_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M600/Zprime_VBF_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M600/Zprime_VBF_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M800/Zprime_VBF_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M800/Zprime_VBF_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1000/Zprime_WW_WlepWhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1000/Zprime_WW_WlepWhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1200/Zprime_WW_WlepWhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1200/Zprime_WW_WlepWhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1400/Zprime_WW_WlepWhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1400/Zprime_WW_WlepWhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1600/Zprime_WW_WlepWhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1600/Zprime_WW_WlepWhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1800/Zprime_WW_WlepWhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M1800/Zprime_WW_WlepWhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M2000/Zprime_WW_WlepWhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M2000/Zprime_WW_WlepWhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M2500/Zprime_WW_WlepWhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M2500/Zprime_WW_WlepWhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M3000/Zprime_WW_WlepWhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M3000/Zprime_WW_WlepWhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M3500/Zprime_WW_WlepWhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M3500/Zprime_WW_WlepWhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M4000/Zprime_WW_WlepWhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M4000/Zprime_WW_WlepWhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M4500/Zprime_WW_WlepWhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M4500/Zprime_WW_WlepWhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M600/Zprime_WW_WlepWhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M600/Zprime_WW_WlepWhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M800/Zprime_WW_WlepWhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_WlepWhad/Zprime_WW_WlepWhad_narrow_M800/Zprime_WW_WlepWhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1000/Zprime_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1000/Zprime_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1200/Zprime_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1200/Zprime_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1400/Zprime_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1400/Zprime_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1600/Zprime_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1600/Zprime_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1800/Zprime_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M1800/Zprime_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M2000/Zprime_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M2000/Zprime_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M2500/Zprime_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M2500/Zprime_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M3000/Zprime_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M3000/Zprime_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M3500/Zprime_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M3500/Zprime_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M4000/Zprime_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M4000/Zprime_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M4500/Zprime_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M4500/Zprime_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M600/Zprime_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M600/Zprime_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M800/Zprime_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_WW_inclu/Zprime_WW_inclu_narrow_M800/Zprime_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1000/Zprime_Zh_Zhadhbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1000/Zprime_Zh_Zhadhbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1200/Zprime_Zh_Zhadhbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1200/Zprime_Zh_Zhadhbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1400/Zprime_Zh_Zhadhbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1400/Zprime_Zh_Zhadhbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1600/Zprime_Zh_Zhadhbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1600/Zprime_Zh_Zhadhbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1800/Zprime_Zh_Zhadhbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M1800/Zprime_Zh_Zhadhbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M2000/Zprime_Zh_Zhadhbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M2000/Zprime_Zh_Zhadhbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M2500/Zprime_Zh_Zhadhbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M2500/Zprime_Zh_Zhadhbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M3000/Zprime_Zh_Zhadhbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M3000/Zprime_Zh_Zhadhbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M3500/Zprime_Zh_Zhadhbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M3500/Zprime_Zh_Zhadhbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M4000/Zprime_Zh_Zhadhbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M4000/Zprime_Zh_Zhadhbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M4500/Zprime_Zh_Zhadhbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M4500/Zprime_Zh_Zhadhbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M600/Zprime_Zh_Zhadhbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M600/Zprime_Zh_Zhadhbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M800/Zprime_Zh_Zhadhbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb/Zprime_Zh_Zhadhbb_narrow_M800/Zprime_Zh_Zhadhbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1000/Zprime_Zh_Zlephbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1000/Zprime_Zh_Zlephbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1200/Zprime_Zh_Zlephbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1200/Zprime_Zh_Zlephbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1400/Zprime_Zh_Zlephbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1400/Zprime_Zh_Zlephbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1600/Zprime_Zh_Zlephbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1600/Zprime_Zh_Zlephbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1800/Zprime_Zh_Zlephbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M1800/Zprime_Zh_Zlephbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M2000/Zprime_Zh_Zlephbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M2000/Zprime_Zh_Zlephbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M2500/Zprime_Zh_Zlephbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M2500/Zprime_Zh_Zlephbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M3000/Zprime_Zh_Zlephbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M3000/Zprime_Zh_Zlephbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M3500/Zprime_Zh_Zlephbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M3500/Zprime_Zh_Zlephbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M4000/Zprime_Zh_Zlephbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M4000/Zprime_Zh_Zlephbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M4500/Zprime_Zh_Zlephbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M4500/Zprime_Zh_Zlephbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M600/Zprime_Zh_Zlephbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M600/Zprime_Zh_Zlephbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M800/Zprime_Zh_Zlephbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zlephbb/Zprime_Zh_Zlephbb_narrow_M800/Zprime_Zh_Zlephbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1000/BulkGraviton_VBF_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1000/BulkGraviton_VBF_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1200/BulkGraviton_VBF_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1200/BulkGraviton_VBF_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1400/BulkGraviton_VBF_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1400/BulkGraviton_VBF_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1600/BulkGraviton_VBF_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1600/BulkGraviton_VBF_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1800/BulkGraviton_VBF_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M1800/BulkGraviton_VBF_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M2000/BulkGraviton_VBF_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M2000/BulkGraviton_VBF_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M2500/BulkGraviton_VBF_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M2500/BulkGraviton_VBF_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M3000/BulkGraviton_VBF_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M3000/BulkGraviton_VBF_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M3500/BulkGraviton_VBF_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M3500/BulkGraviton_VBF_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M4000/BulkGraviton_VBF_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M4000/BulkGraviton_VBF_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M4500/BulkGraviton_VBF_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M4500/BulkGraviton_VBF_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M600/BulkGraviton_VBF_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M600/BulkGraviton_VBF_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M800/BulkGraviton_VBF_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow_M800/BulkGraviton_VBF_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1000/BulkGraviton_VBF_ZZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1000/BulkGraviton_VBF_ZZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1200/BulkGraviton_VBF_ZZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1200/BulkGraviton_VBF_ZZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1400/BulkGraviton_VBF_ZZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1400/BulkGraviton_VBF_ZZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1600/BulkGraviton_VBF_ZZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1600/BulkGraviton_VBF_ZZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1800/BulkGraviton_VBF_ZZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M1800/BulkGraviton_VBF_ZZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M2000/BulkGraviton_VBF_ZZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M2000/BulkGraviton_VBF_ZZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M2500/BulkGraviton_VBF_ZZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M2500/BulkGraviton_VBF_ZZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M3000/BulkGraviton_VBF_ZZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M3000/BulkGraviton_VBF_ZZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M3500/BulkGraviton_VBF_ZZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M3500/BulkGraviton_VBF_ZZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M4000/BulkGraviton_VBF_ZZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M4000/BulkGraviton_VBF_ZZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M4500/BulkGraviton_VBF_ZZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M4500/BulkGraviton_VBF_ZZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M600/BulkGraviton_VBF_ZZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M600/BulkGraviton_VBF_ZZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M800/BulkGraviton_VBF_ZZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow_M800/BulkGraviton_VBF_ZZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1000/BulkGraviton_WW_WlepWhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1000/BulkGraviton_WW_WlepWhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1200/BulkGraviton_WW_WlepWhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1200/BulkGraviton_WW_WlepWhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1400/BulkGraviton_WW_WlepWhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1400/BulkGraviton_WW_WlepWhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1600/BulkGraviton_WW_WlepWhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1600/BulkGraviton_WW_WlepWhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1800/BulkGraviton_WW_WlepWhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M1800/BulkGraviton_WW_WlepWhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M2000/BulkGraviton_WW_WlepWhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M2000/BulkGraviton_WW_WlepWhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M2500/BulkGraviton_WW_WlepWhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M2500/BulkGraviton_WW_WlepWhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M3000/BulkGraviton_WW_WlepWhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M3000/BulkGraviton_WW_WlepWhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M3500/BulkGraviton_WW_WlepWhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M3500/BulkGraviton_WW_WlepWhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M4000/BulkGraviton_WW_WlepWhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M4000/BulkGraviton_WW_WlepWhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M4500/BulkGraviton_WW_WlepWhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M4500/BulkGraviton_WW_WlepWhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M600/BulkGraviton_WW_WlepWhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M600/BulkGraviton_WW_WlepWhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M800/BulkGraviton_WW_WlepWhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_WlepWhad/BulkGraviton_WW_WlepWhad_narrow_M800/BulkGraviton_WW_WlepWhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1000/BulkGraviton_WW_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1000/BulkGraviton_WW_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1200/BulkGraviton_WW_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1200/BulkGraviton_WW_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1400/BulkGraviton_WW_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1400/BulkGraviton_WW_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1600/BulkGraviton_WW_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1600/BulkGraviton_WW_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1800/BulkGraviton_WW_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M1800/BulkGraviton_WW_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M2000/BulkGraviton_WW_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M2000/BulkGraviton_WW_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M2500/BulkGraviton_WW_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M2500/BulkGraviton_WW_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M3000/BulkGraviton_WW_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M3000/BulkGraviton_WW_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M3500/BulkGraviton_WW_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M3500/BulkGraviton_WW_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M4000/BulkGraviton_WW_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M4000/BulkGraviton_WW_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M4500/BulkGraviton_WW_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M4500/BulkGraviton_WW_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M600/BulkGraviton_WW_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M600/BulkGraviton_WW_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M800/BulkGraviton_WW_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_WW_inclu/BulkGraviton_WW_inclu_narrow_M800/BulkGraviton_WW_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1000/BulkGraviton_ZZ_ZhadZhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1000/BulkGraviton_ZZ_ZhadZhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1200/BulkGraviton_ZZ_ZhadZhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1200/BulkGraviton_ZZ_ZhadZhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1400/BulkGraviton_ZZ_ZhadZhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1400/BulkGraviton_ZZ_ZhadZhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1600/BulkGraviton_ZZ_ZhadZhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1600/BulkGraviton_ZZ_ZhadZhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1800/BulkGraviton_ZZ_ZhadZhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M1800/BulkGraviton_ZZ_ZhadZhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M2000/BulkGraviton_ZZ_ZhadZhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M2000/BulkGraviton_ZZ_ZhadZhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M2500/BulkGraviton_ZZ_ZhadZhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M2500/BulkGraviton_ZZ_ZhadZhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M3000/BulkGraviton_ZZ_ZhadZhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M3000/BulkGraviton_ZZ_ZhadZhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M3500/BulkGraviton_ZZ_ZhadZhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M3500/BulkGraviton_ZZ_ZhadZhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M4000/BulkGraviton_ZZ_ZhadZhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M4000/BulkGraviton_ZZ_ZhadZhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M4500/BulkGraviton_ZZ_ZhadZhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M4500/BulkGraviton_ZZ_ZhadZhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M600/BulkGraviton_ZZ_ZhadZhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M600/BulkGraviton_ZZ_ZhadZhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M800/BulkGraviton_ZZ_ZhadZhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZhad/BulkGraviton_ZZ_ZhadZhad_narrow_M800/BulkGraviton_ZZ_ZhadZhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1000/BulkGraviton_ZZ_ZhadZinv_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1000/BulkGraviton_ZZ_ZhadZinv_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1200/BulkGraviton_ZZ_ZhadZinv_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1200/BulkGraviton_ZZ_ZhadZinv_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1400/BulkGraviton_ZZ_ZhadZinv_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1400/BulkGraviton_ZZ_ZhadZinv_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1600/BulkGraviton_ZZ_ZhadZinv_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1600/BulkGraviton_ZZ_ZhadZinv_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1800/BulkGraviton_ZZ_ZhadZinv_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M1800/BulkGraviton_ZZ_ZhadZinv_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2000/BulkGraviton_ZZ_ZhadZinv_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2000/BulkGraviton_ZZ_ZhadZinv_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2500/BulkGraviton_ZZ_ZhadZinv_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M2500/BulkGraviton_ZZ_ZhadZinv_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3000/BulkGraviton_ZZ_ZhadZinv_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3000/BulkGraviton_ZZ_ZhadZinv_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3500/BulkGraviton_ZZ_ZhadZinv_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M3500/BulkGraviton_ZZ_ZhadZinv_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4000/BulkGraviton_ZZ_ZhadZinv_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4000/BulkGraviton_ZZ_ZhadZinv_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4500/BulkGraviton_ZZ_ZhadZinv_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M4500/BulkGraviton_ZZ_ZhadZinv_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M600/BulkGraviton_ZZ_ZhadZinv_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M600/BulkGraviton_ZZ_ZhadZinv_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M800/BulkGraviton_ZZ_ZhadZinv_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZhadZinv/BulkGraviton_ZZ_ZhadZinv_narrow_M800/BulkGraviton_ZZ_ZhadZinv_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1000/BulkGraviton_ZZ_ZlepZhad_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1000/BulkGraviton_ZZ_ZlepZhad_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1200/BulkGraviton_ZZ_ZlepZhad_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1200/BulkGraviton_ZZ_ZlepZhad_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1400/BulkGraviton_ZZ_ZlepZhad_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1400/BulkGraviton_ZZ_ZlepZhad_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1600/BulkGraviton_ZZ_ZlepZhad_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1600/BulkGraviton_ZZ_ZlepZhad_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1800/BulkGraviton_ZZ_ZlepZhad_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1800/BulkGraviton_ZZ_ZlepZhad_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M2000/BulkGraviton_ZZ_ZlepZhad_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M2000/BulkGraviton_ZZ_ZlepZhad_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M2500/BulkGraviton_ZZ_ZlepZhad_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M2500/BulkGraviton_ZZ_ZlepZhad_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M3000/BulkGraviton_ZZ_ZlepZhad_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M3000/BulkGraviton_ZZ_ZlepZhad_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M3500/BulkGraviton_ZZ_ZlepZhad_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M3500/BulkGraviton_ZZ_ZlepZhad_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M4000/BulkGraviton_ZZ_ZlepZhad_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M4000/BulkGraviton_ZZ_ZlepZhad_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M4500/BulkGraviton_ZZ_ZlepZhad_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M4500/BulkGraviton_ZZ_ZlepZhad_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M600/BulkGraviton_ZZ_ZlepZhad_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M600/BulkGraviton_ZZ_ZlepZhad_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M800/BulkGraviton_ZZ_ZlepZhad_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M800/BulkGraviton_ZZ_ZlepZhad_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1000/BulkGraviton_ZZ_inclu_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1000/BulkGraviton_ZZ_inclu_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1200/BulkGraviton_ZZ_inclu_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1200/BulkGraviton_ZZ_inclu_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1400/BulkGraviton_ZZ_inclu_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1400/BulkGraviton_ZZ_inclu_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1600/BulkGraviton_ZZ_inclu_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1600/BulkGraviton_ZZ_inclu_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1800/BulkGraviton_ZZ_inclu_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M1800/BulkGraviton_ZZ_inclu_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M2000/BulkGraviton_ZZ_inclu_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M2000/BulkGraviton_ZZ_inclu_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M2500/BulkGraviton_ZZ_inclu_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M2500/BulkGraviton_ZZ_inclu_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M3000/BulkGraviton_ZZ_inclu_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M3000/BulkGraviton_ZZ_inclu_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M3500/BulkGraviton_ZZ_inclu_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M3500/BulkGraviton_ZZ_inclu_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M4000/BulkGraviton_ZZ_inclu_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M4000/BulkGraviton_ZZ_inclu_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M4500/BulkGraviton_ZZ_inclu_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M4500/BulkGraviton_ZZ_inclu_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M600/BulkGraviton_ZZ_inclu_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M600/BulkGraviton_ZZ_inclu_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M800/BulkGraviton_ZZ_inclu_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_inclu/BulkGraviton_ZZ_inclu_narrow_M800/BulkGraviton_ZZ_inclu_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1200/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1200/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1400/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1400/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1600/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1600/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1800/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1800/BulkGraviton_hh_hVVhbb_fullLep_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M260/BulkGraviton_hh_hVVhbb_fullLep_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M260/BulkGraviton_hh_hVVhbb_fullLep_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M270/BulkGraviton_hh_hVVhbb_fullLep_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M270/BulkGraviton_hh_hVVhbb_fullLep_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M300/BulkGraviton_hh_hVVhbb_fullLep_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M300/BulkGraviton_hh_hVVhbb_fullLep_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M350/BulkGraviton_hh_hVVhbb_fullLep_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M350/BulkGraviton_hh_hVVhbb_fullLep_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M400/BulkGraviton_hh_hVVhbb_fullLep_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M400/BulkGraviton_hh_hVVhbb_fullLep_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4000/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M450/BulkGraviton_hh_hVVhbb_fullLep_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M450/BulkGraviton_hh_hVVhbb_fullLep_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M500/BulkGraviton_hh_hVVhbb_fullLep_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M550/BulkGraviton_hh_hVVhbb_fullLep_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M550/BulkGraviton_hh_hVVhbb_fullLep_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M600/BulkGraviton_hh_hVVhbb_fullLep_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M600/BulkGraviton_hh_hVVhbb_fullLep_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M650/BulkGraviton_hh_hVVhbb_fullLep_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M650/BulkGraviton_hh_hVVhbb_fullLep_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M700/BulkGraviton_hh_hVVhbb_fullLep_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M700/BulkGraviton_hh_hVVhbb_fullLep_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M800/BulkGraviton_hh_hVVhbb_fullLep_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M800/BulkGraviton_hh_hVVhbb_fullLep_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M900/BulkGraviton_hh_hVVhbb_fullLep_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_fullLep/BulkGraviton_hh_hVVhbb_fullLep_narrow_M900/BulkGraviton_hh_hVVhbb_fullLep_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1200/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1200/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1400/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1400/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1600/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1600/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1800/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1800/BulkGraviton_hh_hVVhbb_inclusive_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M260/BulkGraviton_hh_hVVhbb_inclusive_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M260/BulkGraviton_hh_hVVhbb_inclusive_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M270/BulkGraviton_hh_hVVhbb_inclusive_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M270/BulkGraviton_hh_hVVhbb_inclusive_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M300/BulkGraviton_hh_hVVhbb_inclusive_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M300/BulkGraviton_hh_hVVhbb_inclusive_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M350/BulkGraviton_hh_hVVhbb_inclusive_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M350/BulkGraviton_hh_hVVhbb_inclusive_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M400/BulkGraviton_hh_hVVhbb_inclusive_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M400/BulkGraviton_hh_hVVhbb_inclusive_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4000/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M450/BulkGraviton_hh_hVVhbb_inclusive_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M450/BulkGraviton_hh_hVVhbb_inclusive_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M500/BulkGraviton_hh_hVVhbb_inclusive_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M550/BulkGraviton_hh_hVVhbb_inclusive_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M550/BulkGraviton_hh_hVVhbb_inclusive_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M600/BulkGraviton_hh_hVVhbb_inclusive_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M600/BulkGraviton_hh_hVVhbb_inclusive_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M650/BulkGraviton_hh_hVVhbb_inclusive_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M650/BulkGraviton_hh_hVVhbb_inclusive_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M700/BulkGraviton_hh_hVVhbb_inclusive_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M700/BulkGraviton_hh_hVVhbb_inclusive_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M800/BulkGraviton_hh_hVVhbb_inclusive_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M800/BulkGraviton_hh_hVVhbb_inclusive_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M900/BulkGraviton_hh_hVVhbb_inclusive_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hVVhbb_inclusive/BulkGraviton_hh_hVVhbb_inclusive_narrow_M900/BulkGraviton_hh_hVVhbb_inclusive_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1000/BulkGraviton_hh_haahbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1000/BulkGraviton_hh_haahbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1200/BulkGraviton_hh_haahbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1200/BulkGraviton_hh_haahbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1400/BulkGraviton_hh_haahbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1400/BulkGraviton_hh_haahbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1600/BulkGraviton_hh_haahbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1600/BulkGraviton_hh_haahbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1800/BulkGraviton_hh_haahbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M1800/BulkGraviton_hh_haahbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M2000/BulkGraviton_hh_haahbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M2000/BulkGraviton_hh_haahbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M250/BulkGraviton_hh_haahbb_narrow_M250_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M250/BulkGraviton_hh_haahbb_narrow_M250_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M2500/BulkGraviton_hh_haahbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M2500/BulkGraviton_hh_haahbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M260/BulkGraviton_hh_haahbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M260/BulkGraviton_hh_haahbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M270/BulkGraviton_hh_haahbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M270/BulkGraviton_hh_haahbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M280/BulkGraviton_hh_haahbb_narrow_M280_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M280/BulkGraviton_hh_haahbb_narrow_M280_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M300/BulkGraviton_hh_haahbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M300/BulkGraviton_hh_haahbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M3000/BulkGraviton_hh_haahbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M3000/BulkGraviton_hh_haahbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M320/BulkGraviton_hh_haahbb_narrow_M320_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M320/BulkGraviton_hh_haahbb_narrow_M320_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M340/BulkGraviton_hh_haahbb_narrow_M340_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M340/BulkGraviton_hh_haahbb_narrow_M340_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M350/BulkGraviton_hh_haahbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M350/BulkGraviton_hh_haahbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M3500/BulkGraviton_hh_haahbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M3500/BulkGraviton_hh_haahbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M400/BulkGraviton_hh_haahbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M400/BulkGraviton_hh_haahbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M4000/BulkGraviton_hh_haahbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M4000/BulkGraviton_hh_haahbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M450/BulkGraviton_hh_haahbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M450/BulkGraviton_hh_haahbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M4500/BulkGraviton_hh_haahbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M4500/BulkGraviton_hh_haahbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M500/BulkGraviton_hh_haahbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M500/BulkGraviton_hh_haahbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M550/BulkGraviton_hh_haahbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M550/BulkGraviton_hh_haahbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M600/BulkGraviton_hh_haahbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M600/BulkGraviton_hh_haahbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M650/BulkGraviton_hh_haahbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M650/BulkGraviton_hh_haahbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M700/BulkGraviton_hh_haahbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M700/BulkGraviton_hh_haahbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M800/BulkGraviton_hh_haahbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M800/BulkGraviton_hh_haahbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M900/BulkGraviton_hh_haahbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_haahbb/BulkGraviton_hh_haahbb_narrow_M900/BulkGraviton_hh_haahbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1000/BulkGraviton_hh_hbbhbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1000/BulkGraviton_hh_hbbhbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1200/BulkGraviton_hh_hbbhbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1200/BulkGraviton_hh_hbbhbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1400/BulkGraviton_hh_hbbhbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1400/BulkGraviton_hh_hbbhbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1600/BulkGraviton_hh_hbbhbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1600/BulkGraviton_hh_hbbhbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1800/BulkGraviton_hh_hbbhbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M1800/BulkGraviton_hh_hbbhbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M2000/BulkGraviton_hh_hbbhbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M2000/BulkGraviton_hh_hbbhbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M2500/BulkGraviton_hh_hbbhbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M2500/BulkGraviton_hh_hbbhbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M260/BulkGraviton_hh_hbbhbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M260/BulkGraviton_hh_hbbhbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M270/BulkGraviton_hh_hbbhbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M270/BulkGraviton_hh_hbbhbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M300/BulkGraviton_hh_hbbhbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M300/BulkGraviton_hh_hbbhbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M3000/BulkGraviton_hh_hbbhbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M3000/BulkGraviton_hh_hbbhbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M350/BulkGraviton_hh_hbbhbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M350/BulkGraviton_hh_hbbhbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M3500/BulkGraviton_hh_hbbhbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M3500/BulkGraviton_hh_hbbhbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M400/BulkGraviton_hh_hbbhbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M400/BulkGraviton_hh_hbbhbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M4000/BulkGraviton_hh_hbbhbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M4000/BulkGraviton_hh_hbbhbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M450/BulkGraviton_hh_hbbhbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M450/BulkGraviton_hh_hbbhbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M4500/BulkGraviton_hh_hbbhbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M4500/BulkGraviton_hh_hbbhbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M500/BulkGraviton_hh_hbbhbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M500/BulkGraviton_hh_hbbhbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M550/BulkGraviton_hh_hbbhbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M550/BulkGraviton_hh_hbbhbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M600/BulkGraviton_hh_hbbhbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M600/BulkGraviton_hh_hbbhbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M650/BulkGraviton_hh_hbbhbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M650/BulkGraviton_hh_hbbhbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M700/BulkGraviton_hh_hbbhbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M700/BulkGraviton_hh_hbbhbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M800/BulkGraviton_hh_hbbhbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M800/BulkGraviton_hh_hbbhbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M900/BulkGraviton_hh_hbbhbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_hbbhbb/BulkGraviton_hh_hbbhbb_narrow_M900/BulkGraviton_hh_hbbhbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1000/BulkGraviton_hh_htatahbb_narrow_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1000/BulkGraviton_hh_htatahbb_narrow_M1000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1200/BulkGraviton_hh_htatahbb_narrow_M1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1200/BulkGraviton_hh_htatahbb_narrow_M1200_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1400/BulkGraviton_hh_htatahbb_narrow_M1400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1400/BulkGraviton_hh_htatahbb_narrow_M1400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1600/BulkGraviton_hh_htatahbb_narrow_M1600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1600/BulkGraviton_hh_htatahbb_narrow_M1600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1800/BulkGraviton_hh_htatahbb_narrow_M1800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M1800/BulkGraviton_hh_htatahbb_narrow_M1800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M2000/BulkGraviton_hh_htatahbb_narrow_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M2000/BulkGraviton_hh_htatahbb_narrow_M2000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M250/BulkGraviton_hh_htatahbb_narrow_M250_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M250/BulkGraviton_hh_htatahbb_narrow_M250_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M2500/BulkGraviton_hh_htatahbb_narrow_M2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M2500/BulkGraviton_hh_htatahbb_narrow_M2500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M260/BulkGraviton_hh_htatahbb_narrow_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M260/BulkGraviton_hh_htatahbb_narrow_M260_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M270/BulkGraviton_hh_htatahbb_narrow_M270_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M270/BulkGraviton_hh_htatahbb_narrow_M270_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M280/BulkGraviton_hh_htatahbb_narrow_M280_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M280/BulkGraviton_hh_htatahbb_narrow_M280_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M300/BulkGraviton_hh_htatahbb_narrow_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M300/BulkGraviton_hh_htatahbb_narrow_M300_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M3000/BulkGraviton_hh_htatahbb_narrow_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M3000/BulkGraviton_hh_htatahbb_narrow_M3000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M320/BulkGraviton_hh_htatahbb_narrow_M320_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M320/BulkGraviton_hh_htatahbb_narrow_M320_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M340/BulkGraviton_hh_htatahbb_narrow_M340_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M340/BulkGraviton_hh_htatahbb_narrow_M340_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M350/BulkGraviton_hh_htatahbb_narrow_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M350/BulkGraviton_hh_htatahbb_narrow_M350_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M3500/BulkGraviton_hh_htatahbb_narrow_M3500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M3500/BulkGraviton_hh_htatahbb_narrow_M3500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M400/BulkGraviton_hh_htatahbb_narrow_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M400/BulkGraviton_hh_htatahbb_narrow_M400_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M4000/BulkGraviton_hh_htatahbb_narrow_M4000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M4000/BulkGraviton_hh_htatahbb_narrow_M4000_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M450/BulkGraviton_hh_htatahbb_narrow_M450_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M450/BulkGraviton_hh_htatahbb_narrow_M450_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M4500/BulkGraviton_hh_htatahbb_narrow_M4500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M4500/BulkGraviton_hh_htatahbb_narrow_M4500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M500/BulkGraviton_hh_htatahbb_narrow_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M500/BulkGraviton_hh_htatahbb_narrow_M500_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M550/BulkGraviton_hh_htatahbb_narrow_M550_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M550/BulkGraviton_hh_htatahbb_narrow_M550_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M600/BulkGraviton_hh_htatahbb_narrow_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M600/BulkGraviton_hh_htatahbb_narrow_M600_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M650/BulkGraviton_hh_htatahbb_narrow_M650_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M650/BulkGraviton_hh_htatahbb_narrow_M650_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M700/BulkGraviton_hh_htatahbb_narrow_M700_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M700/BulkGraviton_hh_htatahbb_narrow_M700_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M800/BulkGraviton_hh_htatahbb_narrow_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M800/BulkGraviton_hh_htatahbb_narrow_M800_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M900/BulkGraviton_hh_htatahbb_narrow_M900_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_hh_htatahbb/BulkGraviton_hh_htatahbb_narrow_M900/BulkGraviton_hh_htatahbb_narrow_M900_run_card.dat
@@ -89,7 +89,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-   T  = cut_decays    ! Cut decay products 
+   F  = cut_decays    ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for


### PR DESCRIPTION
Although this update affects 646 files (all run cards), the update is only
 changing the settings of cut_decays from True to False.

@bendavid, @covarell,  Josh, I would like to commit this change first before I add new decay modes. 

Note, I have discussed with analyzers. For most of the analyses, the lepton/jet pt spectrum are not 
affected. pt<10 GeV events only occupies less than 1% of the full spectrum.

But we need to update the gridpacks for the low mass dihiggs and all modes that involve taus because these analysis use pt>10 GeV cut.

Here, I still update the cards for all channels. If there's a chance to update gridpacks for other decay modes, we will have the right run card in place.