### PR TITLE
Fix LHAPDF iteration id; refine code style

### DIFF
--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -117,65 +117,65 @@ then
     grep -q "compute_rwgt 1" powheg.input.tmp ; test $? -eq 0 || fail_exit "Weights are not calculated!"
 
     echo -e "\ncomputing weights for 9 scale variations\n"
-    iteration=-1
+    iteration=0
     lastfile=2
     array=(1 2 0.5)
     counter=1000
     while [ $iteration -lt $lastfile ];
-      do
-      iteration=$(( iteration + 1 ))
-      scale1=${array[$iteration]}
-
-      iter=-1
-      last=2
-      while [ $iter -lt $last ];
-	do
-	iter=$(( iter + 1 ))
-	scale2=${array[$iter]}
-	rm -rf powheg.input	      
+    do
+        scale1=${array[$iteration]}
+        
+        iter=0
+        last=2
+        while [ $iter -lt $last ];
+	    do
+	        scale2=${array[$iter]}
+	        rm -rf powheg.input	      
 #	if (( $(bc <<< "$scale1 <= 2*$scale2") == 1 && $(bc <<< "$scale1 >= 0.5*$scale2") == 1 )); 
 #	    then 
-	echo -e "\n doing scale ${scale1}, ${scale2}\n"
-	sed -e 's/.*renscfact.*/renscfact '$scale1'd0/ ; s/.*facscfact.*/facscfact '$scale2'd0/' powheg.input.tmp > powheg.input
+	        echo -e "\n doing scale ${scale1}, ${scale2}\n"
+	        sed -e 's/.*renscfact.*/renscfact '$scale1'd0/ ; s/.*facscfact.*/facscfact '$scale2'd0/' powheg.input.tmp > powheg.input
 
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'muR=${scale1} muF=${scale2}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'scale_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'envelope'" >> powheg.input
+	        counter=$(( counter + 1 ))
+	        echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	        echo -e "lhrwgt_descr 'muR=${scale1} muF=${scale2}'" >> powheg.input
+	        echo -e "lhrwgt_group_name 'scale_variation'" >> powheg.input
+	        echo -e "lhrwgt_group_combine 'envelope'" >> powheg.input
 	
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${scale1}_${scale2}
+	        ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	        mv pwgevents-rwgt.lhe pwgevents.lhe
+	        mv powheg.input powheg.input.${scale1}_${scale2}
 #      fi;      
-      done
-    done
+	        iter=$(( iter + 1 ))
+        done
+
+        iteration=$(( iteration + 1 ))
+   done
 
 
-    echo -e "\ncomputing weights for 100 NNPDF3.0 variations\n"
+    echo -e "\ncomputing weights for 100 NNPDF3.0 nlo variations\n"
     iteration=260000
     lastfile=260100
     counter=2000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
 
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'gaussian'" >> powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'gaussian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
 
-
-    echo -e "\ncomputing weights for NNPDF 3.0 alphas=0.117 variation\n"
+    echo -e "\ncomputing weights for NNPDF 3.0 nlo alphas=0.117 variation\n"
     iteration=265000
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
@@ -205,27 +205,27 @@ then
     mv powheg.input powheg.input.${iteration}
 
 
-    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
-    iteration=13199
+    echo -e "\ncomputing weights for 56+1 CT14 nlo PDF variations\n"
+    iteration=13100
     lastfile=13156
     counter=3000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
-    echo -e "\ncomputing weights for CT14 alphas=0.117 variation\n"
+    echo -e "\ncomputing weights for CT14 nlo alphas=0.117 variation\n"
     iteration=13164
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
@@ -239,7 +239,7 @@ then
     mv pwgevents-rwgt.lhe pwgevents.lhe
     mv powheg.input powheg.input.${iteration}
 
-    echo -e "\ncomputing weights for CT14 alphas=0.119 variation\n"
+    echo -e "\ncomputing weights for CT14 nlo alphas=0.119 variation\n"
     iteration=13166
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
@@ -253,7 +253,7 @@ then
     mv pwgevents-rwgt.lhe pwgevents.lhe
     mv powheg.input powheg.input.${iteration}
  
-    echo -e "\ncomputing weights for CT10 central values\n"
+    echo -e "\ncomputing weights for CT10 nlo central values\n"
     iteration=11000
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
@@ -269,63 +269,63 @@ then
  
 
     echo -e "\ncomputing weights for 50+1 MMHT2014nlo68clas118 PDF variations\n"
