### PR TITLE
Fragment for additional DYJetsToLL for EXO-RunIIWinter15GS

### DIFF
--- a/python/ThirteenTeV/DYJetsToLL_M-50_HTbinned_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/python/ThirteenTeV/DYJetsToLL_M-50_HTbinned_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 19.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 4', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters',
+                                    )
+    )
+)


### PR DESCRIPTION
An EXO groups would like to extend SUS-RunIIWinter15wmLHE-00030 ---> SUS-RunIIWinter15wmLHE-00033 to a few higher HT bins.

The fragment is from https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/SUS-RunIIWinter15GS-00031/0