### PR TITLE
GS fragments for TH* requests

### DIFF
--- a/python/ThirteenTeV/Higgs/THQ_HToGG_13TeV-madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/THQ_HToGG_13TeV-madgraph_pythia8_cff.py
@@ -1,22 +1,22 @@
 generator = cms.EDFilter("Pythia8HadronizerFilter",
-	maxEventsToPrint = cms.untracked.int32(1),
-	pythiaPylistVerbosity = cms.untracked.int32(1),
-	filterEfficiency = cms.untracked.double(1.0),
-	pythiaHepMCVerbosity = cms.untracked.bool(False),
-	comEnergy = cms.double(13000.),
-	PythiaParameters = cms.PSet(
-		pythia8CommonSettingsBlock,
-		pythia8CUEP8M1SettingsBlock,
-		parameterSets = cms.vstring(
-			'pythia8CommonSettings',
-			'pythia8CUEP8M1Settings'
-			'25:m0 = 125.0',
-			'23:mMin = 0.05',       # Solve problem with mZ cut
-			'24:mMin = 0.05',       # Solve problem with mW cut
-			'25:onMode = off', 
-			'25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
-		)
-	)
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CUEP8M1Settings'
+            '25:m0 = 125.0',
+            '23:mMin = 0.05',       # Solve problem with mZ cut
+            '24:mMin = 0.05',       # Solve problem with mW cut
+            '25:onMode = off', 
+            '25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
+        )
+    )
 )
 
 

--- a/python/ThirteenTeV/Higgs/THQ_HToGG_13TeV-madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/THQ_HToGG_13TeV-madgraph_pythia8_cff.py
@@ -1,0 +1,24 @@
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13000.),
+	PythiaParameters = cms.PSet(
+		pythia8CommonSettingsBlock,
+		pythia8CUEP8M1SettingsBlock,
+		parameterSets = cms.vstring(
+			'pythia8CommonSettings',
+			'pythia8CUEP8M1Settings'
+			'25:m0 = 125.0',
+			'23:mMin = 0.05',       # Solve problem with mZ cut
+			'24:mMin = 0.05',       # Solve problem with mW cut
+			'25:onMode = off', 
+			'25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
+		)
+	)
+)
+
+
+
+

--- a/python/ThirteenTeV/Higgs/THQ_Hincl_13TeV-madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/THQ_Hincl_13TeV-madgraph_pythia8_cff.py
@@ -1,0 +1,23 @@
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CUEP8M1Settings'
+            '25:m0 = 125.0',
+            '23:mMin = 0.05',       # Solve problem with mZ cut
+            '24:mMin = 0.05',       # Solve problem with mW cut
+            '25:onMode = on'        # inclusive decay
+        )
+    )
+)
+
+
+
+


### PR DESCRIPTION
Gen fragment for the requests listed below, please check carefully as it's the first mg5nlo fragment I inject.
 * The samples are LO madgraph, no matching needed, 4f scheme. There's a pair of H > GG sample and H > all one
 * top is already decayed by madgraph
 * the fragments will serve THW and THQ

[1](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-RunIIWinter15GS-00493&page=0&shown=268437561)
[2](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-RunIIWinter15GS-00492&page=0&shown=268437561)

[3](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-RunIIWinter15GS-00494&page=0&shown=268437561)
[4](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-RunIIWinter15GS-00495&page=0&shown=268437561)