### PR TITLE
ggH and VBF cards for HWW high mass

### DIFF
--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_reweightPMWW.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_reweightPMWW.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10 ReweightDecay WidthSchemeIn=3 ReadPMZZ

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M1000.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    1000       ! Higgs boson mass
+hwidth   647.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M1500.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    1500       ! Higgs boson mass
+hwidth   750.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M2000.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    2000       ! Higgs boson mass
+hwidth   1000.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M2500.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    2500       ! Higgs boson mass
+hwidth   1250.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M300.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    300       ! Higgs boson mass
+hwidth   8.43D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M3000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M3000.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    3000       ! Higgs boson mass
+hwidth   1500.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M350.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    350       ! Higgs boson mass
+hwidth   15.2D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M400.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    400       ! Higgs boson mass
+hwidth   29.2D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M450.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    450       ! Higgs boson mass
+hwidth   46.8D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M500.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    500       ! Higgs boson mass
+hwidth   68.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M550.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    550       ! Higgs boson mass
+hwidth   93.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M600.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    600       ! Higgs boson mass
+hwidth   123.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M650.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M650.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    650       ! Higgs boson mass
+hwidth   158.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M700.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    700       ! Higgs boson mass
+hwidth   199.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M750.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    750       ! Higgs boson mass
+hwidth   247.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M800.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    800       ! Higgs boson mass
+hwidth   304.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/VBF_H_NNPDF30_13TeV_M900.input
@@ -1,0 +1,82 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+! 131 cteq4m
+!  83 cteq4l
+!ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! To be set only if using LHA pdfs
+! 19150 cteq4m
+! 19170 cteq4l
+! 10050 cteq6m
+lhans1  260000         ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000         ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000  ! number of calls for initializing the integration grid
+itmx1    7     ! number of iterations for initializing the integration grid
+ncall2 75000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 175000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 1 ! default 0,
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     941046295      ! initialize random number sequence 
+#rand2     3      ! initialize random number sequence 
+
+hmass    900       ! Higgs boson mass
+hwidth   449.0D0    ! Higgs boson width
+hdecaymode -1   ! -1 no decay
+                ! 0 all decay channels open
+                ! 1-6 d dbar, u ubar,..., t tbar
+                ! 7-9 e+ e-, mu+ mu-, tau+ tau-
+                ! 10  W+W-
+                ! 11  ZZ
+                ! 12  gamma gamma
+
+complexpolescheme 1 ! switch on Complex Pole scheme
+masswindow 9999d0
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! Z+jet production
+#bornktmin  0d0    ! (default 0d0) kt min at Born level for jet in Z+jet 
+
+
+

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_reweightPMWW.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_reweightPMWW.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10 ReweightDecay WidthSchemeIn=3 ReadPMZZ

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1000.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    147.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 1000            ! Higgs boson mass
+hwidth 647.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M1500.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    197.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 1500            ! Higgs boson mass
+hwidth 750.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M2000.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    247.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 2000            ! Higgs boson mass
+hwidth 1000.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M2500.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    297.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 2500            ! Higgs boson mass
+hwidth 1250.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M300.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    77.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 300            ! Higgs boson mass
+hwidth 8.43D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M3000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M3000.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    347.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 3000            ! Higgs boson mass
+hwidth 1500.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M350.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    82.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 350            ! Higgs boson mass
+hwidth 15.2D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M400.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    87.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 400            ! Higgs boson mass
+hwidth 29.2D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M450.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    92.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 450            ! Higgs boson mass
+hwidth 46.8D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M500.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    97.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 500            ! Higgs boson mass
+hwidth 68.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M550.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    102.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 550            ! Higgs boson mass
+hwidth 93.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M600.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    107.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 600            ! Higgs boson mass
+hwidth 123.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M650.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M650.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    112.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 650            ! Higgs boson mass
+hwidth 158.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M700.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    117.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 700            ! Higgs boson mass
+hwidth 199.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M750.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    122.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 750            ! Higgs boson mass
+hwidth 247.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M800.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    127.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 800            ! Higgs boson mass
+hwidth 304.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M900.input
@@ -1,0 +1,89 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000     ! number of calls for initializing the integration grid
+itmx1  7      ! number of iterations for initializing the integration grid
+ncall2 75000     ! number of calls for computing the integral and finding upper bound
+itmx2  5      ! number of iterations for computing the integral and finding upper bound
+foldcsi  2    ! number of folds on csi integration
+foldy    5      ! number of folds on  y  integration
+foldphi  2    ! number of folds on phi integration
+nubound 50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0     ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#ptsupp     0d0   ! (default 0d0)  mass param for Born suppression factor (generation cut) If < 0 suppfact = 1
+#bornonly   0      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+#withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+#ptsqmin    0.8   ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    137.5d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+# mur,muf settings
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality; 
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+# When using 2 uncomment the following option
+# btlscalereal 1
+
+iseed    SEED    ! initialize random number sequence 
+#rand1    32      ! initialize random number sequence 
+#rand2    0      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+! allowed values are:  -1 all decay channels closed
+!                      0 all decay channels open
+!	               1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!	               7-9 e+ e-, mu+ mu-, tau+ tau-
+!		       10  W+W-
+!	               11  ZZ
+!	               12  gamma gamma
+! **** Mandatory parameters for SM or MW ****
+hmass 900            ! Higgs boson mass
+hwidth 449.0D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+!charmmass 1.5d0     ! char quark mass - if defined it enables the charm quark
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 0
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+bwshape 3 ! complex-pole scheme according to Passarino et al.


### PR DESCRIPTION
New POWHEG and JHUGen cards for ggH and VBF high mass signals for HWW, following what was done by HZZ.
The POWHEG cards are essentially the same as the old ones, the only difference is that the number of calls (ncall1 and ncall2) has been increased.
The new JHUGenV698 is used and this is the new card for ggH and VBF:
https://github.com/lviliani/genproductions/blob/5ae57ab331b20e11a25db397e7f78d7d4267efd2/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGenV698_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_reweightPMWW.input

