### PR TITLE
add extramodels.dat cards for BulkGraviton_ZZ_ZlepZinv

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1000/BulkGraviton_ZZ_ZlepZinv_narrow_M1000_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1000/BulkGraviton_ZZ_ZlepZinv_narrow_M1000_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1200/BulkGraviton_ZZ_ZlepZinv_narrow_M1200_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1200/BulkGraviton_ZZ_ZlepZinv_narrow_M1200_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1400/BulkGraviton_ZZ_ZlepZinv_narrow_M1400_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1400/BulkGraviton_ZZ_ZlepZinv_narrow_M1400_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1600/BulkGraviton_ZZ_ZlepZinv_narrow_M1600_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1600/BulkGraviton_ZZ_ZlepZinv_narrow_M1600_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1800/BulkGraviton_ZZ_ZlepZinv_narrow_M1800_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M1800/BulkGraviton_ZZ_ZlepZinv_narrow_M1800_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M2000/BulkGraviton_ZZ_ZlepZinv_narrow_M2000_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M2000/BulkGraviton_ZZ_ZlepZinv_narrow_M2000_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M2500/BulkGraviton_ZZ_ZlepZinv_narrow_M2500_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M2500/BulkGraviton_ZZ_ZlepZinv_narrow_M2500_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M3000/BulkGraviton_ZZ_ZlepZinv_narrow_M3000_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M3000/BulkGraviton_ZZ_ZlepZinv_narrow_M3000_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M3500/BulkGraviton_ZZ_ZlepZinv_narrow_M3500_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M3500/BulkGraviton_ZZ_ZlepZinv_narrow_M3500_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M4000/BulkGraviton_ZZ_ZlepZinv_narrow_M4000_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M4000/BulkGraviton_ZZ_ZlepZinv_narrow_M4000_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M4500/BulkGraviton_ZZ_ZlepZinv_narrow_M4500_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M4500/BulkGraviton_ZZ_ZlepZinv_narrow_M4500_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M600/BulkGraviton_ZZ_ZlepZinv_narrow_M600_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M600/BulkGraviton_ZZ_ZlepZinv_narrow_M600_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M800/BulkGraviton_ZZ_ZlepZinv_narrow_M800_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZinv/BulkGraviton_ZZ_ZlepZinv_narrow_M800/BulkGraviton_ZZ_ZlepZinv_narrow_M800_extramodels.dat
@@ -1,0 +1,2 @@
+# HVT, RS, Bulk, and radion models from https://twiki.cern.ch/twiki/bin/view/CMS/MCsEXO
+dibosonResonanceModel.tar.gz


### PR DESCRIPTION
Add extramodels.dat cards for BulkGraviton_ZZ_ZlepZinv in order to generate gridpacks with the recent gridpack generation script. 