### PR TITLE
Point to May 2016 version of powheg source

### DIFF
--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -315,7 +315,7 @@ if [[ -s ./JHUGen.input ]]; then
 fi
 
 ### retrieve the powheg source tar ball
-export POWHEGSRC=powhegboxV2_Mar2016.tar.gz 
+export POWHEGSRC=powhegboxV2_May2016.tar.gz 
 
 echo 'D/L POWHEG source...'
 


### PR DESCRIPTION
The source tarball of powheg checked out in May was put in the official directory. Just now we've tested some example processes and should point to it.