-    iteration=25199
+    iteration=25200
     lastfile=25250
     counter=4000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
 
     echo -e "\ncomputing weights for 5 MMHT2014nlo68cl 5 alphas variations\n"
-    iteration=25259
+    iteration=25260
     lastfile=25264
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
-    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
-    iteration=13099
+    echo -e "\ncomputing weights for 56+1 CT14 nnlo PDF variations\n"
+    iteration=13000
     lastfile=13056
     counter=5000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
 

--- a/bin/Powheg/runcmsgrid_powhegjhugen.sh
+++ b/bin/Powheg/runcmsgrid_powhegjhugen.sh
@@ -106,7 +106,7 @@ fi
 
 
 cat powheg.input
-../pwhg_main &> log_${process}_${seed}.txt
+../pwhg_main &> log_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
 
 if [ "$produceWeights" == "true" ];
 then 
@@ -117,104 +117,143 @@ then
     grep -q "compute_rwgt 1" powheg.input.tmp ; test $? -eq 0 || fail_exit "Weights are not calculated!"
 
     echo -e "\ncomputing weights for 9 scale variations\n"
-    iteration=-1
+    iteration=0
     lastfile=2
     array=(1 2 0.5)
     counter=1000
     while [ $iteration -lt $lastfile ];
-      do
-      iteration=$(( iteration + 1 ))
-      scale1=${array[$iteration]}
-
-      iter=-1
-      last=2
-      while [ $iter -lt $last ];
-	do
-	iter=$(( iter + 1 ))
-	scale2=${array[$iter]}
-	rm -rf powheg.input	      
+    do
+        scale1=${array[$iteration]}
+        
+        iter=0
+        last=2
+        while [ $iter -lt $last ];
+	    do
+	        scale2=${array[$iter]}
+	        rm -rf powheg.input	      
 #	if (( $(bc <<< "$scale1 <= 2*$scale2") == 1 && $(bc <<< "$scale1 >= 0.5*$scale2") == 1 )); 
 #	    then 
-	echo -e "\n doing scale ${scale1}, ${scale2}\n"
-	sed -e 's/.*renscfact.*/renscfact '$scale1'd0/ ; s/.*facscfact.*/facscfact '$scale2'd0/' powheg.input.tmp > powheg.input
+	        echo -e "\n doing scale ${scale1}, ${scale2}\n"
+	        sed -e 's/.*renscfact.*/renscfact '$scale1'd0/ ; s/.*facscfact.*/facscfact '$scale2'd0/' powheg.input.tmp > powheg.input
 
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'muR=${scale1} muF=${scale2}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'scale_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'envelope'" >> powheg.input
+	        counter=$(( counter + 1 ))
+	        echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	        echo -e "lhrwgt_descr 'muR=${scale1} muF=${scale2}'" >> powheg.input
+	        echo -e "lhrwgt_group_name 'scale_variation'" >> powheg.input
+	        echo -e "lhrwgt_group_combine 'envelope'" >> powheg.input
 	
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${scale1}_${scale2}
+	        ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	        mv pwgevents-rwgt.lhe pwgevents.lhe
+	        mv powheg.input powheg.input.${scale1}_${scale2}
 #      fi;      
-      done
-    done
+	        iter=$(( iter + 1 ))
+        done
+
+        iteration=$(( iteration + 1 ))
+   done
 
 
-    echo -e "\ncomputing weights for 100 NNPDF3.0 variations\n"
+    echo -e "\ncomputing weights for 100 NNPDF3.0 nlo variations\n"
     iteration=260000
     lastfile=260100
     counter=2000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
 
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'gaussian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
 
-    echo -e "\ncomputing weights for 56+1 CT14 PDF variations\n"
-    iteration=13099
+    echo -e "\ncomputing weights for NNPDF 3.0 nlo alphas=0.117 variation\n"
+    iteration=265000
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'gaussian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+
+
+    echo -e "\ncomputing weights for NNPDF 3.0 alphas=0.119 variation\n"
+    iteration=266000
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'gaussian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+
+
+    echo -e "\ncomputing weights for 56+1 CT14 nlo PDF variations\n"
+    iteration=13100
     lastfile=13156
     counter=3000
     while [ $iteration -lt $lastfile ];
     do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
     done
 
