### PR TITLE
Add a way to patch ME after generation

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -279,6 +279,11 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
   ########################
 
   ./$MGBASEDIRORIG/bin/mg5_aMC ${name}_proc_card.dat
+
+  if [ -e $CARDSDIR/${name}_patch_me.sh ]; then
+      echo "Patching generated matrix element code with " $CARDSDIR/${name}_patch_me.sh
+      /bin/bash "$CARDSDIR/${name}_patch_me.sh" "$WORKDIR/$MGBASEDIRORIG"
+  fi;
   
 else  
   echo "Reusing existing directory assuming generated code already exists"


### PR DESCRIPTION
If a file named `<name>_patch_me.sh` is found, it's executed right after the generation of the ME code.

This is useful if you need to patch the code generated by Madgraph before the gridpack generation starts. The script is provided with one argument, the absolute path of the current Madgraph working directory.