### PR TITLE
Updating WZ aQGC cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
@@ -3,147 +3,148 @@
 #******************************************************************
 change helicity False
 change rwgt_dir rwgt
-launch #Standard model
+launch --rwgt_name=standard_model
 set anoinputs 3 0.000000e-12 #fm0
 set anoinputs 4 0.000000e-12 #fm1
-launch
+launch --rwgt_name=fm0_m8__fm1_0
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 0.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_0
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 0.000000e-12
-launch   
+launch --rwgt_name=fm0_m2__fm1_0
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 0.000000e-12
-aunch   
+launch --rwgt_name=fm0_2__fm1_0
 set anoinputs 3 2.000000e-12
 set anoinputs 4 0.000000e-12
-launch   
+launch --rwgt_name=fm0_8__fm1_0
 set anoinputs 3 8.000000e-12
 set anoinputs 4 0.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_m8
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -8.000000e-12
-launch   
+launch --rwgt_name=fm0_0__fm1_m4
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_m2
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_2
 set anoinputs 3 0.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_4
 set anoinputs 3 0.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_8
 set anoinputs 3 0.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m8
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m4
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m2
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_2
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_4
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_8
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m8
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m4
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m2
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_2
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_4
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_8
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m8
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m4
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m2
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_2
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_4
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_8
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m8
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m4
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m2
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_2
 set anoinputs 3 2.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_4
 set anoinputs 3 2.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_8
 set anoinputs 3 2.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m8
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m4
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m2
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_2
 set anoinputs 3 4.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_4
 set anoinputs 3 4.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_8
 set anoinputs 3 4.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m8
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m4
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m2
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_2
 set anoinputs 3 8.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_4
 set anoinputs 3 8.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_8
 set anoinputs 3 8.000000e-12
 set anoinputs 4 8.000000e-12
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model
 set anoinputs 3 0.000000e-12 #fm0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_proc_card.dat
@@ -36,4 +36,4 @@ define vl~ = ve~ vm~ vt~
 generate    p p > w+ l+ l- j j QED=5 QCD=0 NP=1 @ 1
 add process p p > w- l+ l- j j QED=5 QCD=0 NP=1 @ 2
 
-output WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfm --nojpeg
+output WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm --nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
@@ -3,147 +3,148 @@
 #******************************************************************
 change helicity False
 change rwgt_dir rwgt
-launch #Standard model
+launch --rwgt_name=standard_model
 set anoinputs 3 0.000000e-12 #fm0
 set anoinputs 4 0.000000e-12 #fm1
-launch
+launch --rwgt_name=fm0_m8__fm1_0
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 0.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_0
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 0.000000e-12
-launch   
+launch --rwgt_name=fm0_m2__fm1_0
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 0.000000e-12
-aunch   
+launch --rwgt_name=fm0_2__fm1_0
 set anoinputs 3 2.000000e-12
 set anoinputs 4 0.000000e-12
-launch   
+launch --rwgt_name=fm0_8__fm1_0
 set anoinputs 3 8.000000e-12
 set anoinputs 4 0.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_m8
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -8.000000e-12
-launch   
+launch --rwgt_name=fm0_0__fm1_m4
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_m2
 set anoinputs 3 0.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_2
 set anoinputs 3 0.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_4
 set anoinputs 3 0.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_0__fm1_8
 set anoinputs 3 0.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m8
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m4
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_m2
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_2
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_4
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m8__fm1_8
 set anoinputs 3 -8.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m8
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m4
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_m2
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_2
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_4
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m4__fm1_8
 set anoinputs 3 -4.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m8
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m4
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_m2
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_2
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_4
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_m2__fm1_8
 set anoinputs 3 -2.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m8
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m4
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_m2
 set anoinputs 3 2.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_2
 set anoinputs 3 2.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_4
 set anoinputs 3 2.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_2__fm1_8
 set anoinputs 3 2.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m8
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m4
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_m2
 set anoinputs 3 4.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_2
 set anoinputs 3 4.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_4
 set anoinputs 3 4.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_4__fm1_8
 set anoinputs 3 4.000000e-12
 set anoinputs 4 8.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m8
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -8.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m4
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -4.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_m2
 set anoinputs 3 8.000000e-12
 set anoinputs 4 -2.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_2
 set anoinputs 3 8.000000e-12
 set anoinputs 4 2.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_4
 set anoinputs 3 8.000000e-12
 set anoinputs 4 4.000000e-12
