### PR TITLE
Fix lhapdf id in LHE file

### DIFF
--- a/bin/Powheg/patches/pwhg_lhepdf.patch
+++ b/bin/Powheg/patches/pwhg_lhepdf.patch
@@ -1,0 +1,27 @@
+--- POWHEG-BOX/lhefwrite.f.org  2015-09-29 18:51:10.000000000 +0800
++++ POWHEG-BOX/lhefwrite.f      2015-11-18 20:09:55.160747624 +0800
+@@ -7,6 +7,7 @@
+       include 'pwhg_rad.h'
+       include 'pwhg_flg.h'
+       include 'pwhg_lhrwgt.h'
++      include 'pwhg_pdf.h'
+       integer nlf
+       real * 8 version
+       common/cversion/version
+@@ -34,8 +35,13 @@
+          write(nlf,'(a)') '</header>'
+       endif
+       write(nlf,'(a)') '<init>'
+-      write(nlf,110) idbmup(1),idbmup(2),ebmup(1),ebmup(2),
+-     &pdfgup(1),pdfgup(2),pdfsup(1),pdfsup(2),idwtup,nprup
++      if(pdfsup(1).ne.-1 .and. pdfsup(2).ne.-1) then
++         write(nlf,110) idbmup(1),idbmup(2),ebmup(1),ebmup(2),
++     &   pdfgup(1),pdfgup(2),pdfsup(1),pdfsup(2),idwtup,nprup
++      else
++         write(nlf,110) idbmup(1),idbmup(2),ebmup(1),ebmup(2),
++     &   pdfgup(1),pdfgup(2),pdf_ndns1,pdf_ndns2,idwtup,nprup
++      endif
+       do 100 ipr=1,nprup
+          write(nlf,120) xsecup(ipr),xerrup(ipr),xmaxup(ipr),
+      &        lprup(ipr)
+

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -327,6 +327,8 @@ if [ -e POWHEG-BOX/${process}.tgz ]; then
 fi
 
 patch -l -p0 -i ${WORKDIR}/patches/pdfweights.patch
+patch -l -p0 -i ${WORKDIR}/patches/pwhg_lhepdf.patch
+
 cd POWHEG-BOX/${process}
 
 # This is just to please gcc 4.8.1


### PR DESCRIPTION
According to POWHEG source code, the PDF SET 'pdfsup' is set to '-1' as using internal herwig pdf's for showering. This patch gets PDF index from 'pdf_ndns' if the value of 'pdfsup' is '-1'. Though the PDF group index 'pdfgup' is untouched.