### PR TITLE
[Powheg] update of create_powheg_tarball.sh, fix of work directory name

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -47,21 +47,25 @@ seed=$rnum
 file="events"
 jhugenversion="v5.2.5"
 
+jobfolder=${tarball}_${name}
+echo "%MSG-POWHEG creating sub work directory ${jobfolder}"
+
 # Release to be used to define the environment and the compiler needed
 export RELEASE=${CMSSW_VERSION}
 export WORKDIR=`pwd`
 
+
 # initialize the CMS environment 
-if [[ -e ${name} ]]; then
-  echo -e "The directory ${name} exists! Move the directory to old_${name}\n"
-  mv ${name} old_${name}
+if [[ -e ${jobfolder} ]]; then
+  echo -e "The directory ${jobfolder} exists! Move the directory to old_${jobfolder}\n"
+  mv ${jobfolder} old_${jobfolder}
   mv output.lhe old_output.lhe
   rm -rf ${myDir}
   echo -e "Move the tar ball to old_${tarball}.tar.gz\n"
   mv ${tarball}_tarball.tar.gz old_${tarball}_tarball.tar.gz
 fi
 
-scram project -n ${name} CMSSW ${RELEASE}; cd ${name} ; mkdir -p work ; 
+scram project -n ${jobfolder} CMSSW ${RELEASE}; cd ${jobfolder} ; mkdir -p work ; 
 eval `scram runtime -sh`
 cd work
 export PATH=`pwd`:${PATH}


### PR DESCRIPTION
Previous version of create_powheg_tarball.sh has a silly feature that the work directory always has the same name (powhegbox_xxxx_xxx).
This is OK if users are running parallel jobs in different directory. But if users are running jobs 
in the same directory, the feature creates confusing output tar balls.

Fix this by giving the work directory a name that corresponds to the name of the output tar ball.

