### PR TITLE
update charged higgs heavy mass cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M1000/ChargedHiggs_heavy_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M1000/ChargedHiggs_heavy_M1000_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M180/ChargedHiggs_heavy_M180_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M180/ChargedHiggs_heavy_M180_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M200/ChargedHiggs_heavy_M200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M200/ChargedHiggs_heavy_M200_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M2000/ChargedHiggs_heavy_M2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M2000/ChargedHiggs_heavy_M2000_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M220/ChargedHiggs_heavy_M220_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M220/ChargedHiggs_heavy_M220_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M250/ChargedHiggs_heavy_M250_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M250/ChargedHiggs_heavy_M250_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M300/ChargedHiggs_heavy_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M300/ChargedHiggs_heavy_M300_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M3000/ChargedHiggs_heavy_M3000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M3000/ChargedHiggs_heavy_M3000_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M350/ChargedHiggs_heavy_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M350/ChargedHiggs_heavy_M350_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M400/ChargedHiggs_heavy_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M400/ChargedHiggs_heavy_M400_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M500/ChargedHiggs_heavy_M500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M500/ChargedHiggs_heavy_M500_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M600/ChargedHiggs_heavy_M600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M600/ChargedHiggs_heavy_M600_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M800/ChargedHiggs_heavy_M800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ChargedHiggs_heavy_M800/ChargedHiggs_heavy_M800_run_card.dat
@@ -25,7 +25,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+   1500 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
     20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).


### PR DESCRIPTION
run cards are modified from 250 events -> 1500 events to protect the errors arising from unsufficient stats. (light charged Higgs cards are already 1500 events from the beginning -> no change here)