### PR TITLE
some additional fixes and example for multiple pdf weights

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/examples/wplustest_5f_NLO/wplustest_5f_NLO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/examples/wplustest_5f_NLO/wplustest_5f_NLO_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a hash (#) are info or comments                *
 #                                                                      *
 #   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
 #***********************************************************************
 #
 #*******************                                                 
@@ -21,15 +24,19 @@
 #***********************************************************************
   tag_1     = run_tag ! name of the run 
 #***********************************************************************
-# Number of events (and their normalization) and the required          *
+# Number of LHE events (and their normalization) and the required      *
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-   250 = nevents ! Number of unweighted events requested 
+ 300 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
-    20 = nevt_job! Max number of events per job in event generation. 
+ 20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).
-average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
 #***********************************************************************
 # Number of points per itegration channel (ignored for aMC@NLO runs)   *
 #***********************************************************************
@@ -43,104 +50,113 @@ average = event_norm ! Normalize events to sum or average to the X sect.
 #***********************************************************************
 # Random number seed                                                   *
 #***********************************************************************
-     0    = iseed       ! rnd seed (0=assigned automatically=default))
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
 #***********************************************************************
 # Collider type and energy                                             *
 #***********************************************************************
-    1   = lpp1    ! beam 1 type (0 = no PDF)
-    1   = lpp2    ! beam 2 type (0 = no PDF)
- 6500   = ebeam1  ! beam 1 energy in GeV
- 6500   = ebeam2  ! beam 2 energy in GeV
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
 #***********************************************************************
 # PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
 #***********************************************************************
- lhapdf    = pdlabel   ! PDF set                                     
- 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+ lhapdf = pdlabel ! PDF set
+ 292200, 90000, 90200, 90400, 13100, 13164, 13166, 25200, 25260, 11000, 11067, 11069 = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
 #***********************************************************************
 # Include the NLO Monte Carlo subtr. terms for the following parton    *
 # shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
 # WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
 #***********************************************************************
   PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
 #***********************************************************************
 # Renormalization and factorization scales                             *
 # (Default functional form for the non-fixed scales is the sum of      *
-# the transverse masses of all final state particles and partons. This *
-# can be changed in SubProcesses/set_scales.f)                         *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
 #***********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.188   = muR_ref_fixed    ! fixed ren reference scale 
- 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
- 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
-#***********************************************************************
-# Renormalization and factorization scales (advanced and NLO options)  *
-#***********************************************************************
- F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
- 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
- 1        = muR_over_ref     ! ratio of current muR over reference muR
- 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
- 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
- 1        = QES_over_ref     ! ratio of current QES over reference QES
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
 #*********************************************************************** 
-# Reweight flags to get scale dependence and PDF uncertainty           *
-# For scale dependence: factor rw_scale_up/down around central scale   *
-# For PDF uncertainty: use LHAPDF with supported set                   *
+# Reweight variables for scale dependence and PDF uncertainty          *
 #***********************************************************************
- .true.   = reweight_scale   ! reweight to get scale dependence
-  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
-  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
-  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
-  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
- .true.  = reweight_PDF     ! reweight to get PDF uncertainty
- 292201   = PDF_set_min      ! First of the error PDF sets 
- 292302   = PDF_set_max      ! Last of the error PDF sets
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ True = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
 #***********************************************************************
-# Merging - WARNING! Applies merging only at the hard-event level.     *
-# After showering an MLM-type merging should be applied as well.       *
-# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
 #***********************************************************************
- 0        = ickkw            ! 0 no merging, 3 FxFx merging
+ False = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 0        = ickkw
 #***********************************************************************
 #
 #***********************************************************************
-# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
 #***********************************************************************
- 15  = bwcutoff
+ 15.0  = bwcutoff
 #***********************************************************************
-# Cuts on the jets                                                     *
-# Jet clustering is performed by FastJet.
-# When matching to a parton shower, these generation cuts should be    *
-# considerably softer than the analysis cuts.                          *
-# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
 #***********************************************************************
