### PR TITLE
MG5_aMC@NLO: ttH gridpack for Higgs mass 70 GeV

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/tth01j_5f_ckm_NLO_FXFX_MH70/tth01j_5f_ckm_NLO_FXFX_MH70_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/tth01j_5f_ckm_NLO_FXFX_MH70/tth01j_5f_ckm_NLO_FXFX_MH70_customizecards.dat
@@ -2,3 +2,4 @@
 set param_card mass 6 172.5
 set param_card yukawa 6 172.5
 set param_card mass 25 70.0
+set param_card decay 25 1.81e-03


### PR DESCRIPTION
I forget to change the Higgs width to the interpolated 70 GeV value