### PR TITLE
Dalitz cards updates

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
@@ -1,43 +1,66 @@
 # Higgs Dalitz Samples
-In this directory we keep all cards used for Higgs Dalitz decay, H -> gamma* gamma -> mu mu gamma.
-The samples produced with these cards are listed at [2][HZg twiki page].
+In this directory we keep all cards used for *H &rightarrow; &gamma;\* &gamma; &rightarrow; ll;&gamma;*, aka **Higgs Dalitz decay**.
+The samples produced with these cards are listed at [HZg MC twiki page](https://twiki.cern.ch/twiki/bin/view/CMS/HZgMC13TeV).
 
-Gridpack production instructions can be found [1][here]. Just an example, for ggH125 production you need to run this command:
+We use the
+[Higgs Characterization](http://feynrules.irmp.ucl.ac.be/wiki/HiggsCharacterisation)
+model in Madgraph/amcatnlo for the decay of the Higgs
+boson. It is crucial part here, since *H
+&rightsarrow; &gamma;\* &gamma;* process does not yet exist in
+Pythia 8.  The mass of the *&gamma;\* &rightsarrow;* decay is
+restricted to *0 < m(ll) < (50)60 GeV*.  However, the lower cut is
+effectively goverened by the masses of leptons: *2m_l < m(ll)*, and
+the masses of leptons are not zero in the decay model for that reason.
+
+
+Gridpack production instructions can be found on
+[QuickGuideMadGraph5aMCatNLO twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/QuickGuideMadGraph5aMCatNLO). Just
+an example, for *ggH125* production you need to run this command from *lxplus*:
 ```
-./submit_gridpack_generation.sh 50000 50000 2nw  ggH125_012j_NLO_FXFX_HtoMuMuGamma cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoMuMuGamma/ 1nw
+./submit_gridpack_generation.sh 50000 50000 2nw ggH125_012j_NLO_FXFX_HtoMuMuGamma cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoMuMuGamma/ 1nw
 ```
-It is important that the job is submitted with 2nw/1nw queues since it takes long to run.
-Below we list the recommended queues for other samples as well.
+It is important that this job is submitted with **2nw/1nw** queues
+since it takes long to run.  Below we list the recommended queues for
+other samples as well.
+
 
 ## Gluon fusion at NLO
 Cards: *ggH120_012j_NLO_FXFX_HtoMuMuGamma*, *ggH125_012j_NLO_FXFX_HtoMuMuGamma*, *ggH130_012j_NLO_FXFX_HtoMuMuGamma*,
 *ggH120_012j_NLO_FXFX_HtoElElGamma*, *ggH125_012j_NLO_FXFX_HtoElElGamma*, *ggH130_012j_NLO_FXFX_HtoElElGamma*
 
   * Use ```2nw/1nw``` queues
-  * It has m(ll) < 60 GeV
-  * Masses of leptons are not zero
+  * Production model: **HC**
+  * Decay model: **HC**
 
 ## Gluon fusion at LO
 Cards: *ggH120_MuMuGamma*, *ggH125_MuMuGamma*, *ggH130_MuMuGamma*, *ggH120_ElElGamma*, *ggH125_ElElGamma*, *ggH130_ElElGamma*
 
-Use ```2nd/1nd``` queues
+  * Use ```2nd/1nd``` queues
+  * Production model: **HC**
+  * Decay model: **HC**
 
 ## Vector Boson Fusion
 Cards: *vbfH120*, *vbfH125*, *vbfH130*
 
-Use ```2nd/1nd``` queues
+  * Use ```2nd/1nd``` queues
+  * Production model: **loop_sm-no_b_mass**
+  * Decay model: **HC**
 
 ## Associated production
-Cards for ZH: *ZH120*, *ZH125*, *ZH130*
+Cards for ZH: *ZH120*, *ZH125*, *ZH130*__
 Cards for WH: *WH120*, *WH125*, *WH130*
 
-Use ```2nw/1nw``` queues
-
+  * Use ```1nw/2nd``` queues
+  * Production model: **loop_sm-no_b_mass**
+  * Decay model: **HC**
 
 ## Higgs to ZGamma
 Card: *ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma*
-It is included for cross check with the official H to ZG process, whcich was produced with Powheg (H production) + Pythia 8 (H decay) combination.
 
-[1]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/QuickGuideMadGraph5aMCatNLO
+  * Use ```2nw/1nw``` queues
+  * Production model: **HC**
+  * Decay model: **HC**
 
-[2]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HZgMC13TeV
+It is included for cross-check with the official *H &rightarrow;
+Z&gamma;* process, whcich was produced with Powheg (H production) +
+Pythia 8 (H decay) combination.

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
@@ -1,13 +1,13 @@
 # Higgs Dalitz Samples
-In this directory we keep all cards used for *H &rightarrow; &gamma;\* &gamma; &rightarrow; ll;&gamma;*, aka **Higgs Dalitz decay**.
+In this directory we keep all cards used for *H &rightarrow; &gamma;&ast;&gamma; &rightarrow; ll&gamma;*, aka **Higgs Dalitz decay**.
 The samples produced with these cards are listed at [HZg MC twiki page](https://twiki.cern.ch/twiki/bin/view/CMS/HZgMC13TeV).
 
 We use the
 [Higgs Characterization](http://feynrules.irmp.ucl.ac.be/wiki/HiggsCharacterisation)
 model in Madgraph/amcatnlo for the decay of the Higgs
 boson. It is crucial part here, since *H
-&rightsarrow; &gamma;\* &gamma;* process does not yet exist in
-Pythia 8.  The mass of the *&gamma;\* &rightsarrow;* decay is
+&rightarrow; &gamma;&ast; &gamma;* process does not yet exist in
+Pythia 8.  The di-lepton mass of the *&gamma;&ast; &rightarrow; ll* decay is
 restricted to *0 < m(ll) < (50)60 GeV*.  However, the lower cut is
 effectively goverened by the masses of leptons: *2m_l < m(ll)*, and
 the masses of leptons are not zero in the decay model for that reason.
@@ -28,29 +28,33 @@ other samples as well.
 Cards: *ggH120_012j_NLO_FXFX_HtoMuMuGamma*, *ggH125_012j_NLO_FXFX_HtoMuMuGamma*, *ggH130_012j_NLO_FXFX_HtoMuMuGamma*,
 *ggH120_012j_NLO_FXFX_HtoElElGamma*, *ggH125_012j_NLO_FXFX_HtoElElGamma*, *ggH130_012j_NLO_FXFX_HtoElElGamma*
 
-  * Use ```2nw/1nw``` queues
+  * Use `2nw/1nw` queues
   * Production model: **HC**
   * Decay model: **HC**
 
 ## Gluon fusion at LO
 Cards: *ggH120_MuMuGamma*, *ggH125_MuMuGamma*, *ggH130_MuMuGamma*, *ggH120_ElElGamma*, *ggH125_ElElGamma*, *ggH130_ElElGamma*
 
-  * Use ```2nd/1nd``` queues
+  * Use `2nd/1nd` queues
   * Production model: **HC**
   * Decay model: **HC**
 
 ## Vector Boson Fusion
-Cards: *vbfH120*, *vbfH125*, *vbfH130*
+Cards: *vbfH120_NLO_HtoMuMuGamma*, *vbfH125_NLO_HtoMuMuGamma*, *vbfH130_NLO_HtoMuMuGamma*, 
+*vbfH120_NLO_HtoElElGamma*, *vbfH125_NLO_HtoElElGamma*, *vbfH130_NLO_HtoElElGamma*
 
-  * Use ```2nd/1nd``` queues
+  * Use `2nd/1nd` queues
   * Production model: **loop_sm-no_b_mass**
   * Decay model: **HC**
 
 ## Associated production
-Cards for ZH: *ZH120*, *ZH125*, *ZH130*__
-Cards for WH: *WH120*, *WH125*, *WH130*
+Cards for ZH: *ZH120_012j_NLO_HtoEMuMuGamma*, *ZH125_012j_NLO_HtoMuMuGamma*, *ZH130_012j_NLO_HtoMuMuGamma*,
+*ZH120_012j_NLO_HtoElElGamma*, *ZH125_012j_NLO_HtoElElGamma*, *ZH130_012j_NLO_HtoElElGamma*
 
-  * Use ```1nw/2nd``` queues
+Cards for WH: *WH120_012j_NLO_HtoEMuMuGamma*, *WH125_012j_NLO_HtoMuMuGamma*, *WH130_012j_NLO_HtoMuMuGamma*,
+*WH120_012j_NLO_HtoElElGamma*, *WH125_012j_NLO_HtoElElGamma*, *WH130_012j_NLO_HtoElElGamma* 
+
+  * Use `1nw/2nd` queues
   * Production model: **loop_sm-no_b_mass**
   * Decay model: **HC**
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
@@ -34,6 +34,10 @@ Cards for WH: *WH120*, *WH125*, *WH130*
 Use ```2nw/1nw``` queues
 
 
+## Higgs to ZGamma
+Card: *ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma*
+It is included for cross check with the official H to ZG process, whcich was produced with Powheg (H production) + Pythia 8 (H decay) combination.
+
 [1]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/QuickGuideMadGraph5aMCatNLO
 
 [2]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HZgMC13TeV

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/README.md
@@ -1,0 +1,39 @@
+# Higgs Dalitz Samples
+In this directory we keep all cards used for Higgs Dalitz decay, H -> gamma* gamma -> mu mu gamma.
+The samples produced with these cards are listed at [2][HZg twiki page].
+
+Gridpack production instructions can be found [1][here]. Just an example, for ggH125 production you need to run this command:
+```
+./submit_gridpack_generation.sh 50000 50000 2nw  ggH125_012j_NLO_FXFX_HtoMuMuGamma cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoMuMuGamma/ 1nw
+```
+It is important that the job is submitted with 2nw/1nw queues since it takes long to run.
+Below we list the recommended queues for other samples as well.
+
+## Gluon fusion at NLO
+Cards: *ggH120_012j_NLO_FXFX_HtoMuMuGamma*, *ggH125_012j_NLO_FXFX_HtoMuMuGamma*, *ggH130_012j_NLO_FXFX_HtoMuMuGamma*,
+*ggH120_012j_NLO_FXFX_HtoElElGamma*, *ggH125_012j_NLO_FXFX_HtoElElGamma*, *ggH130_012j_NLO_FXFX_HtoElElGamma*
+
+  * Use ```2nw/1nw``` queues
+  * It has m(ll) < 60 GeV
+  * Masses of leptons are not zero
+
+## Gluon fusion at LO
+Cards: *ggH120_MuMuGamma*, *ggH125_MuMuGamma*, *ggH130_MuMuGamma*, *ggH120_ElElGamma*, *ggH125_ElElGamma*, *ggH130_ElElGamma*
+
+Use ```2nd/1nd``` queues
+
+## Vector Boson Fusion
+Cards: *vbfH120*, *vbfH125*, *vbfH130*
+
+Use ```2nd/1nd``` queues
+
+## Associated production
+Cards for ZH: *ZH120*, *ZH125*, *ZH130*
+Cards for WH: *WH120*, *WH125*, *WH130*
+
+Use ```2nw/1nw``` queues
+
+
+[1]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/QuickGuideMadGraph5aMCatNLO
+
+[2]: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HZgMC13TeV

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoElElGamma/WH120_012j_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoElElGamma/WH120_012j_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoElElGamma/WH120_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoElElGamma/WH120_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoMuMuGamma/WH120_012j_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoMuMuGamma/WH120_012j_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoMuMuGamma/WH120_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH120_012j_NLO_HtoMuMuGamma/WH120_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH125_012j_NLO_HtoElElGamma/WH125_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH125_012j_NLO_HtoElElGamma/WH125_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH125_012j_NLO_HtoMuMuGamma/WH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH125_012j_NLO_HtoMuMuGamma/WH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoElElGamma/WH130_012j_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoElElGamma/WH130_012j_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoElElGamma/WH130_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoElElGamma/WH130_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoMuMuGamma/WH130_012j_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoMuMuGamma/WH130_012j_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoMuMuGamma/WH130_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/WH130_012j_NLO_HtoMuMuGamma/WH130_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,8 +31,8 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
-decay w+ > all all
-decay w- > all all
+#decay w+ > all all
+#decay w- > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoElElGamma/ZH120_012j_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoElElGamma/ZH120_012j_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoElElGamma/ZH120_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoElElGamma/ZH120_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,7 +31,7 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay z > all all
+#decay z > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoMuMuGamma/ZH120_012j_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH120_012j_NLO_HtoMuMuGamma/ZH120_012j_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoElElGamma/ZH125_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoElElGamma/ZH125_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,7 +31,7 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay z > all all
+#decay z > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,6 +31,7 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
+
 #decay z > all all
 
 # running the actual code

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,7 +31,7 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
-decay z > all all
+#decay z > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_proc_card.dat
@@ -7,8 +7,8 @@ define j = j b b~
 
 define V = z
 
-generate p p > V h [QCD] @0
-add process p p > V h j [QCD] @1
-add process p p > V h j j [QCD] @2
+define allVdecay = u u~ c c~ d d~ s s~ b b~ vl vl~ e+ e- mu+ mu- ta+ ta-
+
+generate p p > V h, V > allVdecay allVdecay
 
 output ZH125_012j_NLO_HtoMuMuGamma -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH125_012j_NLO_HtoMuMuGamma/ZH125_012j_NLO_HtoMuMuGamma_proc_card.dat
@@ -7,8 +7,11 @@ define j = j b b~
 
 define V = z
 
-define allVdecay = u u~ c c~ d d~ s s~ b b~ vl vl~ e+ e- mu+ mu- ta+ ta-
+#define allVdecay = u u~ c c~ d d~ s s~ b b~ vl vl~ e+ e- mu+ mu- ta+ ta-
+#generate p p > V h, V > allVdecay allVdecay
 
-generate p p > V h, V > allVdecay allVdecay
+generate p p > V h [QCD] @0
+add process p p > V h j [QCD] @1
+add process p p > V h j j [QCD] @2
 
 output ZH125_012j_NLO_HtoMuMuGamma -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoElElGamma/ZH130_012j_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoElElGamma/ZH130_012j_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoElElGamma/ZH130_012j_NLO_HtoElElGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoElElGamma/ZH130_012j_NLO_HtoElElGamma_madspin_card.dat
@@ -31,7 +31,7 @@ define l+ = e+
 define l- = e-
 
 decay x0 > l+ l- a
-decay z > all all
+#decay z > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoMuMuGamma/ZH130_012j_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoMuMuGamma/ZH130_012j_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoMuMuGamma/ZH130_012j_NLO_HtoMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ZH130_012j_NLO_HtoMuMuGamma/ZH130_012j_NLO_HtoMuMuGamma_madspin_card.dat
@@ -31,7 +31,7 @@ define l+ = m+
 define l- = m-
 
 decay x0 > l+ l- a
-decay z > all all
+#decay z > all all
 
 # running the actual code
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH120_012j_NLO_FXFX_HtoElElGamma/ggH120_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH120_012j_NLO_FXFX_HtoElElGamma/ggH120_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH120_012j_NLO_FXFX_HtoMuMuGamma/ggH120_012j_NLO_FXFX_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH120_012j_NLO_FXFX_HtoMuMuGamma/ggH120_012j_NLO_FXFX_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+#set param_card mass 6 173.0
+#set param_card yukawa 6 173.0
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_extramodels.dat
@@ -1,0 +1,6 @@
+#higgs characterization NLO model version 1.3 from http://feynrules.irmp.ucl.ac.be/wiki/HiggsCharacterisation
+HC_NLO_X0_UFO-v1.3.zip
+
+#additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_madspin_card.dat
@@ -1,0 +1,36 @@
+#************************************************************
+#*                        MadSpin                           *
+#*                                                          *
+#*    P. Artoisenet, R. Frederix, R. Rietkerk, O. Mattelaer * 
+#*                                                          *
+#*    Part of the MadGraph5_aMC@NLO Framework:              *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#Some options (uncomment to apply)
+
+import model HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas --bypass_check
+
+set ms_dir ./madspingrid
+
+#initialization parameters
+ set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
+ #set BW_cut 15                # cut on how far the particle can be off-shell
+ set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+# 
+
+set max_running_process 1
+
+# specify the decay for the final state particles
+set spinmode=none
+set run_card mmll=50
+set run_card mmllmax=1000
+
+define l+ = m+
+define l- = m-
+
+decay x0 > l+ l- a
+
+# running the actual code
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_proc_card.dat
@@ -9,5 +9,5 @@ generate p p > x0 / t [QCD] @0
 add process p p > x0 j / t [QCD] @1
 add process p p > x0 j j / t [QCD] @2
 
-output ggH125_012j_NLO_FXFX_HtoMuMuGamma -nojpeg
+output ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_proc_card.dat
@@ -1,0 +1,13 @@
+#special model for gluon fusion higgs at NLO (effective theory in infinite top mass limit)
+#note that this model is NOT needed for other SM higgs production modes
+import model HC_NLO_X0_UFO-heft
+
+define p = p b b~
+define j = j b b~
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggH125_012j_NLO_FXFX_HtoMuMuGamma -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma/ggH125_012j_NLO_FXFX_HtoZGammaToMuMuGamma_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ .true.  = reweight_PDF     ! reweight to get PDF uncertainty
+ 292201   = PDF_set_min      ! First of the error PDF sets 
+ 292302   = PDF_set_max      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoElElGamma/ggH130_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoElElGamma/ggH130_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MXO_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoElElGamma/ggH130_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoElElGamma/ggH130_012j_NLO_FXFX_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MXO_130-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoMuMuGamma/ggH130_012j_NLO_FXFX_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/ggH130_012j_NLO_FXFX_HtoMuMuGamma/ggH130_012j_NLO_FXFX_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH120_NLO_HtoElElGamma/vbfH120_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH120_NLO_HtoElElGamma/vbfH120_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH120_NLO_HtoMuMuGamma/vbfH120_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH120_NLO_HtoMuMuGamma/vbfH120_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_120-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH130_NLO_HtoElElGamma/vbfH130_NLO_HtoElElGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH130_NLO_HtoElElGamma/vbfH130_NLO_HtoElElGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH130_NLO_HtoMuMuGamma/vbfH130_NLO_HtoMuMuGamma_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/dalitz/vbfH130_NLO_HtoMuMuGamma/vbfH130_NLO_HtoMuMuGamma_extramodels.dat
@@ -2,5 +2,5 @@
 HC_NLO_X0_UFO-v1.3.zip
 
 #additional variation useful for higgs dalitz decays, in order to exclude tiny contributions proportional to ye^2 and ymu^2
-HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas-v1.3.tar.gz
+HC_NLO_X0_UFO-lepton_masses_no_lepton_yukawas_MX0_130-v1.3.tar.gz
 


### PR DESCRIPTION
In this update:
* Added mH=120 and 130 names in extramodels.dat. The updated parameter cards themselves were loaded to [cms-project-generators](https://cms-project-generators.web.cern.ch/cms-project-generators) web page.
* Commented out decays of the Z and W in VH production. This is because Madspin would not preserve the correct spin of those particles due to *spinmode=none* setting. The idea now is to decay W/Z in Pythia 8 wile doing the hadronization. **Please advise if that is possible?**
* Added readme file.