### PR TITLE
[Madgraph5_aMC@NLO] ExoDiboson: add higher HT bins for DYJetsToLL and ZJetsToNuNu

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-1200to2500/DYJets_HT-1200to2500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-1200to2500/DYJets_HT-1200to2500_proc_card.dat
@@ -1,0 +1,39 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define j  = p
+# Specify process(es) to run
+generate p p > l+ l- / h @0
+add process p p > l+ l- j / h @1
+add process p p > l+ l- j j / h @2
+add process p p > l+ l- j j j / h @3
+add process p p > l+ l- j j j j / h @4
+# Output processes to MadEvent directory
+output DYJets_HT-1200to2500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-1200to2500/DYJets_HT-1200to2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-1200to2500/DYJets_HT-1200to2500_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  DY     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 50   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+1200  = htjmin ! minimum jet HT=Sum(jet pt)
+2500  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-2500toInf/DYJets_HT-2500toInf_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-2500toInf/DYJets_HT-2500toInf_proc_card.dat
@@ -1,0 +1,39 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define j  = p
+# Specify process(es) to run
+generate p p > l+ l- / h @0
+add process p p > l+ l- j / h @1
+add process p p > l+ l- j j / h @2
+add process p p > l+ l- j j j / h @3
+add process p p > l+ l- j j j j / h @4
+# Output processes to MadEvent directory
+output DYJets_HT-2500toInf -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-2500toInf/DYJets_HT-2500toInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-2500toInf/DYJets_HT-2500toInf_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  DY     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 50   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+2500  = htjmin ! minimum jet HT=Sum(jet pt)
+ 1d5  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-600to800/DYJets_HT-600to800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-600to800/DYJets_HT-600to800_proc_card.dat
@@ -1,0 +1,39 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define j  = p
+# Specify process(es) to run
+generate p p > l+ l- / h @0
+add process p p > l+ l- j / h @1
+add process p p > l+ l- j j / h @2
+add process p p > l+ l- j j j / h @3
+add process p p > l+ l- j j j j / h @4
+# Output processes to MadEvent directory
+output DYJets_HT-600to800 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-600to800/DYJets_HT-600to800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-600to800/DYJets_HT-600to800_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  DY     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 50   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 600  = htjmin ! minimum jet HT=Sum(jet pt)
+ 800  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-800to1200/DYJets_HT-800to1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-800to1200/DYJets_HT-800to1200_proc_card.dat
@@ -1,0 +1,39 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define j  = p
+# Specify process(es) to run
+generate p p > l+ l- / h @0
+add process p p > l+ l- j / h @1
+add process p p > l+ l- j j / h @2
+add process p p > l+ l- j j j / h @3
+add process p p > l+ l- j j j j / h @4
+# Output processes to MadEvent directory
+output DYJets_HT-800to1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-800to1200/DYJets_HT-800to1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-800to1200/DYJets_HT-800to1200_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  DY     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 50   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 800  = htjmin ! minimum jet HT=Sum(jet pt)
+ 1200 = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-1200to2500/ZJetsToNuNu_HT1200to2500_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-1200to2500/ZJetsToNuNu_HT1200to2500_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define j  = p
+# Specify process(es) to run
+generate p p > ve ve~ / h @0
+add process p p > ve ve~ j / h @1
+add process p p > ve ve~ j j / h @2
+add process p p > ve ve~ j j j / h @3
+add process p p > ve ve~ j j j j / h @4
+# Output processes to MadEvent directory
+output ZJetsToNuNu_HT1200to2500 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-1200to2500/ZJetsToNuNu_HT1200to2500_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-1200to2500/ZJetsToNuNu_HT1200to2500_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  ZJets     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+1200  = htjmin ! minimum jet HT=Sum(jet pt)
+2500  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-2500toInf/ZJetsToNuNu_HT2500toInf_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-2500toInf/ZJetsToNuNu_HT2500toInf_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define j  = p
+# Specify process(es) to run
+generate p p > ve ve~ / h @0
+add process p p > ve ve~ j / h @1
+add process p p > ve ve~ j j / h @2
+add process p p > ve ve~ j j j / h @3
+add process p p > ve ve~ j j j j / h @4
+# Output processes to MadEvent directory
+output ZJetsToNuNu_HT2500toInf -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-2500toInf/ZJetsToNuNu_HT2500toInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-2500toInf/ZJetsToNuNu_HT2500toInf_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  ZJets     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+2500  = htjmin ! minimum jet HT=Sum(jet pt)
+ 1d5  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-600to800/ZJetsToNuNu_HT600to800_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-600to800/ZJetsToNuNu_HT600to800_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define j  = p
+# Specify process(es) to run
+generate p p > ve ve~ / h @0
+add process p p > ve ve~ j / h @1
+add process p p > ve ve~ j j / h @2
+add process p p > ve ve~ j j j / h @3
+add process p p > ve ve~ j j j j / h @4
+# Output processes to MadEvent directory
+output ZJetsToNuNu_HT600to800 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-600to800/ZJetsToNuNu_HT600to800_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-600to800/ZJetsToNuNu_HT600to800_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  ZJets     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 600  = htjmin ! minimum jet HT=Sum(jet pt)
+ 800  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-800to1200/ZJetsToNuNu_HT800to1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-800to1200/ZJetsToNuNu_HT800to1200_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model sm-ckm_no_b_mass
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+# Define multiparticle labels
+define p u c s d b u~ c~ s~ d~ b~ g
+define j  = p
+# Specify process(es) to run
+generate p p > ve ve~ / h @0
+add process p p > ve ve~ j / h @1
+add process p p > ve ve~ j j / h @2
+add process p p > ve ve~ j j j / h @3
+add process p p > ve ve~ j j j j / h @4
+# Output processes to MadEvent directory
+output ZJetsToNuNu_HT800to1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-800to1200/ZJetsToNuNu_HT800to1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ZJets_LO_MLM/ZJetsToNuNu_HT-800to1200/ZJetsToNuNu_HT800to1200_run_card.dat
@@ -1,0 +1,247 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  ZJets     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+    1500       = nevents ! Number of unweighted events requested
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.01  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ 1d5  = ptjmax    ! maximum pt for the jets
+ 1d5  = ptbmax    ! maximum pt for the b
+ 1d5  = ptamax    ! maximum pt for the photons
+ 1d5  = ptlmax    ! maximum pt for the charged leptons
+ 1d5  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ 1d5   = ejmax ! maximum E for the jets
+ 1d5   = ebmax ! maximum E for the b
+ 1d5   = eamax ! maximum E for the photons
+ 1d5   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  1d2  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 1d2  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ 1d2  = drjjmax ! max distance between jets
+ 1d2  = drbbmax ! max distance between b's
+ 1d2  = drllmax ! max distance between leptons
+ 1d2  = draamax ! max distance between gammas
+ 1d2  = drbjmax ! max distance between b and jet
+ 1d2  = drajmax ! max distance between gamma and jet
+ 1d2  = drjlmax ! max distance between jet and lepton
+ 1d2  = drabmax ! max distance between gamma and b
+ 1d2  = drblmax ! max distance between b and lepton
+ 1d2  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ 1d5  = mmjjmax ! max invariant mass of a jet pair
+ 1d5  = mmbbmax ! max invariant mass of a b pair
+ 1d5  = mmaamax ! max invariant mass of gamma gamma pair
+ 1d5  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ 1d5  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ 1d5  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ 1d5  = ptj1max ! maximum pt for the leading jet in pt 
+ 1d5  = ptj2max ! maximum pt for the second jet in pt
+ 1d5  = ptj3max ! maximum pt for the third jet in pt
+ 1d5  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ 1d5  = ptl1max ! maximum pt for the leading lepton in pt 
+ 1d5  = ptl2max ! maximum pt for the second lepton in pt
+ 1d5  = ptl3max ! maximum pt for the third lepton in pt
+ 1d5  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 800  = htjmin ! minimum jet HT=Sum(jet pt)
+1200  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ 1d5  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ 1d5  = ht2max ! maximum Ht for the two leading jets
+ 1d5  = ht3max ! maximum Ht for the three leading jets
+ 1d5  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies


### PR DESCRIPTION
In order to have enough statistics to model the background of high mass Z'/Graviton, we need to add higher HT bins for the following modes:
DY(->LL)+Jets and Z(->nunu)+Jets

The number of events we would like to request is as follows:

DY+Jets:
600-800 GeV : 4M
800-1200 GeV: 1.5M
1200-2500: 250K
2500-Inf: 250K

Z(->nunu)+Jets:
600-800 GeV : 8M
800-1200 GeV: 3M
1200-2500: 500K
2500-Inf: 500K


