### PR TITLE
Patch VBF processes to have configurable H mass window bounds (re-worked)

### DIFF
--- a/bin/Powheg/patches/vbf_h_init_couplings.patch
+++ b/bin/Powheg/patches/vbf_h_init_couplings.patch
@@ -1,0 +1,20 @@
+--- init_couplings.f.org	2015-07-30 14:35:19.000000001 +0200
++++ init_couplings.f	2015-09-18 17:05:38.000000001 +0200
+@@ -88,12 +88,14 @@
+ 
+ c     set mass windows around the resonance peak 
+ c     It is used in the generation of the Born phase space
+-      masswindow = 30
++c      masswindow = 30
++      masswindow = powheginput("#masswindow")
++      if(masswindow.lt.0d0) masswindow=10d0
+ c      ph_Zmass2low=(ph_Zmass-masswindow*ph_Zwidth)**2
+ c      ph_Zmass2high=(ph_Zmass+masswindow*ph_Zwidth)**2
+-      ph_Hmass2low=max(0d0,ph_Hmass-masswindow*ph_Hwidth)
++      ph_Hmass2low=max(0.5d0,ph_Hmass-masswindow*ph_Hwidth)
+       ph_Hmass2low=ph_Hmass2low**2
+-      ph_Hmass2high=(ph_Hmass+masswindow*ph_Hwidth)**2
++      ph_Hmass2high=min(kn_sbeams,(ph_Hmass+masswindow*ph_Hwidth)**2)
+ c      ph_Hmass2low=0d0
+ c      ph_Hmass2high=kn_sbeams/4
+     

--- a/bin/Powheg/patches/vbf_h_init_couplings.patch
+++ b/bin/Powheg/patches/vbf_h_init_couplings.patch
@@ -4,14 +4,12 @@
  
  c     set mass windows around the resonance peak 
  c     It is used in the generation of the Born phase space
--      masswindow = 30
-+c      masswindow = 30
+       masswindow = 30
 +      masswindow = powheginput("#masswindow")
-+      if(masswindow.lt.0d0) masswindow=10d0
++      if(masswindow.lt.0d0) masswindow=30d0
  c      ph_Zmass2low=(ph_Zmass-masswindow*ph_Zwidth)**2
  c      ph_Zmass2high=(ph_Zmass+masswindow*ph_Zwidth)**2
--      ph_Hmass2low=max(0d0,ph_Hmass-masswindow*ph_Hwidth)
-+      ph_Hmass2low=max(0.5d0,ph_Hmass-masswindow*ph_Hwidth)
+       ph_Hmass2low=max(0d0,ph_Hmass-masswindow*ph_Hwidth)
        ph_Hmass2low=ph_Hmass2low**2
 -      ph_Hmass2high=(ph_Hmass+masswindow*ph_Hwidth)**2
 +      ph_Hmass2high=min(kn_sbeams,(ph_Hmass+masswindow*ph_Hwidth)**2)

--- a/bin/Powheg/patches/vbf_z_z_init_couplings.patch
+++ b/bin/Powheg/patches/vbf_z_z_init_couplings.patch
@@ -1,0 +1,16 @@
+--- init_couplings.f.orig	2015-07-30 14:36:08.000000001 +0200
++++ init_couplings.f	2015-09-18 17:11:30.000000001 +0200
+@@ -96,9 +96,10 @@
+       ph_WmWw = ph_Wmass * ph_Wwidth
+ 
+ c Higgs parameters
+-      masswindow = 30
+-      ph_Hmass2low=(ph_Hmass-masswindow*ph_Hwidth)**2
+-      ph_Hmass2high=(ph_Hmass+masswindow*ph_Hwidth)**2
++      masswindow = powheginput("#masswindow")
++      if(masswindow.lt.0d0) masswindow=10d0
++      ph_Hmass2low=max(0.5d0,ph_Hmass-masswindow*ph_Hwidth)**2
++      ph_Hmass2high=min(kn_sbeams,(ph_Hmass+masswindow*ph_Hwidth)**2)
+       ph_HmHw = ph_Hmass * ph_Hwidth
+     
+       ph_unit_e = sqrt(4*pi*ph_alphaem)

--- a/bin/Powheg/patches/vbf_z_z_init_couplings.patch
+++ b/bin/Powheg/patches/vbf_z_z_init_couplings.patch
@@ -19,8 +19,8 @@
 -      ph_Hmass2low=(ph_Hmass-masswindow*ph_Hwidth)**2
 -      ph_Hmass2high=(ph_Hmass+masswindow*ph_Hwidth)**2
 +      masswindow = powheginput("#masswindow")
-+      if(masswindow.lt.0d0) masswindow=10d0
-+      ph_Hmass2low=max(0.5d0,ph_Hmass-masswindow*ph_Hwidth)**2
++      if(masswindow.lt.0d0) masswindow=30d0
++      ph_Hmass2low=max(0d0,ph_Hmass-masswindow*ph_Hwidth)**2
 +      ph_Hmass2high=min(kn_sbeams,(ph_Hmass+masswindow*ph_Hwidth)**2)
        ph_HmHw = ph_Hmass * ph_Hwidth
      

--- a/bin/Powheg/patches/vbf_z_z_init_couplings.patch
+++ b/bin/Powheg/patches/vbf_z_z_init_couplings.patch
@@ -1,6 +1,17 @@
---- init_couplings.f.orig	2015-07-30 14:36:08.000000001 +0200
-+++ init_couplings.f	2015-09-18 17:11:30.000000001 +0200
-@@ -96,9 +96,10 @@
+--- init_couplings.f	2015-07-30 14:36:08.000000001 +0200
++++ init_couplings.f.new	2015-09-19 11:35:59.000000001 +0200
+@@ -5,6 +5,10 @@
+       include 'pwhg_math.h'
+       include 'pwhg_physpar.h'
+       include 'PhysPars_Higgs.h'
++      include 'nlegborn.h'
++      include 'pwhg_flst.h'
++      include 'pwhg_kn.h'
++
+       real * 8 masswindow
+       logical verbose
+       parameter(verbose=.true.)
+@@ -96,9 +100,10 @@
        ph_WmWw = ph_Wmass * ph_Wwidth
  
  c Higgs parameters
@@ -14,3 +25,4 @@
        ph_HmHw = ph_Hmass * ph_Hwidth
      
        ph_unit_e = sqrt(4*pi*ph_alphaem)
+

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -346,6 +346,10 @@ if [ "$process" = "VBF_HJJJ" ]; then
 fi  
 if [ "$process" = "VBF_H" ]; then 
   sed -i '/pwhginihist/d' pwhg_analysis-dummy.f 
+  patch -l -p0 -i ${WORKDIR}/patches/vbf_h_init_couplings.patch
+fi  
+if [ "$process" = "VBF_Z_Z" ]; then 
+  patch -l -p0 -i ${WORKDIR}/patches/vbf_z_z_init_couplings.patch
 fi  
 if [ "$process" = "Wgamma" ] || [ "$process" = "W_ew-BMNNP" ]; then
     patch -l -p0 -i ${WORKDIR}/patches/pwhg_analysis_driver.patch 


### PR DESCRIPTION
Patches files for VBF_H and VBF_Z_Z processes so that H mass window can be configurable with the code of gg_H_quark-mass-effects, following the suggestion from David Sperka.

The patches are put in the patches folder. The run_pwg.py script fetches those patches when necessary  as create_powheg_tarball.sh does. The default mass window is now set back to 0.0 GeV - 30 sigmas if not set as suggested by @dsperka .
