### PR TITLE
remove off-diagonal ckm model

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TTTT_5f_NLO/TTTT_5f_NLO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TTTT_5f_NLO/TTTT_5f_NLO_proc_card.dat
@@ -1,6 +1,6 @@
-import model loop_sm-ckm_no_b_mass
+#import model loop_sm-ckm_no_b_mass
 #switch to diagonal ckm matrix if needed for speed
-#import model loop_sm-no_b_mass
+import model loop_sm-no_b_mass
 
 define p = p b b~
 define j = j b b~


### PR DESCRIPTION
Switched back to diagonal ckm to solve the madspin memory issue we had before. And because of the tiny cross section for this process, we don't think the off-diagonal decays really matter. 