### PR TITLE
ggH and VBF for the HWW mass scan: final commit!

### DIFF
--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M1000.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M115.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M120.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=MASS Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M124.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M125.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M126.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M130.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M135.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M140.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M145.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M150.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M155.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M160.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M165.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M170.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M175.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M180.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M190.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M200.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M210.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M230.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M250.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M270.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M300.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M350.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M400.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M450.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M500.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M550.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M600.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M700.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M800.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M900.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M1000_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M1000_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    1000d0       ! Higgs boson mass
+hwidth   647.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M115_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M115_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    115d0       ! Higgs boson mass
+hwidth   0.00312d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M120_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M120_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    120d0       ! Higgs boson mass
+hwidth   0.00351d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M124_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M124_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    124d0       ! Higgs boson mass
+hwidth   0.00394d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M125_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M125_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    125d0       ! Higgs boson mass
+hwidth   0.00407d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M126_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M126_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    126d0       ! Higgs boson mass
+hwidth   0.00421d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M130_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M130_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    130d0       ! Higgs boson mass
+hwidth   0.00491d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M135_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M135_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    135d0       ! Higgs boson mass
+hwidth   0.00618d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M140_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M140_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    140d0       ! Higgs boson mass
+hwidth   0.00817d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M145_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M145_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    145d0       ! Higgs boson mass
+hwidth   0.0114d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M150_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M150_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    150d0       ! Higgs boson mass
+hwidth   0.0173d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M155_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M155_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    155d0       ! Higgs boson mass
+hwidth   0.0309d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M160_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M160_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    160d0       ! Higgs boson mass
+hwidth   0.0831d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M165_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M165_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    165d0       ! Higgs boson mass
+hwidth   0.246d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M170_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M170_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    170d0       ! Higgs boson mass
+hwidth   0.38d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M175_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M175_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    175d0       ! Higgs boson mass
+hwidth   0.501d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M180_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M180_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    180d0       ! Higgs boson mass
+hwidth   0.631d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M190_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M190_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    190d0       ! Higgs boson mass
+hwidth   1.04d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M200_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M200_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    200d0       ! Higgs boson mass
+hwidth   1.43d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M210_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M210_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    210d0       ! Higgs boson mass
+hwidth   1.85d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M230_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M230_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    230d0       ! Higgs boson mass
+hwidth   2.82d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M250_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M250_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    250d0       ! Higgs boson mass
+hwidth   4.04d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M270_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M270_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    270d0       ! Higgs boson mass
+hwidth   5.55d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M300_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M300_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    300d0       ! Higgs boson mass
+hwidth   8.43d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M350_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M350_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    350d0       ! Higgs boson mass
+hwidth   15.2d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M400_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M400_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    400d0       ! Higgs boson mass
+hwidth   29.2d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M450_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M450_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    450d0       ! Higgs boson mass
+hwidth   46.8d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M500_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M500_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    500d0       ! Higgs boson mass
+hwidth   68.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M550_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M550_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    550d0       ! Higgs boson mass
+hwidth   93.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M600_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M600_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    600d0       ! Higgs boson mass
+hwidth   123.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M700_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M700_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    700d0       ! Higgs boson mass
+hwidth   199.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M800_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M800_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    800d0       ! Higgs boson mass
+hwidth   304.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M900_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/VBF_H_M900_NNPDF30_13TeV.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    900d0       ! Higgs boson mass
+hwidth   449.0d0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M105.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M105.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=105 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=MASS Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 647.0D0     ! Higgs boson width    
+hmass 1000            ! Higgs boson mass
+hwidth 647.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M105.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M105.input
@@ -47,7 +47,7 @@ hfact    58.0d0    ! (default no dumping factor) dump factor for high-pt radiati
 #charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
 #bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
 # mur,muf settings
-runningscale 0    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 # When using 2 uncomment the following option
 # btlscalereal 1
@@ -63,11 +63,11 @@ iseed    SEED    ! initialize random number sequence
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 ! allowed values are:  -1 all decay channels closed
 !                      0 all decay channels open
 !	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
@@ -77,12 +77,13 @@ masswindow 10d0  !(default 10d0) number of widths around hmass in the BW for an 
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass 105            ! Higgs boson mass
-hwidth 2.64D-03     ! Higgs boson width
+hwidth 0.00264D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M115.input
@@ -77,13 +77,13 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass 115            ! Higgs boson mass
-hwidth 0.00312D0     ! Higgs boson width    
+hwidth 0.00312D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M120.input
@@ -77,13 +77,13 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
 hmass 120            ! Higgs boson mass