-   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
- 0.7  = jetradius ! The radius parameter for the jet algorithm
-  10  = ptj       ! Min jet transverse momentum
-  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
 #***********************************************************************
 # Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
-# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
 #***********************************************************************
-   0  = ptl     ! Min lepton transverse momentum
-  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
-   0  = drll    ! Min distance between opposite sign lepton pairs
-   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
-   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
-  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
 #***********************************************************************
-# Photon-isolation cuts, according to hep-ph/9801442                   *
-# When ptgmin=0, all the other parameters are ignored                  *
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
 #***********************************************************************
-  20  = ptgmin    ! Min photon transverse momentum
-  -1  = etagamma  ! Max photon abs(pseudo-rap)
- 0.4  = R0gamma   ! Radius of isolation code
- 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
- 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
 #***********************************************************************
-# Maximal PDG code for quark to be considered a jet when applying cuts.*
-# At least all massless quarks of the model should be included here.   *
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
 #***********************************************************************
- 5 = maxjetflavor
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
 #***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/patches/0001-add-additional-restrict-files-for-sm-models.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0001-add-additional-restrict-files-for-sm-models.patch
@@ -1,7 +1,7 @@
 From 632805b6eaaae6dcea6fb716b66c61806faa6beb Mon Sep 17 00:00:00 2001
 From: Josh Bendavid <Josh.Bendavid@cern.ch>
 Date: Mon, 27 Jun 2016 18:53:27 +0200
-Subject: [PATCH 1/5] add additional restrict files for sm models
+Subject: [PATCH 1/8] add additional restrict files for sm models
 
 ---
  .../restrict_lepton_masses_no_lepton_yukawas.dat   |   65 ++++++++++++++++++++

--- a/bin/MadGraph5_aMCatNLO/patches/0002-skip-modification-of-masses-at-NLO-for-pythia8-since.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0002-skip-modification-of-masses-at-NLO-for-pythia8-since.patch
@@ -1,7 +1,7 @@
 From db33b2369c7f3bc3ab84575ed500b45612cccf53 Mon Sep 17 00:00:00 2001
 From: Josh Bendavid <Josh.Bendavid@cern.ch>
 Date: Mon, 27 Jun 2016 19:02:12 +0200
-Subject: [PATCH 2/5] skip modification of masses at NLO for pythia8 since this is unnecessary and can cause kinematic issues
+Subject: [PATCH 2/8] skip modification of masses at NLO for pythia8 since this is unnecessary and can cause kinematic issues
 
 ---
  Template/NLO/SubProcesses/MCmasses_PYTHIA8.inc |   22 +++++++++++-----------

--- a/bin/MadGraph5_aMCatNLO/patches/0003-completely-remove-possible-execution-of-decay-replac.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0003-completely-remove-possible-execution-of-decay-replac.patch
@@ -1,7 +1,7 @@
 From 434a2734d923a29d02934bd52244d6dac3ac8326 Mon Sep 17 00:00:00 2001
 From: Josh Bendavid <Josh.Bendavid@cern.ch>
 Date: Mon, 27 Jun 2016 19:02:53 +0200
-Subject: [PATCH 3/5] completely remove possible execution of decay, replace and addmasses for LO gridpacks
+Subject: [PATCH 3/8] completely remove possible execution of decay, replace and addmasses for LO gridpacks
 
 ---
  Template/LO/bin/internal/Gridpack/run.sh |   38 ------------------------------

--- a/bin/MadGraph5_aMCatNLO/patches/0004-fix-dependency-of-ninja-installation-on-current-dire.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0004-fix-dependency-of-ninja-installation-on-current-dire.patch
@@ -1,7 +1,7 @@
 From 11fbdc8fd25669f94c770bf85253a8c2823ccde6 Mon Sep 17 00:00:00 2001
 From: Josh Bendavid <Josh.Bendavid@cern.ch>
 Date: Mon, 27 Jun 2016 19:08:19 +0200
