### PR TITLE
Patch for 'change rwgt_dir' in 2.4.2

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0009-fix-to-change-rwgt_dir-for-LO-reweight.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0009-fix-to-change-rwgt_dir-for-LO-reweight.patch
@@ -1,0 +1,27 @@
+diff --git a/interface/reweight_interface.py b/interface/reweight_interface.py
+--- a/madgraph/interface/reweight_interface.py
++++ b/madgraph/interface/reweight_interface.py
+@@ -1612,18 +1612,21 @@
+         to_save['rwgt_dir'] = self.rwgt_dir
+         to_save['has_nlo'] = self.has_nlo
+         to_save['rwgt_mode'] = self.rwgt_mode
++        to_save['rwgt_name'] = self.options['rwgt_name']
+ 
+         name = pjoin(self.rwgt_dir, 'rw_me', 'rwgt.pkl')
+         save_load_object.save_to_file(name, to_save)
+ 
+-    def load_from_pickle(self):
++    def load_from_pickle(self, keep_name=False):
+         import madgraph.iolibs.save_load_object as save_load_object
+         
+         obj = save_load_object.load_from_file( pjoin(self.rwgt_dir, 'rw_me', 'rwgt.pkl'))
+         
+         self.has_standalone_dir = True
+         self.options = {'curr_dir': os.path.realpath(os.getcwd()),
+-                        'rewgt_name': None}
++                    'rwgt_name': self.options['rwgt_name'] if (hasattr(self, 'options') and 'rwgt_name' in self.options) else None}
++        if keep_name:
++            self.options['rwgt_name'] = obj['rwgt_name']
+         
+         old_rwgt = obj['rwgt_dir']
+            

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -36,26 +36,10 @@ fi
 #generate events
 ./run.sh $nevt $rnum
 
-domadspin=0
-if [ -f ./madspin_card.dat ] ;then
-    domadspin=1
-    echo "import events.lhe.gz" > madspinrun.dat
-    rnum2=$(($rnum+1000000))
-    echo `echo "set seed $rnum2"` >> madspinrun.dat
-    cat ./madspin_card.dat >> madspinrun.dat
-    cat madspinrun.dat | $LHEWORKDIR/mgbasedir/MadSpin/madspin
-fi
-
 cd $LHEWORKDIR
 
-if [ "$domadspin" -gt "0" ] ; then 
-    mv process/events_decayed.lhe.gz events_presys.lhe.gz
-else
-    mv process/events.lhe.gz events_presys.lhe.gz
-fi
-
+mv process/events.lhe.gz events_presys.lhe.gz
 gzip -d events_presys.lhe.gz
-
 
 #run syscalc to populate pdf and scale variation weights
 echo "
@@ -93,6 +77,20 @@ if [ -e process/madevent/Cards/reweight_card.dat ]; then
     ./bin/madevent reweight -f GridRun_${rnum}
     cd ../..
     mv process/madevent/Events/GridRun_${rnum}/unweighted_events.lhe.gz cmsgrid_final.lhe.gz
+    gzip -d  cmsgrid_final.lhe.gz
+fi
+
+if [ -f process/madspin_card.dat ] ;then
+    mv cmsgrid_final.lhe process
+    cd process
+    gzip  cmsgrid_final.lhe
+    echo "import cmsgrid_final.lhe.gz" > madspinrun.dat
+    rnum2=$(($rnum+1000000))
+    echo `echo "set seed $rnum2"` >> madspinrun.dat
+    cat ./madspin_card.dat >> madspinrun.dat
+    cat madspinrun.dat | $LHEWORKDIR/mgbasedir/MadSpin/madspin
+    cd $LHEWORKDIR
+    mv process/cmsgrid_final_decayed.lhe.gz cmsgrid_final.lhe.gz
     gzip -d  cmsgrid_final.lhe.gz
 fi
 


### PR DESCRIPTION
Adding patch from Olivier Mattalear to fix bug affecting 'change rwgt_dir' in 2.4.2, which is critical for using precompiled MadSpin. Also moving MadSpin to run after reweight.

@bendavid I wasn't sure how you managed to format the patch files in the way you did. Let me know if it should be done differently.

Correspondence with Olivier:

I actually
fixed many bug in 2.5.0 related to “change rwgt_dir rwgt”
but I guess mainly for the NLO re-weighting and not that many for the LO
re-weighting.

Here is the full difference in those file (in case they can be usefull)
    http://bazaar.launchpad.net/~madteam/mg5amcnlo/series2.0/revision/267#madgraph/interface/reweight_interface.py
http://bazaar.launchpad.net/~madteam/mg5amcnlo/series2.0/revision/268#madgraph/interface/reweight_interface.py

Just for information here is a small timeline of the re-weighting package:
2.0.0 (2013) first implementation (only same model/same process) based on MadSpin idea (fortran executable called on the flight)
2.3.2 (2015) new implementation via fortran library linked to python (f2py). possibility to change model/process definition.
                    possibility to perform a LO accurate re-weighting on NLO sample.
2.4.0 (2016) proper NLO re-weighting of NLO sample.
2.5.0 (2016) Possibility to run the re-weighting on multiple core
2.x.y (2017) change of structure.
                    - having only two (four at NLO) fortran library to be linked to python (faster compilation/better memory footprint)
                    - the fortran code would be modified such that the python code will extract information from the fortran library directly.
                      This allows more flexibility for modifying the re-weighitng code by hand.