-launch
+launch --rwgt_name=fm0_8__fm1_8
 set anoinputs 3 8.000000e-12
 set anoinputs 4 8.000000e-12
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FM_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfm_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model
 set anoinputs 3 0.000000e-12 #fm0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
@@ -3,147 +3,147 @@
 #******************************************************************
 change helicity False
 change rwgt_dir rwgt
-launch #Standard model  
+launch --rwgt_name=standard_model
 set anoinputs 1 0.000000e-12 #fs0
 set anoinputs 2 0.000000e-12 #fs1
-launch
+launch --rwgt_name=fs0_m32__fs1_0
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 0.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_0
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_m8__fs1_0
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_8__fs1_0
 set anoinputs 1 8.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_32__fs1_0
 set anoinputs 1 32.000000e-12
 set anoinputs 2 0.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_m32
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -32.000000e-12
-launch   
+launch --rwgt_name=fs0_0__fs1_m16
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_m8
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_8
 set anoinputs 1 0.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_16
 set anoinputs 1 0.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_32
 set anoinputs 1 0.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m32
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m16
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m8
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_8
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_16
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_32
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m32
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m16
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m8
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_8
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_16
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_32
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m32
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m16
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m8
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_8
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_16
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_32
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m32
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m16
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m8
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_8
 set anoinputs 1 8.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_16
 set anoinputs 1 8.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_32
 set anoinputs 1 8.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m32
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m16
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m8
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_8
 set anoinputs 1 16.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_16
 set anoinputs 1 16.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_32
 set anoinputs 1 16.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m32
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m16
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m8
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_8
 set anoinputs 1 32.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_16
 set anoinputs 1 32.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_32
 set anoinputs 1 32.000000e-12
 set anoinputs 2 32.000000e-12

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 1 0.000000e-12 #fs0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_proc_card.dat
@@ -36,4 +36,4 @@ define vl~ = ve~ vm~ vt~
 generate    p p > w+ l+ l- j j QED=5 QCD=0 NP=1 @ 1
 add process p p > w- l+ l- j j QED=5 QCD=0 NP=1 @ 2
 
-output WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCfs --nojpeg
+output WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs --nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
@@ -3,147 +3,147 @@
 #******************************************************************
 change helicity False
 change rwgt_dir rwgt
-launch #Standard model  
+launch --rwgt_name=standard_model
 set anoinputs 1 0.000000e-12 #fs0
 set anoinputs 2 0.000000e-12 #fs1
-launch
+launch --rwgt_name=fs0_m32__fs1_0
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 0.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_0
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_m8__fs1_0
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_8__fs1_0
 set anoinputs 1 8.000000e-12
 set anoinputs 2 0.000000e-12
-launch   
+launch --rwgt_name=fs0_32__fs1_0
 set anoinputs 1 32.000000e-12
 set anoinputs 2 0.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_m32
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -32.000000e-12
-launch   
+launch --rwgt_name=fs0_0__fs1_m16
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_m8
 set anoinputs 1 0.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_8
 set anoinputs 1 0.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_16
 set anoinputs 1 0.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_0__fs1_32
 set anoinputs 1 0.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m32
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m16
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_m8
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_8
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_16
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m32__fs1_32
 set anoinputs 1 -32.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m32
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m16
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_m8
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_8
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_16
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m16__fs1_32
 set anoinputs 1 -16.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m32
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m16
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_m8
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_8
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_16
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_m8__fs1_32
 set anoinputs 1 -8.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m32
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m16
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_m8
 set anoinputs 1 8.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_8
 set anoinputs 1 8.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_16
 set anoinputs 1 8.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_8__fs1_32
 set anoinputs 1 8.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m32
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m16
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_m8
 set anoinputs 1 16.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_8
 set anoinputs 1 16.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_16
 set anoinputs 1 16.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_16__fs1_32
 set anoinputs 1 16.000000e-12
 set anoinputs 2 32.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m32
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -32.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m16
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -16.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_m8
 set anoinputs 1 32.000000e-12
 set anoinputs 2 -8.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_8
 set anoinputs 1 32.000000e-12
 set anoinputs 2 8.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_16
 set anoinputs 1 32.000000e-12
 set anoinputs 2 16.000000e-12
-launch
+launch --rwgt_name=fs0_32__fs1_32
 set anoinputs 1 32.000000e-12
 set anoinputs 2 32.000000e-12

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FS_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCfs_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 1 0.000000e-12 #fs0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 11 0.000000e-12 #ft0 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/highMll/WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft_reweight_card.dat
@@ -1,77 +1,77 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
-change helicity False
+change helicty False
 change rwgt_dir rwgt