-    echo -e "\ncomputing weights for 11 CT14 alphas variations\n"
-    iteration=13159
-    lastfile=13170
-    counter=4000
-    while [ $iteration -lt $lastfile ];
-    do
-	iteration=$(( iteration + 1 ))
-	echo -e "\n PDF set ${iteration}"
-	sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-	counter=$(( counter + 1 ))
-	echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-	echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-	echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-	echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+    echo -e "\ncomputing weights for CT14 nlo alphas=0.117 variation\n"
+    iteration=13164
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-	../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-	mv pwgevents-rwgt.lhe pwgevents.lhe
-	mv powheg.input powheg.input.${iteration}
-    done
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
 
-    echo -e "\ncomputing weights for CT10 central values\n"
+    echo -e "\ncomputing weights for CT14 nlo alphas=0.119 variation\n"
+    iteration=13166
+    echo -e "\n PDF set ${iteration}"
+    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+    counter=$(( counter + 1 ))
+    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+    mv pwgevents-rwgt.lhe pwgevents.lhe
+    mv powheg.input powheg.input.${iteration}
+ 
+    echo -e "\ncomputing weights for CT10 nlo central values\n"
     iteration=11000
     echo -e "\n PDF set ${iteration}"
     sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
@@ -224,68 +263,71 @@ then
     echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
     echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
+    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
     mv pwgevents-rwgt.lhe pwgevents.lhe
     mv powheg.input powheg.input.${iteration}
  
-    echo -e "\ncomputing weights for MSTW central values\n"
-    iteration=21100
+
+    echo -e "\ncomputing weights for 50+1 MMHT2014nlo68clas118 PDF variations\n"
+    iteration=25200
+    lastfile=25250
+    counter=4000
+    while [ $iteration -lt $lastfile ];
+    do
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
+    done
+
+
+    echo -e "\ncomputing weights for 5 MMHT2014nlo68cl 5 alphas variations\n"
+    iteration=25260
+    lastfile=25264
+    while [ $iteration -lt $lastfile ];
+    do
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
+    done
+
+    echo -e "\ncomputing weights for 56+1 CT14 nnlo PDF variations\n"
+    iteration=13000
+    lastfile=13056
     counter=5000
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
+    while [ $iteration -lt $lastfile ];
+    do
+	    echo -e "\n PDF set ${iteration}"
+	    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
+	    counter=$(( counter + 1 ))
+	    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
+	    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
+	    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
+	    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
 
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
+	    ../pwhg_main &>> reweightlog_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+	    mv pwgevents-rwgt.lhe pwgevents.lhe
+	    mv powheg.input powheg.input.${iteration}
+	    iteration=$(( iteration + 1 ))
+    done
 
-    echo -e "\ncomputing weights for NNPDF 2.3 central values\n"
-    iteration=244600
-    counter=6000
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
-
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
-
-
-    echo -e "\ncomputing weights for NNPDF 2.3 two alphas variation\n"
-    iteration=244400
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
-
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
-
-
-    iteration=244800
-    echo -e "\n PDF set ${iteration}"
-    sed -e 's/.*lhans1.*/lhans1 '$iteration'/ ; s/.*lhans2.*/lhans2 '$iteration'/' powheg.input.tmp > powheg.input
-    counter=$(( counter + 1 ))
-    echo -e "\nlhrwgt_id '${counter}'" >> powheg.input
-    echo -e "lhrwgt_descr 'PDF set = ${iteration}'" >> powheg.input
-    echo -e "lhrwgt_group_name 'PDF_variation'" >> powheg.input
-    echo -e "lhrwgt_group_combine 'hessian'" >> powheg.input
-
-    ../pwhg_main &>> reweightlog_${process}_${seed}.txt  
-    mv pwgevents-rwgt.lhe pwgevents.lhe
-    mv powheg.input powheg.input.${iteration}
 
     rm -rf powheg.input*
     sed -e "/#new weight/d" -e "/<wgt id='c'>/d" -e "/<weight id='c'>/d" pwgevents.lhe > pwgevents.lhe.tmp
@@ -293,6 +335,7 @@ then
     echo -e "\n finished computing weights ..\n" 
 fi
 
+xmllint --noout pwgevents.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on pwgevents.lhe"
 
 cat pwgevents.lhe | grep -v "Random number generator exit values" > ${file}_final.lhe
 
@@ -330,4 +373,3 @@ cp ${file}_final.lhe ${WORKDIR}/.
 echo "Output ready with ${file}_final.lhe at $WORKDIR"
 echo "End of job on " `date`
 exit 0;
-


### PR DESCRIPTION
This fix the bug on CT14 PDF as discussed on HN.
https://hypernews.cern.ch/HyperNews/CMS/get/generators/3014.html

Also as suggested by Luca, the coding style on the while loops is modified and re-indented.