### PR TITLE
latest ggH datacards for mass scan  following the example of HZZ

### DIFF
--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M1000.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M115.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=MASS Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M124.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M125.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M126.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M130.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M135.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M140.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M145.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M150.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M155.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M160.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M165.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M170.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M175.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M180.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M190.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M200.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M210.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M230.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M250.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M270.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M300.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M350.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M400.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M450.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M500.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M550.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M600.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M700.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M800.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M900.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    147.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 647.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M115.input
@@ -47,7 +47,7 @@ hfact    59.0d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -77,7 +77,7 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass 115            ! Higgs boson mass
-hwidth 3.12D-03     ! Higgs boson width
+hwidth 0.00312D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M120.input
@@ -47,7 +47,7 @@ hfact    59.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -77,7 +77,7 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass 120            ! Higgs boson mass
-hwidth 3.51D-03     ! Higgs boson width
+hwidth 0.00351D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M124.input
@@ -47,7 +47,7 @@ hfact    59.9d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 124            ! Higgs boson mass
-hwidth 3.94D-03     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.00394D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
@@ -47,7 +47,7 @@ hfact    60.0d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 125            ! Higgs boson mass
-hwidth 4.07D-03     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.00407D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M126.input
@@ -47,7 +47,7 @@ hfact    60.1d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 126            ! Higgs boson mass
-hwidth 4.21D-03     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.00421D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M130.input
@@ -47,7 +47,7 @@ hfact    60.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 130            ! Higgs boson mass
-hwidth 4.91D-03     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.00491D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M140.input
@@ -47,7 +47,7 @@ hfact    61.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 140            ! Higgs boson mass
-hwidth 8.17D-03     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.00817D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M145.input
@@ -47,7 +47,7 @@ hfact    62.0d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 145            ! Higgs boson mass
-hwidth 1.14D-02     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.0114D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M150.input
@@ -47,7 +47,7 @@ hfact    62.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 150            ! Higgs boson mass
-hwidth 1.73D-02     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.0173D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M155.input
@@ -41,13 +41,13 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    63d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    63.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 155            ! Higgs boson mass
-hwidth 3.09D-02     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.0309D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M160.input
@@ -47,7 +47,7 @@ hfact    63.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 160            ! Higgs boson mass
-hwidth 8.31D-02     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.0831D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M165.input
@@ -41,13 +41,13 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    64d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    64.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 165            ! Higgs boson mass
-hwidth 2.46D-01     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.246D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M170.input
@@ -47,7 +47,7 @@ hfact    64.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 170            ! Higgs boson mass
-hwidth 3.80D-01     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.38D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M175.input
@@ -41,13 +41,13 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    65d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    65.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 175            ! Higgs boson mass
-hwidth 5.01D-01     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.501D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M180.input
@@ -47,7 +47,7 @@ hfact    65.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 180            ! Higgs boson mass
-hwidth 6.31D-01     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 0.631D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M190.input
@@ -47,7 +47,7 @@ hfact    66.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 190            ! Higgs boson mass
-hwidth 1.04     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 1.04D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
@@ -47,7 +47,7 @@ hfact    67.5d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -76,8 +76,8 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass 200            ! Higgs boson mass
-hwidth 1.43     ! Higgs boson width
+hmass MASS            ! Higgs boson mass
+hwidth 1.43D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
@@ -86,3 +86,4 @@ hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 
 withnegweights 1
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M210.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    68.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 1.85D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M230.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    70.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 2.82D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    72.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 4.04D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M270.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    74.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 5.55D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    77.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 8.43D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    82.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 15.2D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    87.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 29.2D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    92.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 46.8D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    97.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 68.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    102.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 93.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    107.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 123.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    117.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 199.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    127.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 304.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
@@ -41,7 +41,7 @@ facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
 #charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
 #bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
-hfact    61.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+hfact    137.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
 #testsuda  1       ! (default 0, do not test) test Sudakov form factor
 #radregion 1       ! (default all regions) only generate radiation in the selected singular region  
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
@@ -77,7 +77,7 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hwidth 449.0D0     ! Higgs boson width    
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark


### PR DESCRIPTION
New ggH powheg and JHU datacards for HWW mass scan. Following HZZ model, keeping negative weights in the event.