### PR TITLE
Fixed output name for WZTo2Q2Nu cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/WZTo2Q2Nu01j_5f_NLO_FXFX/WZTo2Q2Nu01j_5f_NLO_FXFX_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/WZTo2Q2Nu01j_5f_NLO_FXFX/WZTo2Q2Nu01j_5f_NLO_FXFX_madspin_card.dat
@@ -14,8 +14,8 @@
 set ms_dir ./madspingrid
 
 #initialization parameters
- set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
- set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
 
 # BW_cut = 40 required by Hbb
 set BW_cut 40                # cut on how far the particle can be off-shell

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/WZTo2Q2Nu01j_5f_NLO_FXFX/WZTo2Q2Nu01j_5f_NLO_FXFX_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/WZTo2Q2Nu01j_5f_NLO_FXFX/WZTo2Q2Nu01j_5f_NLO_FXFX_proc_card.dat
@@ -11,5 +11,5 @@ define V = w+ w-
 generate p p > V vl vl~ [QCD] @0
 add process p p > V vl vl~ j [QCD] @1
 
-output ZZTo2Q2Nu01j_5f_NLO_FXFX -nojpeg
+output WZTo2Q2Nu01j_5f_NLO_FXFX -nojpeg
 


### PR DESCRIPTION
Output process name wasn't matching the sample name