### PR TITLE
[Powheg] update create_powheg_tarball.sh and patches to fix the compiling error of 4 proceses

### DIFF
--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -3,12 +3,12 @@
 fail_exit() { echo "$@" 1>&2; exit 1; }
 
 #set -o verbose
-EXPECTED_ARGS=8
+EXPECTED_ARGS=5
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
-    echo "Usage: `basename $0` source_repository source_tarball_name process card tarballName othercard Nevents RandomSeed"
-    echo "Example: `basename $0` slc6_amd64_gcc481/powheg/V1.0/src powhegboxv1.0_Oct2013 Z slc6_amd64_gcc481/powheg/V1.0/8TeV_Summer12/DYToEE_M-20_8TeV-powheg/v1/DYToEE_M-20_8TeV-powheg.input none Z_local 1000 1212" 
+    echo "Usage: `basename $0` process card othercard Nevents RandomSeed"
+    echo "Example: `basename $0` Z slc6_amd64_gcc481/powheg/V1.0/8TeV_Summer12/DYToEE_M-20_8TeV-powheg/v1/DYToEE_M-20_8TeV-powheg.input none 1000 1212" 
     exit 1
 fi
 
@@ -16,34 +16,31 @@ echo "   ______________________________________________________    "
 echo "         Running Powheg  create_powheg_tarball.sh            "
 echo "   ______________________________________________________    "
 
-repo=${1}
+repo=slc6_amd64_gcc481/powheg/V2.0/src
 echo "%MSG-POWHEG source repository = $repo"
 
-name=${2} 
+name=powhegboxV2_July2015
 echo "%MSG-POWHEG source tarball name = $name"
 
-if [ "$name" != "powhegboxV2_July2015" ]; then
-    fail_exit "You must use powhegboxV2_July2015 with the current version of $0"
-fi    
-process=${3}
+process=${1}
 echo "%MSG-POWHEG process = $process"
 
-cardinput=${4}
+cardinput=${2}
 echo "%MSG-POWHEG location of the card = $cardinput"
 
-tarball=${5}
+tarball=${process}
 echo "%MSG-POWHEG tar ball file name = ${tarball}_tarball.tar.gz"
 
-usejhugen=${6}
+usejhugen=${3}
 echo "%MSG-POWHEG JHUGen datacard for decays = ${usejhugen}"
 
-nevt=${7}
+nevt=${4}
 echo "%MSG-POWHEG number of events requested = $nevt"
 
-rnum=${8}
+rnum=${5}
 echo "%MSG-POWHEG random seed used for the run = $rnum"
 
-skipgen=${9}
+skipgen=${6}
 echo "%MSG-POWHEG if not null skip generation = $skipgen"
 
 seed=$rnum
@@ -63,7 +60,15 @@ export WORKDIR=`pwd`
 
 # initialize the CMS environment 
 if [[ -e ${jobfolder} ]]; then
-  fail_exit "The directory ${jobfolder} exists! Please clean up your work directory before running!! \n"
+  fail_exit "The directory ${jobfolder} exists! Please clean up your work directory before running!!"
+fi
+
+if [[ -e ${tarball}_tarball.tar.gz ]]; then
+  fail_exit "The tarball ${tarball}_tarball.tar.gz exists! Please rename it or move it somewhere else before running!!"
+fi
+
+if [[ -e events_final.lhe ]]; then
+  fail_exit "The LHE file events_final.lhe exists! Please remove this file before running!!"
 fi
 
 scram project -n ${jobfolder} CMSSW ${RELEASE}; cd ${jobfolder} ; mkdir -p work ; 

--- a/bin/Powheg/create_powheg_tarball.sh
+++ b/bin/Powheg/create_powheg_tarball.sh
@@ -22,6 +22,9 @@ echo "%MSG-POWHEG source repository = $repo"
 name=${2} 
 echo "%MSG-POWHEG source tarball name = $name"
 
+if [ "$name" != "powhegboxV2_July2015" ]; then
+    fail_exit "You must use powhegboxV2_July2015 with the current version of $0"
+fi    
 process=${3}
 echo "%MSG-POWHEG process = $process"
 
@@ -60,12 +63,7 @@ export WORKDIR=`pwd`
 
 # initialize the CMS environment 
 if [[ -e ${jobfolder} ]]; then
-  echo -e "The directory ${jobfolder} exists! Move the directory to old_${jobfolder}\n"
-  mv ${jobfolder} old_${jobfolder}
-  mv output.lhe old_output.lhe
-  rm -rf ${myDir}
-  echo -e "Move the tar ball to old_${tarball}.tar.gz\n"
-  mv ${tarball}_tarball.tar.gz old_${tarball}_tarball.tar.gz
+  fail_exit "The directory ${jobfolder} exists! Please clean up your work directory before running!! \n"
 fi
 
 scram project -n ${jobfolder} CMSSW ${RELEASE}; cd ${jobfolder} ; mkdir -p work ; 
