### PR TITLE
[monoHiggs group] Pythia8 configuration file for decaying Higgs into 5 subchannels

### DIFF
--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0', 
+            '25:onMode = off',
+            '25:onIfMatch = 24 -24',           # turn ON H->WW
+            '24:mMin = 0.05',                  #  
+            '24:onMode = off',                 # turn OFF all W decays
+            '24:onIfAny = 11 13 15 12 14 16'   # turn ON W->lnu
+
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0', 
+            '23:mMin = 0.05',                 # Solve problem with mZ cut
+            '25:onMode = off',
+            '25:onIfAll = 23 23',           # turn ON H->ZZ
+            '23:onMode = off',                # turn OFF all Z decays
+            '23:onIfAny = 11 13 15'           # turn ON Z->ll
+
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 15 -15'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
The gridpacks for the monoHiggs signal do not include decays of Higgs.
These 5 configuration files further decay Higgs into aa, bb, tau tau, WW(llnunu) and ZZ(4l).
The gridpacks were produced with LO Madgraph5_aMC@NLO and zero jet multiplicity. Therefore, 
there is no jet matching in the configuration file.
