### PR TITLE
bugfix (used correctly in the sample generation)

### DIFF
--- a/python/ThirteenTeV/Higgs/THQ_Hincl_13TeV-madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/THQ_Hincl_13TeV-madgraph_pythia8_cff.py
@@ -7,13 +7,17 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,
-        parameterSets = cms.vstring(
-            'pythia8CommonSettings',
-            'pythia8CUEP8M1Settings'
+        processParameters = cms.vstring(
+            '6:m0 = 172.5',
             '25:m0 = 125.0',
             '23:mMin = 0.05',       # Solve problem with mZ cut
             '24:mMin = 0.05',       # Solve problem with mW cut
             '25:onMode = on'        # inclusive decay
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CUEP8M1Settings',
+            'processParameters',
         )
     )
 )


### PR DESCRIPTION
the fragment field has been used: https://cms-pdmv.cern.ch/mcm/edit?db_name=requests&prepid=HIG-RunIIWinter15GS-00492&page=0