### PR TITLE
Adding hadronizer for RPV Stops with HT filter

### DIFF
--- a/python/ThirteenTeV/RPVStop_Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max2j_LHE_HTFilter_pythia8_cff.py
+++ b/python/ThirteenTeV/RPVStop_Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max2j_LHE_HTFilter_pythia8_cff.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 40.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+
+htFilter = cms.EDFilter("PythiaFilterHT",
+		MinHT = cms.untracked.double(500.0),
+		)
+
+
+ProductionFilterSequence = cms.Sequence( generator * htFilter )


### PR DESCRIPTION
As discussed here #663, we created a filter in genparticles HT to reduce the number of generated events for the low mass RPV Stops. This is the hadronizer with that filter.

Btw, for the filter in CMSSW, is there any specific release that I have to include it?
In case you want to check it, the filter is here:
https://github.com/alefisico/cmssw/blob/CMSSW_7_1_X_PythiaHTFilter/GeneratorInterface/GenFilters/src/PythiaFilterHT.cc

Please let me know if you have any question about this.