### PR TITLE
Replacing CT10 with CT14 for PDF reweights calculation

### DIFF
--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -205,9 +205,9 @@ then
     mv powheg.input powheg.input.${iteration}
 
 
-    echo -e "\ncomputing weights for 52+1 CT10 PDF variations\n"
-    iteration=10999
-    lastfile=11052
+    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
+    iteration=13199
+    lastfile=13156
     counter=3000
     while [ $iteration -lt $lastfile ];
     do
@@ -225,8 +225,8 @@ then
 	mv powheg.input powheg.input.${iteration}
     done
 
-    echo -e "\ncomputing weights for CT10 alphas=0.117 variation\n"
-    iteration=11067
+    echo -e "\ncomputing weights for CT14 alphas=0.117 variation\n"
+    iteration=13164
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
     counter=$(( counter + 1 ))
@@ -239,8 +239,8 @@ then
     mv pwgevents-rwgt.lhe pwgevents.lhe
     mv powheg.input powheg.input.${iteration}
 
-    echo -e "\ncomputing weights for CT10 alphas=0.119 variation\n"
-    iteration=11069
+    echo -e "\ncomputing weights for CT14 alphas=0.119 variation\n"
+    iteration=13166
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
     counter=$(( counter + 1 ))

--- a/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
+++ b/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
@@ -209,9 +209,9 @@ then
     mv powheg.input powheg.input.${iteration}
 
 
-    echo -e "\ncomputing weights for 52+1 CT10 PDF variations\n"
-    iteration=10999
-    lastfile=11052
+    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
+    iteration=13099
+    lastfile=13156
     counter=3000
     while [ $iteration -lt $lastfile ];
     do
@@ -229,8 +229,8 @@ then
 	mv powheg.input powheg.input.${iteration}
     done
 
-    echo -e "\ncomputing weights for CT10 alphas=0.117 variation\n"
-    iteration=11067
+    echo -e "\ncomputing weights for CT14 alphas=0.117 variation\n"
+    iteration=13164
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
     counter=$(( counter + 1 ))
@@ -243,8 +243,8 @@ then
     mv pwgevents-rwgt.lhe pwgevents.lhe
     mv powheg.input powheg.input.${iteration}
 
-    echo -e "\ncomputing weights for CT10 alphas=0.119 variation\n"
-    iteration=11069
+    echo -e "\ncomputing weights for CT14 alphas=0.119 variation\n"
+    iteration=13166
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
     counter=$(( counter + 1 ))

--- a/bin/Powheg/runcmsgrid_powhegjhugen.sh
+++ b/bin/Powheg/runcmsgrid_powhegjhugen.sh
@@ -172,9 +172,9 @@ then
 	mv pwgevents-rwgt.lhe pwgevents.lhe
 	mv powheg.input powheg.input.${iteration}
     done
-    echo -e "\ncomputing weights for 52+1 CT10 PDF variations\n"
-    iteration=10999
-    lastfile=11052
+    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
+    iteration=13099
+    lastfile=13156
     counter=3000
     while [ $iteration -lt $lastfile ];
     do
@@ -192,9 +192,9 @@ then
 	mv powheg.input powheg.input.${iteration}
     done
 
-    echo -e "\ncomputing weights for 16 CT10 alphas variations\n"
-    iteration=11061
-    lastfile=11077
+    echo -e "\ncomputing weights for 11 CT14 alphas variations\n"
+    iteration=13159
+    lastfile=13170
     counter=4000
     while [ $iteration -lt $lastfile ];
     do


### PR DESCRIPTION
The patch replaces the CT10 PDF weights calculations with CT14 PDF sets in the LHE production script. All three scripts to be packed in the gridpack tarball are modified.