@@ -137,6 +135,7 @@ if [ `echo ${name} | cut -d "_" -f 1` = "powhegboxV1" ]; then
 fi 
 if [ "$process" = "trijet" ]; then 
    BOOK_HISTO+=" observables.o"
+   rm -rf ../progress/bbinit.f
 fi  
 if [ "$process" = "VBF_HJJJ" ]; then 
   mv pwhg_analysis-dummy.f pwhg_analysis-dummy.f.orig
@@ -145,6 +144,12 @@ fi
 if [ "$process" = "VBF_H" ]; then 
   sed -i '/pwhginihist/d' pwhg_analysis-dummy.f 
 fi  
+if [ "$process" = "Wgamma" ] || [ "$process" = "W_ew-BMNNP" ]; then
+    patch -l -p0 -i ${WORKDIR}/patches/pwhg_analysis_driver.patch 
+fi
+if [ "$process" = "ttb_NLO_dec" ]; then
+    patch -l -p0 -i ${WORKDIR}/patches/pwhg_analysis_driver_offshellmap.patch
+fi
 
 # Remove ANY kind of analysis with parton shower
 if [ `grep particle_identif pwhg_analysis-dummy.f` = ""]; then

--- a/bin/Powheg/patches/pwhg_analysis_driver.patch
+++ b/bin/Powheg/patches/pwhg_analysis_driver.patch
@@ -1,0 +1,38 @@
+--- pwhg_analysis_driver.f	2015-07-31 18:54:42.187975715 +0200
++++ pwhg_analysis_driver_new.f	2015-07-31 19:06:03.558330295 +0200
+@@ -83,3 +83,35 @@
+       enddo
+       end
+ 
++c     This is to store in common block extra information on the
++c     partonic NLO event
++C     type is either: 'born', 'virt', 'real', 'realct'
++C     narr number of entries  in the array arr 
++C     weight is the integration weight 
++      subroutine analysis_extrainfo(type,narr,arr,weight)
++      implicit none
++      include 'nlegborn.h'
++      include 'pwhg_flg.h'
++      include 'pwhg_anexinf.h'
++      character *(*) type
++      integer narr
++      real * 8 arr(narr),weight
++      integer marr,dummy
++      
++      if(.not.flg_analysisextrainfo) return
++      if(narr.gt.maxalr) then
++         write(*,*) ' analysis_extrainfo: arr dimension too big '
++         write(*,*) ' exiting ...'
++         call exit(-1) 
++      endif
++      anexinf_sigarr(1:narr) = arr * weight
++      anexinf_narr = narr
++      anexinf_type = type
++      if(anexinf_type.ne.type) then
++         write(*,*) 'anexinf_type',anexinf_type
++         write(*,*) 'type', type
++         write(*,*) ' analysis_extrainfo: type string too long '
++         write(*,*) ' exiting ...'
++         call exit(-1) 
++      endif
++      end

--- a/bin/Powheg/patches/pwhg_analysis_driver_offshellmap.patch
+++ b/bin/Powheg/patches/pwhg_analysis_driver_offshellmap.patch
@@ -1,0 +1,38 @@
+--- pwhg_analysis_driver_offshellmap.f	2015-07-30 14:35:42.000000001 +0200
++++ pwhg_analysis_driver.f.new	2015-08-01 14:49:57.000000001 +0200
+@@ -103,3 +103,35 @@
+       enddo
+       end
+ 
++c     This is to store in common block extra information on the
++c     partonic NLO event
++C     type is either: 'born', 'virt', 'real', 'realct'
++C     narr number of entries  in the array arr 
++C     weight is the integration weight 
++      subroutine analysis_extrainfo(type,narr,arr,weight)
++      implicit none
++      include 'nlegborn.h'
++      include 'pwhg_flg.h'
++      include 'pwhg_anexinf.h'
++      character *(*) type
++      integer narr
++      real * 8 arr(narr),weight
++      integer marr,dummy
++      
++      if(.not.flg_analysisextrainfo) return
++      if(narr.gt.maxalr) then
++         write(*,*) ' analysis_extrainfo: arr dimension too big '
++         write(*,*) ' exiting ...'
++         call exit(-1) 
++      endif
++      anexinf_sigarr(1:narr) = arr * weight
++      anexinf_narr = narr
++      anexinf_type = type
++      if(anexinf_type.ne.type) then
++         write(*,*) 'anexinf_type',anexinf_type
++         write(*,*) 'type', type
++         write(*,*) ' analysis_extrainfo: type string too long '
++         write(*,*) ' exiting ...'
++         call exit(-1) 
++      endif
++      end


### PR DESCRIPTION

Updates include:

1) create_powheg_tarball.sh :
a) call the patches for Wgamma/W_ew/ttb_nlo_dec and trijet so that the POWHEG-BOX-V2 source tar ball (dated July 30, 2015) could compile without problem.

b) If an old directory with the same name exits, instead of moving the directory to a different name, stop the program completely

c) if the user does not use July2015 tar ball for this script, stop the program completely.

2) patches for the processes listed above.