-launch #Standard model  
+launch --rwgt_name=standard_model
 set anoinputs 11 0.000000e-12 #ft0 
 set anoinputs 12 0.000000e-12 #ft1 
 set anoinputs 13 0.000000e-12 #ft2 
-launch
+launch --rwgt_name=ft0_m16__ft1_0__ft2_0
 set anoinputs 11 -16.000000e-12 
 set anoinputs 12 0.000000e-12   
 set anoinputs 13 0.000000e-12   
-launch
+launch --rwgt_name=ft0_m8__ft1_0__ft2_0
 set anoinputs 11 -8.000000e-12 
 set anoinputs 12 0.000000e-12  
 set anoinputs 13 0.000000e-12  
-launch   
+launch --rwgt_name=ft0_m4__ft1_0__ft2_0
 set anoinputs 11 -4.000000e-12  
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_4__ft1_0__ft2_0
 set anoinputs 11 4.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_16__ft1_0__ft2_0
 set anoinputs 11 16.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_m8__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -8.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_0__ft1_m4__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -4.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_m2__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -2.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_2__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 2.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_4__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 4.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_8__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 8.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m24
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -24.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m12
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -12.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m6
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -6.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_6
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 6.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_12
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 12.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_24
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 24.000000e-12

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_proc_card.dat
@@ -36,4 +36,4 @@ define vl~ = ve~ vm~ vt~
 generate    p p > w+ l+ l- j j QED=5 QCD=0 NP=1 @ 1
 add process p p > w- l+ l- j j QED=5 QCD=0 NP=1 @ 2
 
-output WLLJJ_WToLNu_EWK_4F_MLL-60_aQGCft --nojpeg
+output WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft --nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
@@ -1,6 +1,7 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
+change helicity False
 change rwgt_dir rwgt
 launch #Standard model  
 set anoinputs 11 0.000000e-12 #ft0 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/AnomalousCouplings-SMP/WLLJJ_WToLNu_aQGC-FT_EWKOnly/lowMll/WLLJJ_WToLNu_EWK_4F_MLL4-60_aQGCft_reweight_card.dat
@@ -1,77 +1,77 @@
 #******************************************************************
 #                       Reweight Module                           *
 #******************************************************************
-change helicity False
+change helicty False
 change rwgt_dir rwgt
-launch #Standard model  
+launch --rwgt_name=standard_model
 set anoinputs 11 0.000000e-12 #ft0 
 set anoinputs 12 0.000000e-12 #ft1 
 set anoinputs 13 0.000000e-12 #ft2 
-launch
+launch --rwgt_name=ft0_m16__ft1_0__ft2_0
 set anoinputs 11 -16.000000e-12 
 set anoinputs 12 0.000000e-12   
 set anoinputs 13 0.000000e-12   
-launch
+launch --rwgt_name=ft0_m8__ft1_0__ft2_0
 set anoinputs 11 -8.000000e-12 
 set anoinputs 12 0.000000e-12  
 set anoinputs 13 0.000000e-12  
-launch   
+launch --rwgt_name=ft0_m4__ft1_0__ft2_0
 set anoinputs 11 -4.000000e-12  
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_4__ft1_0__ft2_0
 set anoinputs 11 4.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_16__ft1_0__ft2_0
 set anoinputs 11 16.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_m8__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -8.000000e-12
 set anoinputs 13 0.000000e-12
-launch   
+launch --rwgt_name=ft0_0__ft1_m4__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -4.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_m2__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 -2.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_2__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 2.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_4__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 4.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_8__ft2_0
 set anoinputs 11 0.000000e-12
 set anoinputs 12 8.000000e-12
 set anoinputs 13 0.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m24
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -24.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m12
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -12.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_m6
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 -6.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_6
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 6.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_12
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 12.000000e-12
-launch
+launch --rwgt_name=ft0_0__ft1_0__ft2_24
 set anoinputs 11 0.000000e-12
 set anoinputs 12 0.000000e-12
 set anoinputs 13 24.000000e-12


### PR DESCRIPTION
Authors suggest always using 'change helicity False' for version < 2.5.1, in which the default helicity true has a bug. 

Also adding --rwgt_name option, which allows the choice of a specific name for the weight and is useful for identifying it later. Note the this option has a lot of characters that won't parse correctly (,=,:- for example).