### PR TITLE
CTEQ6L1 cards from Emrah

### DIFF
--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_100
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_100
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   100.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1000
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1000
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1000.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_125
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_125
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   125.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_150
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_150
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   150.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_1500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_175
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_175
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   175.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_200
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_200
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   200.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_300
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_300
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   300.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_350
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_350
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   350.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_40
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_40
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   40.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_400
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_400
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   400.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_50
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_50
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   50.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_60
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_60
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   60.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_600
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_600
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   600.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_70
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_70
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   70.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_700
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_700
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   700.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_80
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_80
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   80.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_800
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_800
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   800.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_90
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_90
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   90.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_900
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EE/input_EE_M_900
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  0.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   900.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_100
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_100
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   100.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1000
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1000
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1000.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_125
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_125
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   125.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_150
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_150
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   150.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_1500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_175
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_175
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   175.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_200
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_200
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   200.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_300
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_300
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   300.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_350
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_350
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   350.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_40
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_40
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   40.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_400
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_400
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   400.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_50
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_50
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   50.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_60
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_60
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   60.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_600
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_600
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   600.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_70
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_70
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   70.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_700
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_700
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   700.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_80
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_80
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   80.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_800
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_800
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   800.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_90
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_90
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   90.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_900
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/EMu/input_EMu_M_900
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  1             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   900.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_100
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_100
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   100.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1000
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1000
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1000.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_125
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_125
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   125.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_150
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_150
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   150.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_1500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_175
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_175
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   175.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_200
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_200
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   200.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_300
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_300
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   300.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_350
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_350
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn  350.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_40
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_40
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   40.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_400
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_400
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   400.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_50
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_50
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   50.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_60
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_60
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   60.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_600
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_600
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   600.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_70
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_70
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn  70.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_700
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_700
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   700.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_80
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_80
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   80.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_800
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_800
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   800.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_90
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_90
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   90.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_900
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuE/input_MuE_M_900
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000       ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  1.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  1              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   900.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_100
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_100
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   100.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1000
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1000
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1000.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_125
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_125
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   125.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_150
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_150
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   150.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_1500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+100000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   1500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_175
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_175
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   175.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_200
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_200
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   200.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_250
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_250
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   250.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_300
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_300
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   300.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_350
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_350
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   350.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_40
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_40
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   40.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_400
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_400
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   400.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_50
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_50
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   50.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_500
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_500
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+10000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   500.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_60
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_60
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn    60.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_600
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_600
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   600.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_70
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_70
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   70.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_700
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_700
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   700.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_80
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_80
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   80.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_800
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_800
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   800.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_90
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_90
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   90.d0

--- a/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_900
+++ b/bin/Alpgen/cards/production/13TeV/MajoranaNeutrinoToLL_cteq6l1/MuMu/input_MuMu_M_900
@@ -1,0 +1,30 @@
+1           ! imode
+hvyn        ! label for files
+0 ! start with: 0=new grid, 1=previous warmup grid, 2=previous generation grid
+10000   4  ! Nevents/iteration,  N(warm-up iterations)
+60000000    ! Nevents generated after warm-up - (it depends on how many events wants to be generated for each mass)
+*** The above 5 lines provide mandatory inputs for all processes
+*** (Comment lines are introduced by the three asteriscs)
+*** The lines below modify existing defaults for the hard process under study
+*** For a complete list of accessible parameters and their values,
+*** input 'print 1' (to display on the screen) or 'print 2' to write to file
+iqopt 1
+qfac  1            
+ih2   1 
+ebeam 6500.
+ndns   9 ! ndns is the PDF choice code in ALPGEN documentation
+ptlmin 0.
+etalmax 10.
+drlmin  0.
+v21  0.000d0      !  v21  0.0054d0
+v22  1.000d0     !  v22  0.0096.d0
+v23  0.00d0       !  v23  0.016.d0
+ilnv 1                 
+il1  2             
+il2  2              
+ima  1               
+***
+***
+indec 1
+idf   1
+mn   900.d0


### PR DESCRIPTION
These are the full set of Majorana Neutrino cards in Alpgen.  The previous set was reduced to only 4 mass points in the MuMu scenario since they were cteq6m.  These are cteq6l.  