### PR TITLE
[Powheg] additional update of the way we name work directory

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -47,7 +47,7 @@ seed=$rnum
 file="events"
 jhugenversion="v5.2.5"
 
-temp1=${cardinput%%.*}
+temp1=${cardinput%%.input*}
 temp2=${temp1##*/}
 jobfolder=${name}_${temp2}_${tarball}
 

--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -47,7 +47,10 @@ seed=$rnum
 file="events"
 jhugenversion="v5.2.5"
 
-jobfolder=${tarball}_${name}
+temp1=${cardinput%%.*}
+temp2=${temp1##*/}
+jobfolder=${name}_${temp2}_${tarball}
+
 echo "%MSG-POWHEG creating sub work directory ${jobfolder}"
 
 # Release to be used to define the environment and the compiler needed


### PR DESCRIPTION
Small change of the way we name work directory.
Previous version take the name of the gridpack and the name of the powheg source tar ball to name the work directory.
To add one extra protection (to avoid users use the same tar ball name by accident), I also take into account the name of the powheg input card. Now the work directory name is 
${source_tarball_name}_${cardinput}_${tarball}.

@covarell @bendavid can you merge the request? Thanks!!

