### PR TITLE
External tarball + madspin

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -424,6 +424,7 @@ if [ "$isnlo" -gt "0" ]; then
       gunzip ./Events/pilotrun_decayed_1/events.lhe.gz
       sed -n '/<MG5ProcCard>/,/<\/slha>/p' ./Events/pilotrun_decayed_1/events.lhe > header_for_madspin.txt
       mv header_for_madspin.txt $WORKDIR
+      gzip ./Events/pilotrun_decayed_1/events.lhe
   fi
   
   echo "mg5_path = ../mgbasedir" >> ./Cards/amcatnlo_configuration.txt

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -419,6 +419,12 @@ if [ "$isnlo" -gt "0" ]; then
   echo "done" >> makegrid.dat
 
   cat makegrid.dat | ./bin/generate_events -n pilotrun
+
+  if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
+      gunzip ./Events/pilotrun_decayed_1/events.lhe.gz
+      sed -n '/<MG5ProcCard>/,/<\/slha>/p' ./Events/pilotrun_decayed_1/events.lhe > header_for_madspin.txt
+      mv header_for_madspin.txt $WORKDIR
+  fi
   
   echo "mg5_path = ../mgbasedir" >> ./Cards/amcatnlo_configuration.txt
   echo "cluster_temp_path = None" >> ./Cards/amcatnlo_configuration.txt
@@ -434,6 +440,10 @@ if [ "$isnlo" -gt "0" ]; then
   cd gridpack
 
   cp $PRODHOME/runcmsgrid_NLO.sh ./runcmsgrid.sh
+  
+  if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
+    mv $WORKDIR/header_for_madspin.txt . 
+  fi
   
 else
   #LO mode
@@ -522,16 +532,41 @@ else
   
 fi
 
+
+
+
 #clean unneeded files for generation
 $PRODHOME/cleangridmore.sh
+
+
+#
+#Plan to decay events from external tarball?
+# 
+
+if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
+    echo "Locating the external tarball"
+    cp $CARDSDIR/${name}_externaltarball.dat .
+    source $CARDSDIR/${name}_externaltarball.dat
+    echo $EXTERNAL_TARBALL 
+    cp $EXTERNAL_TARBALL .
+    tarname=$(basename $EXTERNAL_TARBALL)
+fi
+
 
 echo "Saving log file"
 #copy log file
 cp ${LOGFILE} ./gridpack_generation.log
 
+
+
 #create tarball with very aggressive xz settings (trade memory and cpu usage for compression ratio)
 echo "Creating tarball"
-XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log
+
+if [ ! -e $CARDSDIR/${name}_externaltarball.dat ]; then
+    XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log
+else
+    XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log $tarname ${name}_externaltarball.dat header_for_madspin.txt
+fi
 
 mv ${name}_tarball.tar.xz ${PRODHOME}/${name}_tarball.tar.xz
 

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -551,6 +551,11 @@ if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
     echo $EXTERNAL_TARBALL 
     cp $EXTERNAL_TARBALL .
     tarname=$(basename $EXTERNAL_TARBALL)
+    mkdir external_tarball
+    cd external_tarball
+    tar -xvaf ../$tarname
+    cd ..
+    rm $tarname
 fi
 
 
@@ -566,7 +571,7 @@ echo "Creating tarball"
 if [ ! -e $CARDSDIR/${name}_externaltarball.dat ]; then
     XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log
 else
-    XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log $tarname ${name}_externaltarball.dat header_for_madspin.txt
+    XZ_OPT="--lzma2=preset=9,dict=512MiB" tar -cJpsf ${name}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation.log external_tarball ${name}_externaltarball.dat header_for_madspin.txt
 fi
 
 mv ${name}_tarball.tar.xz ${PRODHOME}/${name}_tarball.tar.xz

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -92,7 +92,12 @@ else
          N
      }" cmsgrid_final.lhe
 
-    cp cmsgrid_final.lhe ../cmsgrid_predecay.lhe
+#check if lhe file has reweighting blocks - temporarily save those, because MadSpin later overrides the entire header
+    if grep -R "<initrwgt>" cmsgrid_final.lhe; then
+        sed -n '/<initrwgt>/,/<\/initrwgt>/p' cmsgrid_final.lhe > ../initrwgt.txt
+    fi
+
+    mv cmsgrid_final.lhe ../cmsgrid_predecay.lhe
     cd $LHEWORKDIR
     rm -r external_tarball
     echo "import $LHEWORKDIR/cmsgrid_predecay.lhe" > madspinrun.dat
@@ -102,6 +107,19 @@ else
     rm madspinrun.dat
     rm cmsgrid_predecay.lhe.gz
     mv cmsgrid_predecay_decayed.lhe.gz cmsgrid_final.lhe.gz
+    
+    if [ -e initrwgt.txt ];then
+    gzip -d cmsgrid_final.lhe.gz
+    sed -i "/<\/header>/ {
+         h
+         r initrwgt.txt
+         g
+         N
+    }" cmsgrid_final.lhe
+    rm initrwgt.txt
+    gzip cmsgrid_final.lhe
+    fi
+
     
 fi
 

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -109,15 +109,15 @@ else
     mv cmsgrid_predecay_decayed.lhe.gz cmsgrid_final.lhe.gz
     
     if [ -e initrwgt.txt ];then
-    gzip -d cmsgrid_final.lhe.gz
-    sed -i "/<\/header>/ {
-         h
-         r initrwgt.txt
-         g
-         N
-    }" cmsgrid_final.lhe
-    rm initrwgt.txt
-    gzip cmsgrid_final.lhe
+    	gzip -d cmsgrid_final.lhe.gz
+    	sed -i "/<\/header>/ {
+             h
+             r initrwgt.txt
+             g
+             N
+        }" cmsgrid_final.lhe
+        rm initrwgt.txt
+        gzip cmsgrid_final.lhe
     fi
 
     

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -71,16 +71,7 @@ if [ ! -e $LHEWORKDIR/header_for_madspin.txt ]; then
 
 #else handle external tarball
 else
-    cd $LHEWORKDIR
-    mkdir external_tarball
-    cd external_tarball
-    if [ -e ../*.tar.xz ];then
-	tar -xvaf ../*.tar.xz
-    elif [ -e ../*.tar.gz ];then
-	tar -xvaf ../*.tar.gz
-    elif [ -e ../*.tgz ]; then
-	tar -xvzf ../*.tgz
-    fi
+    cd $LHEWORKDIR/external_tarball
 
     ./runcmsgrid.sh $nevtjob $rnum $ncpu
 


### PR DESCRIPTION
Enabling generating events from an external tarball and decaying them with MadSpin.
For this, it just detects whether a $name_externaltarball.dat can be found among the input cards (see example here https://github.com/maierbenedikt/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/13TeV/st_tch_4f_antitop_ckm_NLO_powheg_madspin), then generates the equivalent MG5_aMCatNLO process and saves all the necessary information from the pilotrun LHE's header in a txt file that is stored together with the external tarball, in the gridpack.

The runcmsgrid_NLO.sh then generates events from the external tarball, splices the header into the LHE and calls madspin.

Tested was:
	•	script works with a PowhegV1 tarball
	•	script works with a PowhegV2 tarball
	•	script still works when using it in the old style, without an externaltarball.dat, i.e. if one just wants to generate aMCatNLO events.

Not possible at the moment: decaying external LO events. (But modifications to extract the header from the pilotrun LHE in the LO section of the gridpack_generation.sh and to the runcmsgrid_LO.sh should be straightforward).