-hwidth 0.00351D0     ! Higgs boson width    
+hwidth 0.00351D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M124.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00394D0     ! Higgs boson width    
+hmass 124            ! Higgs boson mass
+hwidth 0.00394D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00407D0     ! Higgs boson width    
+hmass 125            ! Higgs boson mass
+hwidth 0.00407D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M126.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00421D0     ! Higgs boson width    
+hmass 126            ! Higgs boson mass
+hwidth 0.00421D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M130.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00491D0     ! Higgs boson width    
+hmass 130            ! Higgs boson mass
+hwidth 0.00491D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M135.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00618D0     ! Higgs boson width    
+hmass 135            ! Higgs boson mass
+hwidth 0.00618D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M140.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.00817D0     ! Higgs boson width    
+hmass 140            ! Higgs boson mass
+hwidth 0.00817D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M145.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.0114D0     ! Higgs boson width    
+hmass 145            ! Higgs boson mass
+hwidth 0.0114D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M150.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.0173D0     ! Higgs boson width    
+hmass 150            ! Higgs boson mass
+hwidth 0.0173D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M155.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.0309D0     ! Higgs boson width    
+hmass 155            ! Higgs boson mass
+hwidth 0.0309D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M160.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.0831D0     ! Higgs boson width    
+hmass 160            ! Higgs boson mass
+hwidth 0.0831D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M165.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.246D0     ! Higgs boson width    
+hmass 165            ! Higgs boson mass
+hwidth 0.246D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M170.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.38D0     ! Higgs boson width    
+hmass 170            ! Higgs boson mass
+hwidth 0.38D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M175.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.501D0     ! Higgs boson width    
+hmass 175            ! Higgs boson mass
+hwidth 0.501D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M180.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 0.631D0     ! Higgs boson width    
+hmass 180            ! Higgs boson mass
+hwidth 0.631D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M190.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 1.04D0     ! Higgs boson width    
+hmass 190            ! Higgs boson mass
+hwidth 1.04D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 1.43D0     ! Higgs boson width    
+hmass 200            ! Higgs boson mass
+hwidth 1.43D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M210.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 1.85D0     ! Higgs boson width    
+hmass 210            ! Higgs boson mass
+hwidth 1.85D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M230.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 2.82D0     ! Higgs boson width    
+hmass 230            ! Higgs boson mass
+hwidth 2.82D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 4.04D0     ! Higgs boson width    
+hmass 250            ! Higgs boson mass
+hwidth 4.04D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M270.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 5.55D0     ! Higgs boson width    
+hmass 270            ! Higgs boson mass
+hwidth 5.55D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 8.43D0     ! Higgs boson width    
+hmass 300            ! Higgs boson mass
+hwidth 8.43D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 15.2D0     ! Higgs boson width    
+hmass 350            ! Higgs boson mass
+hwidth 15.2D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 29.2D0     ! Higgs boson width    
+hmass 400            ! Higgs boson mass
+hwidth 29.2D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 46.8D0     ! Higgs boson width    
+hmass 450            ! Higgs boson mass
+hwidth 46.8D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 68.0D0     ! Higgs boson width    
+hmass 500            ! Higgs boson mass
+hwidth 68.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 93.0D0     ! Higgs boson width    
+hmass 550            ! Higgs boson mass
+hwidth 93.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 123.0D0     ! Higgs boson width    
+hmass 600            ! Higgs boson mass
+hwidth 123.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 199.0D0     ! Higgs boson width    
+hmass 700            ! Higgs boson mass
+hwidth 199.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 304.0D0     ! Higgs boson width    
+hmass 800            ! Higgs boson mass
+hwidth 304.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
@@ -76,14 +76,14 @@ masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for a
 !	               11  ZZ
 !	               12  gamma gamma
 ! **** Mandatory parameters for SM or MW ****
-hmass MASS            ! Higgs boson mass
-hwidth 449.0D0     ! Higgs boson width    
+hmass 900            ! Higgs boson mass
+hwidth 449.0D0     ! Higgs boson width
 topmass 172.5        ! top quark mass
 bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
 !charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-withnegweights 1
+withnegweights 0
 pdfreweight 1       ! PDF reweighting
 storeinfo_rwgt 1    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.


### PR DESCRIPTION
Modified again to go in synch with HZZ.
JHU version 6.2.8.
Now *NOT* keeping negative weight events in the ggH. 

Moreover, previous ggH datacards were not correct (wrong folder).