### PR TITLE
Mono-Higgs ZpBaryonic: corrected model name to _UFO in proc cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi1/ZpBaryonic_MZp10000_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi1/ZpBaryonic_MZp10000_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi10/ZpBaryonic_MZp10000_MChi10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi10/ZpBaryonic_MZp10000_MChi10_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi10 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi1000/ZpBaryonic_MZp10000_MChi1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi1000/ZpBaryonic_MZp10000_MChi1000_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi150/ZpBaryonic_MZp10000_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi150/ZpBaryonic_MZp10000_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi50/ZpBaryonic_MZp10000_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi50/ZpBaryonic_MZp10000_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi500/ZpBaryonic_MZp10000_MChi500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10000_MChi500/ZpBaryonic_MZp10000_MChi500_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10000_MChi500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi1/ZpBaryonic_MZp1000_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi1/ZpBaryonic_MZp1000_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp1000_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi1000/ZpBaryonic_MZp1000_MChi1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi1000/ZpBaryonic_MZp1000_MChi1000_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp1000_MChi1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi150/ZpBaryonic_MZp1000_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1000_MChi150/ZpBaryonic_MZp1000_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp1000_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp100_MChi1/ZpBaryonic_MZp100_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp100_MChi1/ZpBaryonic_MZp100_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp100_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp100_MChi10/ZpBaryonic_MZp100_MChi10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp100_MChi10/ZpBaryonic_MZp100_MChi10_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp100_MChi10 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi1/ZpBaryonic_MZp10_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi1/ZpBaryonic_MZp10_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi10/ZpBaryonic_MZp10_MChi10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi10/ZpBaryonic_MZp10_MChi10_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi10 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi1000/ZpBaryonic_MZp10_MChi1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi1000/ZpBaryonic_MZp10_MChi1000_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi150/ZpBaryonic_MZp10_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi150/ZpBaryonic_MZp10_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi50/ZpBaryonic_MZp10_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi50/ZpBaryonic_MZp10_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi500/ZpBaryonic_MZp10_MChi500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp10_MChi500/ZpBaryonic_MZp10_MChi500_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp10_MChi500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp15_MChi10/ZpBaryonic_MZp15_MChi10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp15_MChi10/ZpBaryonic_MZp15_MChi10_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp15_MChi10 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1995_MChi1000/ZpBaryonic_MZp1995_MChi1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp1995_MChi1000/ZpBaryonic_MZp1995_MChi1000_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp1995_MChi1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp2000_MChi1/ZpBaryonic_MZp2000_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp2000_MChi1/ZpBaryonic_MZp2000_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp2000_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp2000_MChi500/ZpBaryonic_MZp2000_MChi500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp2000_MChi500/ZpBaryonic_MZp2000_MChi500_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp2000_MChi500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi1/ZpBaryonic_MZp200_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi1/ZpBaryonic_MZp200_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp200_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi150/ZpBaryonic_MZp200_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi150/ZpBaryonic_MZp200_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp200_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi50/ZpBaryonic_MZp200_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp200_MChi50/ZpBaryonic_MZp200_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp200_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp20_MChi1/ZpBaryonic_MZp20_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp20_MChi1/ZpBaryonic_MZp20_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp20_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp295_MChi150/ZpBaryonic_MZp295_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp295_MChi150/ZpBaryonic_MZp295_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp295_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp300_MChi1/ZpBaryonic_MZp300_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp300_MChi1/ZpBaryonic_MZp300_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp300_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp300_MChi50/ZpBaryonic_MZp300_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp300_MChi50/ZpBaryonic_MZp300_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp300_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi1/ZpBaryonic_MZp500_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi1/ZpBaryonic_MZp500_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp500_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi150/ZpBaryonic_MZp500_MChi150_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi150/ZpBaryonic_MZp500_MChi150_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp500_MChi150 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi500/ZpBaryonic_MZp500_MChi500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp500_MChi500/ZpBaryonic_MZp500_MChi500_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp500_MChi500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi1/ZpBaryonic_MZp50_MChi1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi1/ZpBaryonic_MZp50_MChi1_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp50_MChi1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi10/ZpBaryonic_MZp50_MChi10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi10/ZpBaryonic_MZp50_MChi10_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp50_MChi10 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi50/ZpBaryonic_MZp50_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp50_MChi50/ZpBaryonic_MZp50_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp50_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp95_MChi50/ZpBaryonic_MZp95_MChi50_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp95_MChi50/ZpBaryonic_MZp95_MChi50_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp95_MChi50 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp995_MChi500/ZpBaryonic_MZp995_MChi500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/monoHiggs/ZpBaryonic/ZpBaryonic_MZp995_MChi500/ZpBaryonic_MZp995_MChi500_proc_card.dat
@@ -1,3 +1,3 @@
-import model Higgs_hzpzp
+import model Higgs_hzpzp_UFO
 generate p p > h chi chi~
 output ZpBaryonic_MZp995_MChi500 -nojpeg


### PR DESCRIPTION
An error in the gridpack generation pointed to the model name in the proc cards being "Higgs_hzpzp" instead of "Higgs_hzpzp_UFO."