### PR TITLE
Powheg VBF_Wp_Wm runtype 1 card

### DIFF
--- a/bin/Powheg/production/VBF_Wp_Wm/powheg-runtype1.input
+++ b/bin/Powheg/production/VBF_Wp_Wm/powheg-runtype1.input
@@ -1,0 +1,90 @@
+! Production parameter for VBF W+ W- production 
+vdecaymodeWp -11  ! PDG code for charged decay product of W+ vector boson (-11:e+;-13 mu+ ...)  
+vdecaymodeWm +13  ! PDG code for charged decay product of W- vector boson ( 11:e-; 13:mu-;...)  
+hmass 125.d0      ! mass of the HIggs boson [GeV]
+hwidth 0.00407d0  ! width of the Higgs boson [GeV]
+wmass 80.419d0    ! mass of the W boson [GeV]
+wwidth 2.099d0    ! width of the W boson [GeV]
+
+numevts 5000      ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+!ndns1 131        ! pdf set for hadron 1 (mlm numbering)
+!ndns2 131        ! pdf set for hadron 2 (mlm numbering)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+! 10050 cteq6m
+! 10042 cteq6l with LO alphas (corr. to vbfnlo LO set)
+! 10041 cteq6l with NLO alphas
+! 21000 MSTW2008 LO
+! 21100 MSTW2008 NLO
+lhans1  260000      ! pdf set for hadron 1 (LHA numbering)
+lhans2  260000      ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+skipbtlgrid 0     ! default 0; if 1 skip calculation of btlgrid  
+skiprmngrid 0     ! default 0; if 1 skip calculation of rmngrid  
+
+ncall1  50000   ! number of calls for initializing the integration grid
+itmx1    1      ! number of iterations for initializing the integration grid
+ncall2  25000   ! number of calls for computing the integral and finding upper bound
+itmx2    1      ! number of iterations for computing the integral and finding upper bound
+foldcsi   1     ! number of folds on csi integration
+foldy     1     ! number of folds on  y  integration
+foldphi   1     ! number of folds on phi integration
+nubound 5000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1      ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0    ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+#renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+#facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+bornonly   0       ! (default 0) if 1 do Born only
+smartsig   1       ! (default 1) remember equal amplitudes (0 do not remember)
+#withsubtr  0      ! (default 1) subtract real counterterms (0 do not subtract)
+withdamp    1      ! (default 0, do not use) use Born-zero damping factor
+bornsuppfact 1     ! (default 0, do not use) use Born suppression factor
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+#testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+#hfact    100d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+#testsuda  1       ! (default 0, do not test) test Sudakov form factor
+#radregion 1       ! (default all regions) only generate radiation in the selected singular region  
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+
+#iseed    12345    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+#iupperisr 1 ! (default 1) choice of ISR upper bounding functional form 
+#iupperfsr 2 ! (default 2) choice of FSR upper bounding functional form 
+
+
+manyseeds  1       ! Used to perform multiple runs with different random
+                   ! seeds in the same directory.
+                   ! If set to 1, the program asks for an integer j;
+                   ! The file pwgseeds.dat at line j is read, and the
+                   ! integer at line j is used to initialize the random
+                   ! sequence for the generation of the event.
+                   ! The event file is called pwgevents-'j'.lhe
+
+
+#fakevirt 1	   ! uses Born for determining virt. grid
+withnegweights 1   ! default 1 allow negative weights
+runningscales 0	   ! default 0 (no running scales); 1&2 use running scales
+btlscalereal  1    ! flag for running scales
+btlscalect 1       ! flag for running scales
+ww_res_type    1   ! 1:WW continuum; 2:Higgs resonance
+#fat_jet        0  ! select fat jet analysis
+storeinfo_rwgt 1   ! store info for reweighting events 
+xgriditeration 1   ! identifier for grid generation
+parallelstage  1   ! identifier for parallel running stages


### PR DESCRIPTION
The powheg card is the same as the default one in the POWHEG-BOX-V2 for this process with updated parameters for the energy of the beams, pdf sets and hwidth.