### PR TITLE
'change helicity False' as suggested by authors

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model
 set anoinputs 3 0.000000e-12 #fm0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model
 set anoinputs 3 0.000000e-12 #fm0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 1 0.000000e-12 #fs0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 1 0.000000e-12 #fs0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 11 0.000000e-12 #ft0 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 11 0.000000e-12 #ft0 


### PR DESCRIPTION
From private conversation with Olivier Mattalear:

Note that if you use version before 2.5.1, I should advise you to always have the following line in the reweight_card
change helicity False
in the default model “change helicity True", they are a bug (that I wrongly fix in 2.4.3 and correctly fixed in 2.5.1).
The problem in 2.3.3 and 2.4.2 is that the helicity are evaluated in the wrong frame which can lead to problem in some cases.

change helicity False
correspond to equation (1) of https://arxiv.org/pdf/1607.00763.pdf
while change helicity True is equation (4)