### PR TITLE
Nnlops hj

### DIFF
--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -985,7 +985,7 @@ if __name__ == "__main__":
         os.system('rm -rf JHUGen.input')
         inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
         if not os.path.exists(inputJHUGen) :
-            os.system('wget --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
+            os.system('wget --quiet --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
 
             if os.path.exists('JHUGen.input') :
                 os.system('cp -p JHUGen.input '+args.folderName+'/.')

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -494,6 +494,12 @@ fi
 
 echo 'Compiling pwhg_main...'
 pwd
+if [ "$process" = "HJ" ]; then
+  echo "fixing q2min determination for HJ"
+  # avoid accessing member 1 for q2min determination. Use member 0, as member 1 may not be available
+  sed -i "s/getq2min(1,tmp)/getq2min(0,tmp)/g" setlocalscales.f
+fi  
+
 
 make pwhg_main || fail_exit "Failed to compile pwhg_main"
 
@@ -526,9 +532,6 @@ if [ "$process" = "HJ" ]; then
 
   cd ${WORKDIR}/${name}/POWHEG-BOX/HJ
  
-  # avoid accessing member 1 for q2min determination. Use member 0, as member 1 may not be available
-  sed -i "s/getq2min(1,tmp)/getq2min(0,tmp)/g" setlocalscales.f
-
   cp Makefile Makefile.orig
   cat Makefile.orig | sed -e "s#ANALYSIS=.\+#ANALYSIS=NNLOPS#g" |sed -e "s#\$(shell \$(LHAPDF_CONFIG) --libdir)#$(scram tool info lhapdf | grep LIBDIR | cut -d "=" -f2)#g" | sed -e "s#FASTJET_CONFIG=.\+#FASTJET_CONFIG=$(scram tool info fastjet | grep BASE | cut -d "=" -f2)/bin/fastjet-config#g" | sed -e "s#NNLOPSREWEIGHTER+=  fastjetfortran.o#NNLOPSREWEIGHTER+=  fastjetfortran.o pwhg_bookhist-multi.o#g" > Makefile
   make nnlopsreweighter || fail_exit "Failed to compile nnlopsreweighter"

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -330,8 +330,8 @@ if [[ -s ./JHUGen.input ]]; then
   jhugen=$(expr $jhugen + 1)
   echo "JHUGen activated!"
   #for decay weights in H->WW and H->ZZ
-  wget https://github.com/hroskes/genproductions/blob/master/bin/JHUGen/Pdecay/PMWWdistribution.out
-  wget https://github.com/hroskes/genproductions/blob/master/bin/JHUGen/Pdecay/PMZZdistribution.out
+  wget https://github.com/hroskes/genproductions/raw/master/bin/JHUGen/Pdecay/PMWWdistribution.out 
+  wget https://github.com/hroskes/genproductions/raw/master/bin/JHUGen/Pdecay/PMZZdistribution.out 
 
   match=`grep -xq "DecayMode1=10" JHUGen.input`
   if grep -q "DecayMode1=10" JHUGen.input || grep -q "DecayMode1=11" JHUGen.input; then 

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -333,11 +333,6 @@ if [[ -s ./JHUGen.input ]]; then
   wget https://github.com/hroskes/genproductions/raw/master/bin/JHUGen/Pdecay/PMWWdistribution.out 
   wget https://github.com/hroskes/genproductions/raw/master/bin/JHUGen/Pdecay/PMZZdistribution.out 
 
-  match=`grep -xq "DecayMode1=10" JHUGen.input`
-  if grep -q "DecayMode1=10" JHUGen.input || grep -q "DecayMode1=11" JHUGen.input; then 
-    echo "This is a WW decay channel, using the corresponfind decay weights"
-    mv PMWWdistribution.out PMZZdistribution.out
-  fi
 fi
 
 ### retrieve the powheg source tar ball

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -748,6 +748,7 @@ sed -i 's/# Check if /sed -i \"s#.*xgriditeration.*#xgriditeration 1#g\" powheg.
 sed -i 's/# Check if /rm -rf pwgseeds.dat; for ii in $(seq 1 9999); do echo $ii >> pwgseeds.dat; done\\n\\n# Check if /g' runcmsgrid_par.sh
 sed -i 's/^..\/pwhg_main/echo \${seed} | ..\/pwhg_main/g' runcmsgrid_par.sh
 sed -i 's/\.lhe/\${idx}.lhe/g' runcmsgrid_par.sh
+sed -i 's/pwgevents.lhe/fornnlops/g' nnlopsreweighter.input
 sed -i "s/^process/idx=-\`echo \${seed} | awk \'{printf \\"%04d\\", \$1}\'\` \\nprocess/g" runcmsgrid_par.sh
 
 chmod 755 runcmsgrid_par.sh
@@ -968,10 +969,11 @@ if __name__ == "__main__":
         os.system('mkdir -p '+rootfolder+'/'+args.folderName)
         os.system('cp -p '+args.inputTemplate.split('/')[-1]+' '+args.folderName+'/powheg.input')
 
-        os.system('rm -rf JHUGen.input')
+        #os.system('rm -rf JHUGen.input')
         inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
         if not os.path.exists(inputJHUGen) :
-            os.system('wget --quiet --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
+            os.system('wget --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
+
             if os.path.exists('JHUGen.input') :
                 os.system('cp -p JHUGen.input '+args.folderName+'/.')
         else :

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -525,6 +525,10 @@ if [ "$process" = "HJ" ]; then
   gfortran -o mergedata mergedata.f
 
   cd ${WORKDIR}/${name}/POWHEG-BOX/HJ
+ 
+  # avoid accessing member 1 for q2min determination. Use member 0, as member 1 may not be available
+  sed -i "s/getq2min(1,tmp)/getq2min(0,tmp)/g" setlocalscales.f
+
   cp Makefile Makefile.orig
   cat Makefile.orig | sed -e "s#ANALYSIS=.\+#ANALYSIS=NNLOPS#g" |sed -e "s#\$(shell \$(LHAPDF_CONFIG) --libdir)#$(scram tool info lhapdf | grep LIBDIR | cut -d "=" -f2)#g" | sed -e "s#FASTJET_CONFIG=.\+#FASTJET_CONFIG=$(scram tool info fastjet | grep BASE | cut -d "=" -f2)/bin/fastjet-config#g" | sed -e "s#NNLOPSREWEIGHTER+=  fastjetfortran.o#NNLOPSREWEIGHTER+=  fastjetfortran.o pwhg_bookhist-multi.o#g" > Makefile
   make nnlopsreweighter || fail_exit "Failed to compile nnlopsreweighter"

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -986,7 +986,6 @@ if __name__ == "__main__":
         inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
         if not os.path.exists(inputJHUGen) :
             os.system('wget --quiet --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
-
             if os.path.exists('JHUGen.input') :
                 os.system('cp -p JHUGen.input '+args.folderName+'/.')
         else :

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -982,10 +982,8 @@ if __name__ == "__main__":
         os.system('mkdir -p '+rootfolder+'/'+args.folderName)
         os.system('cp -p '+args.inputTemplate.split('/')[-1]+' '+args.folderName+'/powheg.input')
 
-        #os.system('rm -rf JHUGen.input')
-        #inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
-        #print powInputName
-        inputJHUGen='JHUGen.input'
+        os.system('rm -rf JHUGen.input')
+        inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
         if not os.path.exists(inputJHUGen) :
             os.system('wget --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
 

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -329,6 +329,15 @@ jhugen=0
 if [[ -s ./JHUGen.input ]]; then
   jhugen=$(expr $jhugen + 1)
   echo "JHUGen activated!"
+  #for decay weights in H->WW and H->ZZ
+  wget https://github.com/hroskes/genproductions/blob/master/bin/JHUGen/Pdecay/PMWWdistribution.out
+  wget https://github.com/hroskes/genproductions/blob/master/bin/JHUGen/Pdecay/PMZZdistribution.out
+
+  match=`grep -xq "DecayMode1=10" JHUGen.input`
+  if grep -q "DecayMode1=10" JHUGen.input || grep -q "DecayMode1=11" JHUGen.input; then 
+    echo "This is a WW decay channel, using the corresponfind decay weights"
+    mv PMWWdistribution.out PMZZdistribution.out
+  fi
 fi
 
 ### retrieve the powheg source tar ball
@@ -452,6 +461,7 @@ if [ $jhugen = 1 ]; then
   mkdir -p ${WORKDIR}/${name}
   cp -p JHUGen ${WORKDIR}/${name}/.
   cp -pr pdfs ${WORKDIR}/${name}/.
+
 
   cd ..
 fi
@@ -606,6 +616,7 @@ echo 'Compiling finished...'
 
 if [ $jhugen = 1 ]; then
   cp -p ${cardj} .
+  
   if [ ! -e ${WORKDIR}/runcmsgrid_powhegjhugen.sh ]; then
    fail_exit "Did not find " ${WORKDIR}/runcmsgrid_powhegjhugen.sh 
   fi
@@ -970,7 +981,9 @@ if __name__ == "__main__":
         os.system('cp -p '+args.inputTemplate.split('/')[-1]+' '+args.folderName+'/powheg.input')
 
         #os.system('rm -rf JHUGen.input')
-        inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
+        #inputJHUGen = '/'.join(powInputName.split('/')[0:-1])+'/JHUGen.input'
+        #print powInputName
+        inputJHUGen='JHUGen.input'
         if not os.path.exists(inputJHUGen) :
             os.system('wget --no-check-certificate -N http://cms-project-generators.web.cern.ch/cms-project-generators/'+inputJHUGen)
 


### PR DESCRIPTION
Fix for running JHUGen
- checks out the proper decay weights for WW and ZZ decays, so that they are available in the gridpack (for recent gridpacks users had to unpack, add the weights and repack)
- also fixes the way the JHU input file is handles. Previous version of the code was deleting JHUGen.input before doing anything with it.

Fixes for HJ + NNLOPS:
- fixes the input file name for nnlops reweighter 
- fixes a problem running HJ + CT14 (code was trying to access member 1 for alphas variation, when there is no member 1 for those variations, only member 0 in LHAPDF 6.1.6)