### PR TITLE
JHUGen

### DIFF
--- a/bin/JHUGen/cards/BulkGraviton/makecards.py
+++ b/bin/JHUGen/cards/BulkGraviton/makecards.py
@@ -1,8 +1,8 @@
 #MC plans as documented here:
 #https://indico.cern.ch/event/481417/contribution/7/attachments/1212251/1768492/High_mass_ZZ4l.pdf
 
-card = "Process=2 VegasNc0=1000000 VegasNc2=NEVT a1=1,0 a2=0,0 b2=0,0 b5=1,0 MReso=%(mass)i GaReso=%(width)i DecayMode1=%(decaymode1)i DecayMode2=%(decaymode2)i OffshellX=1 PChannel=%(pchannel)i LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED"
-card_narrow = "Process=2 VegasNc0=1000000 VegasNc2=NEVT a1=1,0 a2=0,0 b2=0,0 b5=1,0 MReso=%(mass)i GaReso=0.000001 DecayMode1=%(decaymode1)i DecayMode2=%(decaymode2)i OffshellX=0 PChannel=%(pchannel)i LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED"
+card = "Process=2 VegasNc0=1000000 VegasNc2=NEVT a1=1,0 a2=0,0 b2=0,0 b5=1,0 MReso=%(mass)i GaReso=%(width)i DecayMode1=%(decaymode1)i DecayMode2=%(decaymode2)i OffshellX=1 PChannel=%(pchannel)i LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED ReadCSmax"
+card_narrow = "Process=2 VegasNc0=1000000 VegasNc2=NEVT a1=1,0 a2=0,0 b2=0,0 b5=1,0 MReso=%(mass)i GaReso=0.000001 DecayMode1=%(decaymode1)i DecayMode2=%(decaymode2)i OffshellX=0 PChannel=%(pchannel)i LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED ReadCSmax"
 cardname = "Graviton2PB%(prod)sTo%(decaymode)s_%(width_forname)s_M-%(mass)i_13TeV-JHUgenV6.input"
 
 masses = [750, 800, 1200, 2000, 3000, 4000]

--- a/bin/JHUGen/cards/Zgamma/makecards.py
+++ b/bin/JHUGen/cards/Zgamma/makecards.py
@@ -1,4 +1,4 @@
-card = "Process={spin} PChannel={PChannel} VegasNc0=1000000 VegasNc2=NEVT MReso={mass} GaReso={width} DecayMode1={DecayMode1} DecayMode2={DecayMode2} {couplings} LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED"
+card = "Process={spin} PChannel={PChannel} VegasNc0=1000000 VegasNc2=NEVT MReso={mass} GaReso={width} DecayMode1={DecayMode1} DecayMode2={DecayMode2} {couplings} LHAPDF=NNPDF30_lo_as_0130/NNPDF30_lo_as_0130.info Seed=SEED ReadCSmax"
 cardname = "{spin_forname}{prod}To{decaymode}To{decaymode_final}_{width_forname}_M-{mass}_13TeV-JHUgenV6.input"
 
 masses = [300, 350, 400, 500, 600, 750, 900, 1200, 1500, 2000, 3000, 4000, 5000]