-Subject: [PATCH 4/5] fix dependency of ninja installation on current directory
+Subject: [PATCH 4/8] fix dependency of ninja installation on current directory
 
 ---
  madgraph/iolibs/export_v4.py |    5 +++--

--- a/bin/MadGraph5_aMCatNLO/patches/0005-add-rsync-based-submit2-functionality-for-lsf-plus-v.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0005-add-rsync-based-submit2-functionality-for-lsf-plus-v.patch
@@ -1,7 +1,7 @@
 From 556b9a5288351fb2730cc9b71ea69a583201c4b7 Mon Sep 17 00:00:00 2001
 From: Josh Bendavid <Josh.Bendavid@cern.ch>
 Date: Mon, 27 Jun 2016 19:10:11 +0200
-Subject: [PATCH 5/5] add rsync-based submit2 functionality for lsf, plus various lsf robustness fixes and minor condor fixes
+Subject: [PATCH 5/8] add rsync-based submit2 functionality for lsf, plus various lsf robustness fixes and minor condor fixes
 
 ---
  madgraph/various/cluster.py |  273 ++++++++++++++++++++++++++++++++++++++++---

--- a/bin/MadGraph5_aMCatNLO/patches/0006-fix-loop-indices-in-reweight.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0006-fix-loop-indices-in-reweight.patch
@@ -1,0 +1,41 @@
+From 5bace9c85037528f39a7c14c3c4a4247f2e5df70 Mon Sep 17 00:00:00 2001
+From: Josh Bendavid <Josh.Bendavid@cern.ch>
+Date: Tue, 28 Jun 2016 22:49:12 +0200
+Subject: [PATCH 6/8] fix loop indices in reweight
+
+---
+ madgraph/interface/amcatnlo_run_interface.py |    8 ++++----
+ 1 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/madgraph/interface/amcatnlo_run_interface.py b/madgraph/interface/amcatnlo_run_interface.py
+index b540cbf..0e1277a 100755
+--- a/madgraph/interface/amcatnlo_run_interface.py
++++ b/madgraph/interface/amcatnlo_run_interface.py
+@@ -3623,20 +3623,20 @@ RESTART = %(mint_mode)s
+             with open(pjoin(self.me_dir, 'SubProcesses', path, 'scale_pdf_dependence.dat'),'r') as f:
+                 data_line=f.readline()
+                 if "scale variations:" in data_line:
+-                    for i,scale in enumerate(self.run_card['dynamical_scale_choice']):
++                    for j,scale in enumerate(self.run_card['dynamical_scale_choice']):
+                         data_line = f.readline().split()
+                         scales_this = [float(val)*evt_wghts[i] for val in f.readline().replace("D", "E").split()]
+                         try:
+-                            scales[i] = [a + b for a, b in zip(scales[i], scales_this)]
++                            scales[j] = [a + b for a, b in zip(scales[j], scales_this)]
+                         except IndexError:
+                             scales+=[scales_this]
+                     data_line=f.readline()
+                 if "pdf variations:" in data_line:
+-                    for i,pdf in enumerate(self.run_card['lhaid']):
++                    for j,pdf in enumerate(self.run_card['lhaid']):
+                         data_line = f.readline().split()
+                         pdfs_this = [float(val)*evt_wghts[i] for val in f.readline().replace("D", "E").split()]
+                         try:
+-                            pdfs[i] = [a + b for a, b in zip(pdfs[i], pdfs_this)]
++                            pdfs[j] = [a + b for a, b in zip(pdfs[j], pdfs_this)]
+                         except IndexError:
+                             pdfs+=[pdfs_this]
+ 
+-- 
+1.7.1
+

