### PR TITLE
Fix for bug in runcmsgrid_powheg*.sh scripts  

### DIFF
--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -360,18 +360,18 @@ if [ -s pwgstat.dat ]; then
   mv pwgstat.dat pwg-stat.dat
 fi
 
-if [ -s pwg-stat.dat ]; then
-  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
-  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
-  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
-  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
-  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
-  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 10001" >>  cmsgrid_final.lhe_F
-  echo "</init>"                                           >>  cmsgrid_final.lhe_F
-  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
-  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
-fi
+#if [ -s pwg-stat.dat ]; then
+#  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
+#  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+#  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
+#  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
+#  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
+#  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
+#  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 322222" >>  cmsgrid_final.lhe_F
+#  echo "</init>"                                           >>  cmsgrid_final.lhe_F
+#  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
+#  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
+#fi
 #Replace the negative so pythia will work
 sed "s@-1000021@ 1000022@g" cmsgrid_final.lhe           > cmsgrid_final.lhe_F1
 sed "s@1000021@1000022@g"   cmsgrid_final.lhe_F1          > cmsgrid_final.lhe

--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -360,18 +360,20 @@ if [ -s pwgstat.dat ]; then
   mv pwgstat.dat pwg-stat.dat
 fi
 
-#if [ -s pwg-stat.dat ]; then
-#  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-#  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
-#  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
-#  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
-#  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
-#  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
-#  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 322222" >>  cmsgrid_final.lhe_F
-#  echo "</init>"                                           >>  cmsgrid_final.lhe_F
-#  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
-#  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
-#fi
+if [ -s pwg-stat.dat ]; then
+  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
+  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
+  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
+  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
+  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
+  proclin=`expr $head + 1`
+  PROCESS=`sed -n -e ${proclin}p  cmsgrid_final.lhe |  awk '{print $4}'`
+  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 "$PROCESS >>  cmsgrid_final.lhe_F
+  echo "</init>"                                           >>  cmsgrid_final.lhe_F
+  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
+  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
+fi
 #Replace the negative so pythia will work
 sed "s@-1000021@ 1000022@g" cmsgrid_final.lhe           > cmsgrid_final.lhe_F1
 sed "s@1000021@1000022@g"   cmsgrid_final.lhe_F1          > cmsgrid_final.lhe

--- a/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
+++ b/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
@@ -379,18 +379,18 @@ if [ -s pwgstat.dat ]; then
   mv pwgstat.dat pwg-stat.dat
 fi
 
-if [ -s pwg-stat.dat ]; then
-  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
-  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
-  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
-  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
-  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
-  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 10001" >>  cmsgrid_final.lhe_F
-  echo "</init>"                                           >>  cmsgrid_final.lhe_F
-  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
-  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
-fi
+#if [ -s pwg-stat.dat ]; then
+#  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
+#  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+#  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
+#  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
+#  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
+#  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
+#  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 322222" >>  cmsgrid_final.lhe_F
+#  echo "</init>"                                           >>  cmsgrid_final.lhe_F
+#  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
+#  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
+#fi
 #Replace the negative so pythia will work
 sed "s@-1000021@ 1000022@g" cmsgrid_final.lhe           > cmsgrid_final.lhe_F1
 sed "s@1000021@1000022@g"   cmsgrid_final.lhe_F1          > cmsgrid_final.lhe

--- a/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
+++ b/bin/Powheg/runcmsgrid_powheg_hdampgrid.sh
@@ -379,18 +379,20 @@ if [ -s pwgstat.dat ]; then
   mv pwgstat.dat pwg-stat.dat
 fi
 
-#if [ -s pwg-stat.dat ]; then
-#  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-#  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
-#  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
-#  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
-#  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
-#  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
-#  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 322222" >>  cmsgrid_final.lhe_F
-#  echo "</init>"                                           >>  cmsgrid_final.lhe_F
-#  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
-#  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
-#fi
+if [ -s pwg-stat.dat ]; then
+  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
+  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+  head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
+  tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
+  tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
+  head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
+  proclin=`expr $head + 1`
+  PROCESS=`sed -n -e ${proclin}p  cmsgrid_final.lhe |  awk '{print $4}'`
+  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 "$PROCESS >>  cmsgrid_final.lhe_F
+  echo "</init>"                                           >>  cmsgrid_final.lhe_F
+  cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
+  mv cmsgrid_final.lhe_F cmsgrid_final.lhe
+fi
 #Replace the negative so pythia will work
 sed "s@-1000021@ 1000022@g" cmsgrid_final.lhe           > cmsgrid_final.lhe_F1
 sed "s@1000021@1000022@g"   cmsgrid_final.lhe_F1          > cmsgrid_final.lhe

--- a/bin/Powheg/runcmsgrid_powhegjhugen.sh
+++ b/bin/Powheg/runcmsgrid_powhegjhugen.sh
@@ -373,7 +373,9 @@ if [ -s pwg-stat.dat ]; then
   tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
   tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail
   head -${head} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_F
-  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 10001" >>  cmsgrid_final.lhe_F
+  proclin=`expr $head + 1`
+  PROCESS=`sed -n -e ${proclin}p  cmsgrid_final.lhe |  awk '{print $4}'`
+  echo "  "$XSECTION"   "$XSECUNC"  1.00000000000E-00 "$PROCESS >>  cmsgrid_final.lhe_F
   echo "</init>"                                           >>  cmsgrid_final.lhe_F
   cat cmsgrid_final.lhe_tail                               >>  cmsgrid_final.lhe_F
   mv cmsgrid_final.lhe_F cmsgrid_final.lhe


### PR DESCRIPTION
which caused GenXsecAnalyzer to report null cross-section after matching in Pythia8