### PR TITLE
Cards for EXO QBHToEMu for RunII

### DIFF
--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-1500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-2500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-3500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-4500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-5500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6000_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n4_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,60 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 4); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n5_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,61 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 5); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/ADD/QBHToEMu_M-6500_n6_ADD_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,62 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 6); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(3); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(false); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");
+
+
+

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-1000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-1000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-1500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-1500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(1500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(1500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-2000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-2000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-2500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-2500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(2500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(2500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-3000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-3000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-3500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-3500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(3500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(3500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-4000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-4000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-4500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-4500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(4500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(4500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-5000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-5000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-5500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-5500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(5500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(5500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-6000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-6000_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6000); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6000); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");

--- a/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-6500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
+++ b/bin/QBH/cards/production/13TeV/exo_QBHToEMu/RS/QBHToEMu_M-6500_n1_RS_TuneCUETP8M1_13TeV-pythia8.txt
@@ -1,0 +1,59 @@
+    /// QCD scale definition                              
+    qbh->setQscale(false); /// Definition of QCD scale for PDFs false(= QBH mass), true (= inverse gravitational radius) (Default = true)
+
+    /// Yoshino-Rychkov stuff
+    qbh->setYRform(false); /// Use YR-factors (Default = false)
+    qbh->setTrap(false); /// User YR trapped surface calculation (Default = false)
+
+    /// SM symmetries
+    qbh->setSM(false); /// Conserve global symmetries (Default = true)
+
+    /// Majorana neutrinos
+    qbh->setMajorana(false); /// neutrinos are majorana (true) or dirac (false) (Default = false) 
+
+    /// Neutrino handedness
+    qbh->setChiral(true); /// neutrinos are left-handed only (false) or left and right-handed (true) (Default = true)
+
+    /// Higgs
+    qbh->setHiggs(false); /// Include Higgs as allowed particle (Default = true)
+
+    /// Graviton
+    qbh->setGraviton(false); /// Include Graviton as allowed particle (Default = true)
+
+    /// Totel number of dimensions
+    qbh->setTotdim(4 + 1); /// Total number of spacetime dimensions 5-11 allowed (Default = 10)
+
+    /// Planck scale definition
+    /// RS or ADD black hole
+    qbh->setPlanckdef(1); /// Definition of the planck scale 1 (= Randall-Sundrum), 2 (= Dimopoulos-Landsberg), 3 (= PDG), else (= Giddings-Thomas definition) (Default = 3)
+    qbh->setRS1(true); /// false (= ADD black hole), true (= Randall-Sundrum type-1 black hole) (Default = false)
+
+    /// Planck mass
+    qbh->setMplanck(6500); /// fundamental planck scale (Default = 1000)
+
+    /// Electric charge
+    qbh->setQstate(0); /// Three time electric charge [-4,-3,-2,-1,0,1,2,3,4] allowed, 9 for all partons (Default = 9)
+
+    /// Initial state
+    qbh->setIstate(2); /// Initial state 0 (q-q), 1 (q-g), 2 (g-g), 3 (all) (Default = 3)
+
+    /// Min QBH mass
+    qbh->setMinmass(6500); /// Minimum quantum black hole mass (Default = 1000)
+
+    /// Max QBH mass
+    qbh->setMaxmass(14000); /// Maximum qunatum black hole mass (Default = 14000)
+
+    /// Center of mass energy
+    qbh->setEcm(13000); /// Proton-proton center of mass energy (Default = 14000)
+
+    /// Initialize PDFs.
+    qbh->setLHAglue(10042);  ///CTEQ6L1
+
+    (void)pythia->readString("SoftQCD:nonDiffractive = off");
+    (void)pythia->readString("SoftQCD:all       = off");
+    (void)pythia->readString("PartonLevel:ISR   = off");
+    (void)pythia->readString("PartonLevel:FSR   = off");
+    (void)pythia->readString("PartonLevel:MPI    = off");
+    (void)pythia->readString("HadronLevel:all   = off");
+    (void)pythia->readString("Check:history     = on");
+    (void)pythia->readString("Check:nErrList    = 10");


### PR DESCRIPTION
from @serdweg

This is for the QBH generator, where the parameters are set directly in the C++ code. Soeren has extracted the parts of the code used to set the parameters and provided them in text files as the "cards".

The reason these use CTEQ6L1 rather than NNPDF:

"the main reason is to be consistend between the QBH generator, where we can easily change the PDF set and CalcHEP where it is not so easy. We use CalcHEP to cross check our QBH results, and therefore it seems useful to use consistend PDF sets, so Cteq6l1. In the future this is definitly a point of improvement, but the effect on our sample should be small as the only contributing channel is q-q_bar annihilation with one valence quark."

Soeren also submitted the recent CalcHEP requests also using CTEQL1, although they were for a different process.