--- a/bin/MadGraph5_aMCatNLO/patches/0007-Fix-in-PDF-reweighting-NLO-process-generation-if-a-P.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0007-Fix-in-PDF-reweighting-NLO-process-generation-if-a-P.patch
@@ -1,0 +1,60 @@
+From e6b9ea1743a9343117e090f1af711680c3498539 Mon Sep 17 00:00:00 2001
+From: Rikkert Frederix <frederix@physik.uzh.ch>
+Date: Tue, 28 Jun 2016 12:26:43 +0200
+Subject: [PATCH 7/8] Fix in PDF reweighting (NLO process generation) if a PDF set has no
+ error members, while reweight_pdf was set to True for that set.
+
+---
+ Template/NLO/Source/setrun.f                     |    4 ++++
+ Template/NLO/SubProcesses/madfks_plot.f          |    4 ++++
+ Template/NLO/SubProcesses/reweight_xsec_events.f |    4 ++++
+ 3 files changed, 12 insertions(+), 0 deletions(-)
+
+diff --git a/Template/NLO/Source/setrun.f b/Template/NLO/Source/setrun.f
+index 77bc48b..239150a 100644
+--- a/Template/NLO/Source/setrun.f
++++ b/Template/NLO/Source/setrun.f
+@@ -204,6 +204,10 @@ C       Fill common block for Les Houches init info
+ c fill the nmemPDF(i) array with the number of PDF error set. This we
+ c get from LHAPDF.
+          call numberPDFm(1,nmemPDF(1))
++         if (nmemPDF(1).eq.1) then
++            nmemPDF(1)=0
++            lpdfvar(1)=0
++         endif
+       else
+          nmemPDF(1)=0
+       endif
+diff --git a/Template/NLO/SubProcesses/madfks_plot.f b/Template/NLO/SubProcesses/madfks_plot.f
+index 4a4bb5b..c5c8b7c 100644
+--- a/Template/NLO/SubProcesses/madfks_plot.f
++++ b/Template/NLO/SubProcesses/madfks_plot.f
+@@ -66,6 +66,10 @@ c     to "setrun")
+                call initpdfsetbynamem(nn,lhaPDFsetname(nn))
+                if (lpdfvar(nn)) then
+                   call numberPDFm(nn,nmemPDF(nn))
++                  if (nmemPDF(nn).eq.1) then
++                     nmemPDF(nn)=0
++                     lpdfvar(nn)=.false.
++                  endif
+                else
+                   nmemPDF(nn)=0
+                endif
+diff --git a/Template/NLO/SubProcesses/reweight_xsec_events.f b/Template/NLO/SubProcesses/reweight_xsec_events.f
+index 512c6a1..54fd9f6 100644
+--- a/Template/NLO/SubProcesses/reweight_xsec_events.f
++++ b/Template/NLO/SubProcesses/reweight_xsec_events.f
+@@ -87,6 +87,10 @@ c to "setrun")
+                call initpdfsetbynamem(nn,lhaPDFsetname(nn))
+                if (lpdfvar(nn)) then
+                   call numberPDFm(nn,nmemPDF(nn))
++                  if (nmemPDF(nn).eq.1) then
++                     nmemPDF(nn)=0
++                     lpdfvar(nn)=.false.
++                  endif
+                else
+                   nmemPDF(nn)=0
+                endif
+-- 
+1.7.1
+

