### PR TITLE
add WZTo3lNu_mllmin01 fragment

### DIFF
--- a/bin/Powheg/production/WZTo3lNu_mllmin01_NNPDF30_13TeV/WZTo3lNu_mllmin01_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/WZTo3lNu_mllmin01_NNPDF30_13TeV/WZTo3lNu_mllmin01_NNPDF30_13TeV.input
@@ -1,0 +1,71 @@
+! WZ boson production parameters
+mllmin 0.1d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS   ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   260000    ! pdf set for hadron 1 (LHA numbering)
+lhans2   260000    ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1  400000   ! number of calls for initializing the integration grid
+itmx1    4       ! number of iterations for initializing the integration grid
+ncall2   1000000     ! number of calls for computing the integral and finding upper bound
+itmx2    5  ! number of iterations for computing the integral and finding upper bound
+foldcsi   1    ! number of folds on csi integration
+foldy     1     ! number of folds on  y  integration
+foldphi   1      ! number of folds on phi integration
+nubound  1000000    ! number of bbarra calls to setup norm of upper bounding function
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#bornonly   0      ! (default 0) if 1 do Born only
+#testplots  0      ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+#manyseeds  1       ! Used to perform multiple runs with different random
+                   ! seeds in the same directory.
+                   ! If set to 1, the program asks for an integer j;
+                   ! The file pwgseeds.dat at line j is read, and the
+                   ! integer at line j is used to initialize the random
+                   ! sequence for the generation of the event.
+                   ! The event file is called pwgevents-'j'.lhe
+
+# Only leptonic decays
+lll 1
+
+#zerowidth 0         ! if 1 (true) use zero width approximatrion (default 0)
+#withinterference 1  ! if 1 (true) include interference for like flavour charged leptons
+#                    ! (default 1)
+#dronly 0        ! if 1 (true) only include double resonant diagrams (default 0)
+#!CKM matrix
+#diagCKM 0       ! if 1 (true) then diagonal CKM (default 0)
+#!anom couplings
+#delg1_z    0d0      ! Delta_g1(Z)
+#delg1_g    0d0      ! Delta_g1(Gamma)
+#lambda_z   0d0      ! Lambda(Z)
+#lambda_g   0d0      ! Lambda(gamma)
+#delk_g     0d0      ! Delta_K(Gamma)
+#delk_z     0d0      ! Delta_K(Z)
+#tevscale   2d0      ! Form-factor scale, in TeV
+
+pdfreweight 1
+storeinfo_rwgt 1   ! store info to allow for reweighting
+
+withnegweights 0
+


### PR DESCRIPTION
Powheg card for WZTo3LNu.
This is the same card as:
https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/WZTo3lNu_NNPDF30_13TeV/WZ_lllnu_NNPDF30_13TeV.input
but we lowered the minimum value for mll (Z boson leptons) to 0.1 GeV (which is the default value).
In this way most of the events produced are actually Wgamma* events, and we can obtain a NLO Wgamma* sample.