--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -51,9 +51,7 @@ job_file.write('sed "s@BASEDIR@%s_JHUGen@g"   runcmsgrid_template.sh > runcmsgri
 job_file.write('chmod +x runcmsgrid.sh \n')
 if "ReadCSmax" in command:
     #set up the grid now so it can be read
-    runcommand = command.replace("ReadCSmax", "")
-    job_file.write("nevt=%s \n" % (args1.nevents))
-    job_file.write("rnum=%s \n" % (args1.seed))
+    runcommand = command.replace("ReadCSmax", "").replace("NEVT", args1.nevents).replace("SEED", args1.seed)
     job_file.write("%s \n" % (runcommand))
 job_file.write('rm *.lhe \n')
 job_file.write('rm -r data/ \n')

--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -12,10 +12,9 @@ import ROOT
 aparser = argparse.ArgumentParser(description='Process benchmarks.')
 aparser.add_argument('-card'    ,'--card'      ,action='store' ,dest='card',default='JHUGen.input',help='card')
 aparser.add_argument('-name'    ,'--name'      ,action='store' ,dest='name'   ,default='ScalarVH'       ,help='name')
-aparser.add_argument('-q'       ,'--queue'     ,action='store' ,dest='queue'  ,default='8nm'            ,help='queue')
+aparser.add_argument('-s'       ,'--seed'      ,action='store' ,dest='seed'   ,default='123456'         ,help='random seed for grid generation')
+aparser.add_argument('-n'       ,'--nevents'   ,action='store' ,dest='nevents',default='100'            ,help='number of events for the test run after grid generation')
 args1 = aparser.parse_args()
-
-print args1.card,args1.name,args1.queue
 
 basedir=os.getcwd()
 #Start with the basics download MCFM and add the options we care  :
@@ -50,7 +49,14 @@ job_file.write('sed "s@Seed=SEED@Seed=\\$\\{rnum\\}@g"   runcmsgrid_template.sh 
 job_file.write('mv runcmsgrid.sh runcmsgrid_template.sh                        \n')
 job_file.write('sed "s@BASEDIR@%s_JHUGen@g"   runcmsgrid_template.sh > runcmsgrid.sh \n'  % (args1.name))
 job_file.write('chmod +x runcmsgrid.sh \n')
+if "ReadCSmax" in command:
+    #set up the grid now so it can be read
+    runcommand = command.replace("ReadCSmax", "")
+    job_file.write("nevt=%s \n" % (args1.nevents))
+    job_file.write("rnum=%s \n" % (args1.seed))
+    job_file.write("%s \n" % (runcommand))
 job_file.write('rm *.lhe \n')
+job_file.write('rm -r data/ \n')
 job_file.close()
 os.chmod('integrate.sh',0777)
 os.system('%s/%s_JHUGen/integrate.sh' % (basedir,args1.name))

--- a/bin/Powheg/examples/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/JHUGen.input
+++ b/bin/Powheg/examples/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/JHUGen.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=0 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=0 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HJ_MiNLO_NNLOPS_HWW2l2nu_NNPDF30_13TeV/JHUGen_HJ_MiNLO_NNLOPS_HWW2l2nu_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HJ_MiNLO_NNLOPS_HWW2l2nu_NNPDF30_13TeV/JHUGen_HJ_MiNLO_NNLOPS_HWW2l2nu_NNPDF30_13TeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_HZZ4L.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_HZZ4L.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HWJ_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_WH_ZZ4L_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HZJ_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ZH_HZZ2LX_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M1000GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M450GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M450GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=1 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M650GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_H_WW_M650GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=1 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M1000GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M450GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M450GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M650GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_WW_highmass_JHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_WW_M650GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M400GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/VBF_H/JHUGen_VBF_ZZ2l2nu_M600GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M1000GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M400GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/H_ZZ_2l2nu_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects/JHUGen_gg_H_ZZ2l2nu_M600GeV.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M450.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M550.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M750_NWA.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M750_NWA.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_VBF_H_WW2L2Nu_M900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_VBF_H_WWLNuQQ_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_VBF_H_WWLNuQQ_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_VBF_H_WWLNuQQ_M750_NWA.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_VBF_H_WWLNuQQ_M750_NWA.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_1500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=1500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=1500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=200 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=200 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_2000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=2000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=2000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_2500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=2500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=2500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=300 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=300 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=700 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=700 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=800 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=800 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_VBF_ZZ2l2nu_mH_900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=1 MReso=900 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=1 MReso=900 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Q_NNPDF30_13TeV/JHUGen_VBF_H_ZZ2L2Q_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ2L2Q_NNPDF30_13TeV/JHUGen_VBF_H_ZZ2L2Q_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=1 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=1 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M1500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M2000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M2500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M3000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M3000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=3000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=3000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M450.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M550.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L_M900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4Q_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4Q_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4Q_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4Q_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=1 DecayMode2=1 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=1 DecayMode2=1 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M105.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M105.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=105 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=105 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M450.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M550.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M650.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M650.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=650 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M750_NWA.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M750_NWA.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWW2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_WW2L2Nu_M900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffXVV=011 
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_gg_H_WWLNuQQ_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_gg_H_WWLNuQQ_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_gg_H_WWLNuQQ_M750_NWA.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HWWLNuQQ_NNPDF30_13TeV/JHUGen_gg_H_WWLNuQQ_M750_NWA.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=5 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_1500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_2000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_2500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Nu_NNPDF30_13TeV/JHUGen_gg_H_ZZ2l2nu_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=3 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=3 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Q_NNPDF30_13TeV/JHUGen_gg_H_ZZ2L2Q_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ2L2Q_NNPDF30_13TeV/JHUGen_gg_H_ZZ2L2Q_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=1 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=1 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M1000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M1000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=1000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M1500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M1500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=1500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M2000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M2000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=2000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M210.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M210.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=210 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M230.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M230.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=230 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M250.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M250.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=250 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M2500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M2500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=2500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M270.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M270.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=270 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M300.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M300.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=300 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M3000.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M3000.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=3000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=3000 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M350.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M350.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=350 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M400.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M400.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=400 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M450.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M450.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=450 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M500.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M500.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=500 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M550.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M550.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=550 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M600.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M600.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=600 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M700.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M700.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=700 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M800.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M800.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=800 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M900.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M900.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=900 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M91.1876.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_gg_H_ZZ4L_M91.1876.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=91.1876 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffXVV=011 
+Collider=1 PChannel=0 MReso=91.1876 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=8 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4Q_NNPDF30_13TeV/JHUGen_gg_H_ZZ4Q_M750.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_JHUGen_HZZ4Q_NNPDF30_13TeV/JHUGen_gg_H_ZZ4Q_M750.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=1 DecayMode2=1 OffXVV=011 
+Collider=1 PChannel=0 MReso=750 Process=0 Unweighted=1 DecayMode1=1 DecayMode2=1 OffshellX=0 

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M115.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M115.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=115 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M120.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M120.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=120 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M124.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M124.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=124 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M125.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M126.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M126.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=126 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M130.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M130.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=130 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M135.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M135.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=135 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M140.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M140.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=140 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M145.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M145.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=145 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M150.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M150.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=150 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M155.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M155.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=155 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M160.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M160.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=160 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M165.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M165.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=165 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M170.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M170.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=170 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M175.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M175.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=175 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M180.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M180.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=180 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M190.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M190.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=190 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M200.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/ttH_inclusive_JHUGen_HZZ2LX_NNPDF30_13TeV/JHUGen_ttH_HZZ2LX_M200.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffXVV=011
+Collider=1 PChannel=0 MReso=200 Process=0 Unweighted=1 DecayMode1=8 DecayMode2=9 OffshellX=0

--- a/bin/Powheg/production/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/JHUGen.input
+++ b/bin/Powheg/production/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/JHUGen.input
@@ -1,1 +1,1 @@
-Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=0 OffXVV=011 
+Collider=1 PChannel=0 Process=0 Unweighted=1 DecayMode1=0 DecayMode2=0 OffshellX=0 


### PR DESCRIPTION
- Fix all JHUGen input cards to be compatible with the newer JHUGen syntax
  - to prevent more people getting confused, if it's not allowed to change cards already used for production I can make this change just for the example cards
- Support generating the phase space ahead of time