### PR TITLE
setting the bwcutoff back to a reasonable value

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/TWj/TWj_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/TWj/TWj_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WGjj/WGjj_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WGjj/WGjj_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/WWjj_OS_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/WWjj_OS_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noHiggs/WWjj_OS_noHiggs_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noHiggs/WWjj_OS_noHiggs_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noHiggs_noTop/WWjj_OS_noHiggs_noTop_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noHiggs_noTop/WWjj_OS_noHiggs_noTop_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_OS/noTop/WWjj_OS_noTop_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WWjj_SS/WWjj_SS_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/WZjj/WZjj_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_ewk_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_ewk_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/highMll_diagCKM/Wlljj_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/lowMll_diagCKM/Wlljj_lowMll_ewk_qcd_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBS/Wlljj/lowMll_diagCKM/Wlljj_lowMll_ewk_qcd_run_card.dat
@@ -84,7 +84,7 @@
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)


### PR DESCRIPTION
The madgraph authors have told us that using the decay chain syntax with such a large bwcutoff does not make sense. Also, we have checked that the results with bwcutoff=15 agree with what we get without decay chain syntax. More details can be found here:

https://indico.cern.ch/event/486671/session/0/contribution/3/attachments/1225694/1794216/VBS_GEN_9Feb16.pdf