--- a/bin/MadGraph5_aMCatNLO/patches/0008-allow-for-reweighting-with-up-to-25-PDF-sets-for-NLO.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0008-allow-for-reweighting-with-up-to-25-PDF-sets-for-NLO.patch
@@ -1,0 +1,60 @@
+From ddfc18a9d88b70282ad7322450e8ff8578062874 Mon Sep 17 00:00:00 2001
+From: Josh Bendavid <Josh.Bendavid@cern.ch>
+Date: Tue, 28 Jun 2016 23:03:49 +0200
+Subject: [PATCH 8/8] allow for reweighting with up to 25 PDF sets (for NLO process generation)
+
+---
+ Template/LO/Source/make_opts            |    8 ++++----
+ Template/NLO/SubProcesses/reweight0.inc |    2 +-
+ madgraph/various/banner.py              |    4 ++--
+ 3 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Template/LO/Source/make_opts b/Template/LO/Source/make_opts
+index 92a3fe4..a2c75f7 100644
+--- a/Template/LO/Source/make_opts
++++ b/Template/LO/Source/make_opts
+@@ -1,9 +1,9 @@
+ DEFAULT_F2PY_COMPILER=f2py
+ DEFAULT_F_COMPILER=gfortran
+-MACFLAG=-mmacosx-version-min=10.7
+-DEFAULT_CPP_COMPILER=clang
+-STDLIB=-lc++
+-STDLIB_FLAG=-stdlib=libc++
++MACFLAG=
++DEFAULT_CPP_COMPILER=g++
++STDLIB=-lstdc++
++STDLIB_FLAG=
+ #end_of_make_opts_variables
+ # Rest of the makefile
+ 
+diff --git a/Template/NLO/SubProcesses/reweight0.inc b/Template/NLO/SubProcesses/reweight0.inc
+index 5329885..5907f1f 100644
+--- a/Template/NLO/SubProcesses/reweight0.inc
++++ b/Template/NLO/SubProcesses/reweight0.inc
+@@ -71,7 +71,7 @@ c
+ c New format to allow for multiple PDF sets and scales (both functional form
+ c and normal)
+       integer    maxPDFsets,   maxdynscales
+-      parameter (maxPDFsets=10,maxdynscales=10)
++      parameter (maxPDFsets=25,maxdynscales=10)
+       integer lhaPDFid(0:maxPDFsets),nmemPDF(maxPDFsets)
+      $     ,dyn_scale(0:maxdynscales)
+       logical lscalevar(maxdynscales),lpdfvar(maxPDFsets)
+diff --git a/madgraph/various/banner.py b/madgraph/various/banner.py
+index 9378184..e8ce9b5 100755
+--- a/madgraph/various/banner.py
++++ b/madgraph/various/banner.py
+@@ -2112,8 +2112,8 @@ class RunCardNLO(RunCard):
+             raise InvalidRunCard, "'reweight_scale' and 'dynamical_scale_choice' lists should have the same length"
+         if len(self['dynamical_scale_choice']) > 10 :
+             raise InvalidRunCard, "Length of list for 'dynamical_scale_choice' too long: max is 10."
+-        if len(self['lhaid']) > 10 :
+-            raise InvalidRunCard, "Length of list for 'lhaid' too long: max is 10."
++        if len(self['lhaid']) > 25 :
++            raise InvalidRunCard, "Length of list for 'lhaid' too long: max is 25."
+         if len(self['rw_rscale']) > 9 :
+             raise InvalidRunCard, "Length of list for 'rw_rscale' too long: max is 9."
+         if len(self['rw_fscale']) > 9 :
+-- 
+1.7.1
+


### PR DESCRIPTION
So for only wplustest_5f_NLO is updated for multiple pdf weights.

Central value is left as nnpdf for now.

Included sets are
292200	NNPDF30_nlo_nf_5_pdfas
90000	PDF4LHC15_nlo_mc_pdfas
90200	PDF4LHC15_nlo_100_pdfas
90400	PDF4LHC15_nlo_30_pdfas
13100	CT14nlo
13164	CT14nlo_as_0117
13166	CT14nlo_as_0119
25200	MMHT2014nlo68clas118
25260	MMHT2014nlo_asmzsmallrange
11000	CT10nlo
11067	CT10nlo_as_0117
11069	CT10nlo_as_0119

If the central value is to shift to pdf4lhc15 then we can just change the order.  (The sample is generated with the first in the list for the central value.)

Important point (up for discussion) is that in this list the version of MMHT included is the one with alpha_s = 0.118, consistent with the other sets.  This is the one which is used as input to pdf4lhc15.  There is also a different set (25100 MMHT2014nlo68cl) which uses alphas=0.120, which I believe is the value preferred by the MMHT fit and/or authors.  Worst case scenario would be to add this in addition.

Note also that the 4fs case will need a slightly different list, keeping in addition at least the PDF4LHC15 5fs sets to allow for evaluation of correlations.  Possibly also other 5fs sets, to be discussed.
