### PR TITLE
Fix parameterSets

### DIFF
--- a/python/ThirteenTeV/ZprimeToMuMu_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/ZprimeToMuMu_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -23,8 +23,8 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                         '32:onMode = off', # switch off all of the Z' decay
                         '32:onIfAny = 13', # switch on the Z'->mu-mu+
                 ),
-                parameterSets = cms.vstring('pythia8CommonSettingsBlock',
-                                            'pythia8CUEP8M1SettingsBlock',
+                parameterSets = cms.vstring('pythia8CommonSettings',
+                                            'pythia8CUEP8M1Settings',
                                             'processParameters')
               )
 )


### PR DESCRIPTION
Fixed typo in 2nd of the two Zprime signal tunes.  (Missed this in the previous pull since the EE config was not incorrect, very sorry!)