### PR TITLE
Explicitly compile all subprocess in rwgt directory

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -513,6 +513,16 @@ else
       export LIBRARY_PATH=$LD_LIBRARY_PATH
       cd madevent
       bin/madevent reweight pilotrun
+      # Explicitly compile all subprocesses
+      for file in $(ls -d rwgt/rw_me/SubProcesses/P* | head -4); do
+        echo "Compiling subprocess $(basename $file)"
+        pushd $file > /dev/null
+        for i in 2 3; do
+            MENUM=$i make matrix${i}py.so >& /dev/null
+            echo "Library MENUM=$i compiled with status $?"
+        done
+        popd >& /dev/null
+      done
       cd ..      
   fi
 

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -516,12 +516,12 @@ else
       # Explicitly compile all subprocesses
       for file in $(ls -d rwgt/rw_me/SubProcesses/P*); do
         echo "Compiling subprocess $(basename $file)"
-        pushd $file > /dev/null
+        cd $file
         for i in 2 3; do
             MENUM=$i make matrix${i}py.so >& /dev/null
             echo "Library MENUM=$i compiled with status $?"
         done
-        popd >& /dev/null
+        cd -
       done
       cd ..      
   fi

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -514,7 +514,7 @@ else
       cd madevent
       bin/madevent reweight pilotrun
       # Explicitly compile all subprocesses
-      for file in $(ls -d rwgt/rw_me/SubProcesses/P*); do
+      for file in $(ls -d rwgt/*/SubProcesses/P*); do
         echo "Compiling subprocess $(basename $file)"
         cd $file
         for i in 2 3; do

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -514,7 +514,7 @@ else
       cd madevent
       bin/madevent reweight pilotrun
       # Explicitly compile all subprocesses
-      for file in $(ls -d rwgt/rw_me/SubProcesses/P* | head -4); do
+      for file in $(ls -d rwgt/rw_me/SubProcesses/P*); do
         echo "Compiling subprocess $(basename $file)"
         pushd $file > /dev/null
         for i in 2 3; do


### PR DESCRIPTION
Following suggestion from MadGraph authors, manually compile libraries
for all subprocesses used by reweight. By default, subprocesses are only
compiled as they are encountered during the reweight run. This change
forces all to be pre-compiled. Note: Requires the lines
"change rwgt_dir rwgt" to be in the reweight_card.dat (currently the
directory name "rwgt" is hardcoded in the compilation commands).
