### PR TITLE
Fix naming of file and remove spurious file

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DarkMatter/DMAxial_W/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0/DMAXial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DarkMatter/DMAxial_W/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0/DMAXial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0_proc_card.dat
@@ -1,9 +1,0 @@
-import axial_monoW_model_1000_1
-generate    p p  > Zp w-,     Zp >  ~n1 Xn1
-add process p p  > Zp w- j,   Zp >  ~n1 Xn1
-add process p p  > Zp w- j j, Zp >  ~n1 Xn1
-add process p p  > Zp w+  ,   Zp >  ~n1 Xn1
-add process p p  > Zp w+ j,   Zp >  ~n1 Xn1
-add process p p  > Zp w+ j j, Zp >  ~n1 Xn1
-output AxialMonoW_1000_1 -nojpeg
-

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DarkMatter/DMAxial_W/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DarkMatter/DMAxial_W/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0/DMAxial_monow012j_mphi_1000_mchi_1_gSM_1p0_gDM_1p0_proc_card.dat
@@ -1,0 +1,9 @@
+import axial_monoW_model_1000_1
+generate    p p  > Zp w-,     Zp >  ~n1 Xn1
+add process p p  > Zp w- j,   Zp >  ~n1 Xn1
+add process p p  > Zp w- j j, Zp >  ~n1 Xn1
+add process p p  > Zp w+  ,   Zp >  ~n1 Xn1
+add process p p  > Zp w+ j,   Zp >  ~n1 Xn1
+add process p p  > Zp w+ j j, Zp >  ~n1 Xn1
+output AxialMonoW_1000_1 -nojpeg
+


### PR DESCRIPTION
The presence of two files with only a difference in capitalization of one letter causes problems on case-insensitive filesystems. Git cannot checkout both of them, and so you end up with a modification. This in turn prevents you from doing a git rebase.

Apart from this issue, the proc_card with the correct name to be picked up by the gridpack generation was empty. So getting rid of the wrongly named card and putting the info in the correct card fixes both problems at the same time.