### PR TITLE
Decay fragment for HH->bbWW (semi-leptonic W decay)

### DIFF
--- a/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_madgraph_pythia8_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/OlivierBondu/genproductions/tree/ed5057598b9fbf246741829603162f1bc6700f7d/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_GF_HH
+
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.3.2.2/Radion_GF_HH/Radion_GF_HH_M650_narrow/v1/Radion_GF_HH_M650_narrow_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            '15:onMode = off',
+            '15:onIfAny = 11 13', # only leptonic tau decays
+            '24:mMin = 0.05',
+            '24:onMode = on', # all W decays
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+            '25:onIfMatch = 24 -24',
+            'ResonanceDecayFilter:filter = on',
+            'ResonanceDecayFilter:exclusive = on', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
+            'ResonanceDecayFilter:eMuAsEquivalent = off', #on: treat electrons and muons as equivalent
+            'ResonanceDecayFilter:eMuTauAsEquivalent = on', #on: treat electrons, muons , and taus as equivalent
+            'ResonanceDecayFilter:allNuAsEquivalent = on', #on: treat all three neutrino flavours as equivalent
+            'ResonanceDecayFilter:mothers = 25,24', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
+            'ResonanceDecayFilter:daughters = 5,5,24,24,11,12,1,1',
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+
+ProductionFilterSequence = cms.Sequence(generator)
+


### PR DESCRIPTION
Content as per title, actual fragment constructed taking inspiration from [HH->bbZ(ll)Z(jj)](https://github.com/cms-sw/genproductions/blob/master/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2B2L2J_madgraph_pythia8_cff.py) as well as [HH->bbVV->bbllnunu](https://github.com/cms-sw/genproductions/blob/master/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2B2L2Nu_madgraph_pythia8_cff.py) decay fragments

May be useful 'soon' as ATLAS is most likely coming with the analysis of this channel for Moriond (no analysis started in CMS as of now)

tagging:
- @DavidMorse and @bendavid for their knowledge of the ResonanceDecayFilter
- @govoni and @giacomoortona for information since we discussed this