### PR TITLE
Changes for bb4l

### DIFF
--- a/bin/Powheg/patches/res_gfortran48.patch
+++ b/bin/Powheg/patches/res_gfortran48.patch
@@ -1,0 +1,307 @@
+Index: include/pwhg_io_interface.h
+===================================================================
+--- include/pwhg_io_interface.h	(revision 3248)
++++ include/pwhg_io_interface.h	(working copy)
+@@ -69,11 +69,12 @@
+       integer, parameter :: z_ok=0
+       integer, parameter:: pwhg_io_maxfiles=10
+       integer, parameter:: szchunk=100
+-      type(c_ptr) :: files_handle(pwhg_io_maxfiles)=c_null_ptr
++c      type(c_ptr) :: files_handle(pwhg_io_maxfiles)=c_null_ptr ! initialization of common block array of type(c_ptr) leads to a gcc segfault
++      type(c_ptr) :: files_handle(pwhg_io_maxfiles)
+ 
+       type pwhg_io_buffer_type
+       sequence
+-      character(len=:), pointer :: buffer
++      character(len=10000) :: buffer
+ c     length: length of buffer
+ c     current: current position in buffer (next read starts at next byte)
+ c     upper: position of last byte already red
+@@ -89,3 +90,4 @@
+       type(pwhg_io_buffer_type) :: pwhg_io_buffer(pwhg_io_maxfiles)
+       common/pwhg_io_interface/files_handle,pwhg_io_buffer,pwhg_io_initialized
+ 
++c			character(len=1000) :: pwhg_io_buffer_buffer(10)
+Index: include/pwhg_rwl.h
+===================================================================
+--- include/pwhg_rwl.h	(revision 3248)
++++ include/pwhg_rwl.h	(working copy)
+@@ -12,7 +12,7 @@
+ 
+       type rwl_weight_info
+          sequence
+-         character(len=:), pointer :: id, desc
++         character(len=100) :: id, desc
+          integer :: group, num_keys
+          integer, pointer :: keys(:,:)
+          real * 8 , pointer :: values(:)
+@@ -21,7 +21,7 @@
+ 
+       type rwl_group_info
+          sequence
+-         character(len=:), pointer :: name, combine
++         character(len=100) :: name, combine
+       end type rwl_group_info
+ 
+       real * 4, pointer :: rwl_weights(:)
+Index: pwhg_io_interface.f
+===================================================================
+--- pwhg_io_interface.f	(revision 3248)
++++ pwhg_io_interface.f	(working copy)
+@@ -5,7 +5,7 @@
+       character(len=*) :: path
+       integer iun,iret
+       call pwhg_io_open('rb',path,iun,iret)
+-      allocate(character(len=szchunk*2)::pwhg_io_buffer(iun)%buffer)
++c4.8.5      allocate(character(len=szchunk*2)::pwhg_io_buffer(iun)%buffer)
+ c     current is the pointer to the file position. Reading will start at
+ c     the next character
+       pwhg_io_buffer(iun)%current=0
+@@ -13,7 +13,7 @@
+       pwhg_io_buffer(iun)%upper=0
+ c     we must always have: 0 <= current <= upper.
+ c     length buffer
+-      pwhg_io_buffer(iun)%length=szchunk*2
++      pwhg_io_buffer(iun)%length=10000
+       pwhg_io_buffer(iun)%mode='rb'
+       end
+ 
+@@ -55,7 +55,7 @@
+       use, intrinsic :: ISO_C_BINDING
+       implicit none
+       include 'pwhg_io_interface.h'
+-      character(*) path,mode
++      character(len=*) :: path, mode
+       integer iun,iret
+       integer j
+       logical ok
+@@ -129,9 +129,9 @@
+             write(*,*) ' iret=',iret
+          endif
+          files_handle(iun) = c_null_ptr
+-         if(pwhg_io_buffer(iun)%buffer == 'rb') then
+-            deallocate(pwhg_io_buffer(iun)%buffer)
+-         endif
++c4.8.5         if(pwhg_io_buffer(iun)%buffer == 'rb') then
++c4.8.5            deallocate(pwhg_io_buffer(iun)%buffer)
++c4.8.5         endif
+       endif
+       pwhg_io_buffer(iun)%opened = .false.
+       end
+@@ -245,7 +245,6 @@
+       implicit none
+       include 'pwhg_io_interface.h'
+       integer iun,nskip
+-      integer(z_off_t) offset,longskip
+       if(.not. pwhg_io_buffer(iun)%opened) then
+          write(*,*) ' pwhg_io_backspace: unit ',iun,
+      1        ' is not opened, exiting ...'
+@@ -297,7 +296,9 @@
+             exit
+          else
+             if(upper+szchunk >  pwhg_io_buffer(iun)%length) then
+-               call pwhg_io_enlarge_buffer
++c4.8.5               call pwhg_io_enlarge_buffer
++              print*,"unimplemented, send email to tomas.jezo@physik.uzh.ch"
++              call exit(-1)
+             endif
+ c read one more chunk into buffer. If it doesn't fit, increase buffer size.
+             inum = gzRead(files_handle(iun),buffer(1:szchunk),szchunk)
+@@ -311,36 +312,36 @@
+             endif
+          endif
+       enddo
+-      contains
+-      subroutine pwhg_io_enlarge_buffer
+-      character (len=:), pointer :: buf
+-      integer i1,h1,i2,h2,length,nu,nl,lg,olg,ibuf,cur,icur
+-      logical, save :: ini=.true.
+-      real(kind=8) :: powheginput
+-      integer, save :: max_io_bufsize
+-      if(ini) then
+-         max_io_bufsize = powheginput("#max_io_bufsize")
+-         if(max_io_bufsize < 0) max_io_bufsize=100000
+-         ini = .false.
+-      endif
+-c     Put safety limit on buffer size
+-      olg=pwhg_io_buffer(iun)%length
+-      lg = olg + 1000
+-      if(lg>max_io_bufsize) then
+-         write(*,*) " pwhg_io_skip_until: we can't find mark '"//mark//"'"
+-         write(*,*) " and are above max_io_bufsize limit."
+-         write(*,*) " if the mark is really there, you must."
+-         write(*,*) " set max_io_bufsize to a value larger than ",
+-     1        max_io_bufsize," in powheg.input"
+-         write(*,*) " exting ..."
+-         call exit(-1)
+-      endif
+-      allocate(character(len=lg)::buf)
+-      buf=pwhg_io_buffer(iun)%buffer(1:olg)
+-      deallocate(pwhg_io_buffer(iun)%buffer)
+-      pwhg_io_buffer(iun)%buffer => buf
+-      pwhg_io_buffer(iun)%length = lg
+-      end subroutine pwhg_io_enlarge_buffer
++c4.8.5      contains
++c4.8.5      subroutine pwhg_io_enlarge_buffer
++c4.8.5      character (len=:), pointer :: buf
++c4.8.5      integer i1,h1,i2,h2,length,nu,nl,lg,olg,ibuf,cur,icur
++c4.8.5      logical, save :: ini=.true.
++c4.8.5      real(kind=8) :: powheginput
++c4.8.5      integer, save :: max_io_bufsize
++c4.8.5      if(ini) then
++c4.8.5         max_io_bufsize = powheginput("#max_io_bufsize")
++c4.8.5         if(max_io_bufsize < 0) max_io_bufsize=100000
++c4.8.5         ini = .false.
++c4.8.5      endif
++c4.8.5c     Put safety limit on buffer size
++c4.8.5      olg=pwhg_io_buffer(iun)%length
++c4.8.5      lg = olg + 1000
++c4.8.5      if(lg>max_io_bufsize) then
++c4.8.5         write(*,*) " pwhg_io_skip_until: we can't find mark '"//mark//"'"
++c4.8.5         write(*,*) " and are above max_io_bufsize limit."
++c4.8.5         write(*,*) " if the mark is really there, you must."
++c4.8.5         write(*,*) " set max_io_bufsize to a value larger than ",
++c4.8.5     1        max_io_bufsize," in powheg.input"
++c4.8.5         write(*,*) " exting ..."
++c4.8.5         call exit(-1)
++c4.8.5      endif
++c4.8.5      allocate(character(len=lg)::buf)
++c4.8.5      buf=pwhg_io_buffer(iun)%buffer(1:olg)
++c4.8.5      deallocate(pwhg_io_buffer(iun)%buffer)
++c4.8.5      pwhg_io_buffer(iun)%buffer => buf
++c4.8.5      pwhg_io_buffer(iun)%length = lg
++c4.8.5      end subroutine pwhg_io_enlarge_buffer
+      
+       end
+ 
+Index: rwl_weightlists.f
+===================================================================
+--- rwl_weightlists.f	(revision 3248)
++++ rwl_weightlists.f	(working copy)
+@@ -186,8 +186,8 @@
+          do kw = 1,rwl_num_weights
+             if(rwl_weights_array(kw)%group == kg) then
+                call pwhg_io_write(iun,"<weight id='"//
+-     1              rwl_weights_array(kw)%id//"' >"//
+-     2              rwl_weights_array(kw)%desc//"</weight>")
++     1              trim(rwl_weights_array(kw)%id)//"' >"//
++     2              trim(rwl_weights_array(kw)%desc)//"</weight>")
+             endif
+          enddo
+          if(kg /= 0) then
+@@ -298,15 +298,15 @@
+       character(len=3) group
+       do j=1,rwl_num_weights
+          write(*,'(a,i2)') 'Weight ',j
+-         write(*,'(a)') '   id='//rwl_weights_array(j)%id//','
++         write(*,'(a)') '   id='//trim(rwl_weights_array(j)%id)//','
+          write(group,'(i3)')  rwl_weights_array(j)%group
+          write(*,'(a,i2)') '   group='//trim(adjustl(group))//','
+          if(rwl_weights_array(j)%num_keys > 0) then
+             write(*,'(a)') '   key value pairs:'
+             do k=1,rwl_weights_array(j)%num_keys
+-               write(*,'(a,d11.5)') '      '//rwl_weights_array(j)%desc(
++               write(*,'(a,d11.5)') '      '//trim(rwl_weights_array(j)%desc(
+      1              rwl_weights_array(j)%keys(1,k):
+-     2              rwl_weights_array(j)%keys(2,k))//'=',
++     2              rwl_weights_array(j)%keys(2,k)))//'=',
+      3              rwl_weights_array(j)%values(k)
+             enddo
+          endif
+@@ -327,7 +327,7 @@
+                if(rwl_weights_array(jw)%group == jg) then
+                   write(tmpstr,'(E11.5)') rwl_weights(jw)
+                   call pwhg_io_write(iun,"<wgt id='"
+-     1                 //rwl_weights_array(jw)%id//"'>"
++     1                 //trim(rwl_weights_array(jw)%id)//"'>"
+      2                 //tmpstr//'</wgt>')
+                endif
+             enddo
+@@ -375,8 +375,8 @@
+                if(j==-1) call errr("did not find end quote after =")
+                i = i+jpos-1
+                j = j+jpos-1
+-               allocate(character(j-i+1)::
+-     1              rwl_groups_array(rwl_num_groups)%name)
++c4.8.5               allocate(character(j-i+1)::
++c4.8.5     1              rwl_groups_array(rwl_num_groups)%name)
+                rwl_groups_array(rwl_num_groups)%name=buf(i:j)
+                jpos = j+2
+             else
+@@ -394,8 +394,12 @@
+                if(j==-1) call errr("did not find end quote after =")
+                i = i+jpos-1
+                j = j+jpos-1
+-               allocate(character(j-i+1)::
+-     1              rwl_groups_array(rwl_num_groups)%combine)
++c4.8.5               allocate(character(j-i+1)::
++c4.8.5     1              rwl_groups_array(rwl_num_groups)%combine)
++            if (j-i>100) then
++              print*,"unimplemented, send email to tomas.jezo@physik.uzh.ch"
++              call exit(-1)
++            endif
+                rwl_groups_array(rwl_num_groups)%combine=buf(i:j)
+                jpos = j+2
+             else
+@@ -410,8 +414,8 @@
+       endif
+       if(iname == 0) call errr("Did not find name in weightgroup")
+       if(icomb == 0) then
+-         allocate(character(1)::
+-     1        rwl_groups_array(rwl_num_groups)%combine)
++c4.8.5         allocate(character(1)::
++c4.8.5     1        rwl_groups_array(rwl_num_groups)%combine)
+          rwl_groups_array(rwl_num_groups)%combine=' '
+       endif
+ c     Check that group is not already present
+@@ -419,8 +423,8 @@
+          if(rwl_groups_array(rwl_num_groups)%name ==
+      1        rwl_groups_array(k)%name) then
+             group = k
+-            deallocate(rwl_groups_array(rwl_num_groups)%name,
+-     1           rwl_groups_array(rwl_num_groups)%combine)
++c4.8.5            deallocate(rwl_groups_array(rwl_num_groups)%name,
++c4.8.5     1           rwl_groups_array(rwl_num_groups)%combine)
+             rwl_num_groups = rwl_num_groups - 1
+             exit
+          endif
+@@ -456,8 +460,13 @@
+      1       ("can't find end of quoted string after id= in a weight")
+             i=i+jpos-1
+             j=j+jpos-1
+-            allocate(character(j-i+1)::
+-     1           rwl_weights_array(rwl_num_weights)%id)
++c4.8.5            allocate(character(j-i+1)::
++c4.8.5     1           rwl_weights_array(rwl_num_weights)%id)
++             
++            if (j-i>100) then
++              print*,"unimplemented, send email to tomas.jezo@physik.uzh.ch"
++              call exit(-1)
++            endif
+             rwl_weights_array(rwl_num_weights)%id=buf(i:j)
+             jpos=j+2
+             if(start_equal_strings(buf,'>',jpos)) then
+@@ -466,8 +475,12 @@
+                if(j>0) then
+                   j=jpos+j-2
+                   jpos=j+len('</weight>')+1
+-                  allocate(character(j-i+1) ::
+-     1                 rwl_weights_array(rwl_num_weights)%desc)
++c4.8.5                  allocate(character(j-i+1) ::
++c4.8.5     1                 rwl_weights_array(rwl_num_weights)%desc)
++                  if (j-i>100) then
++                    print*,"unimplemented, send email to tomas.jezo@physik.uzh.ch"
++                    call exit(-1)
++                  endif
+                   rwl_weights_array(rwl_num_weights)%desc=buf(i:j)
+                else
+                   call errr ("can't find </weight> after <weight>")
+@@ -487,7 +500,7 @@
+          if(rwl_weights_array(rwl_num_weights)%id ==
+      1        rwl_weights_array(k)%id) call errr
+      2        ('This weight id is already present:'//
+-     3        rwl_weights_array(k)%id)
++     3        trim(rwl_weights_array(k)%id))
+       enddo
+ c     Set up arrays of key-value pairs contained in the desc string
+       k=1

--- a/bin/Powheg/patches/res_openloops_long_install_dir.patch
+++ b/bin/Powheg/patches/res_openloops_long_install_dir.patch
@@ -1,0 +1,24 @@
+--- OpenLoopsStuff/OpenLoops/lib_src/openloops/src/ol_interface.F90     (revision 3248)
++++ OpenLoopsStuff/OpenLoops/lib_src/openloops/src/ol_interface.F90     (working copy)
+@@ -990,6 +990,7 @@
+     inquire(directory=trim(install_path)//"/proclib", exist=proclib_exists)
+ #endif
+     if (.not. proclib_exists) then
++      call ol_msg("expected proclib folder in " // trim(install_path))
+       call ol_fatal("register_process: proclib folder not found, check install_path or install libraries.")
+       check_proclib_exists = .false.
+       return
+Index: OpenLoopsStuff/OpenLoops/lib_src/openloops/src/parameters.F90
+===================================================================
+--- OpenLoopsStuff/OpenLoops/lib_src/openloops/src/parameters.F90       (revision 3248)
++++ OpenLoopsStuff/OpenLoops/lib_src/openloops/src/parameters.F90       (working copy)
+@@ -175,7 +175,7 @@
+   ! OpenLoops installation path; used to locate info files and process libraries
+   ! character(len=:), allocatable :: install_path ! gfortran 4.7: doesn't work in modules and type (though it does in subroutines)
+   character(len=255) :: &
+-    & install_path = OL_INSTALL_PATH
++    & install_path = "obj-gfortran/"
+   ! Mode for check_last_[...] in laststep and tensor integral routine in looproutines
+   integer, save :: l_switch = 1, a_switch = 5, a_switch_rescue = 5, redlib_qp = 5
+   ! switchers for checking Ward identities at tree/loop level
+

--- a/bin/Powheg/production/b_bbar_4l_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/b_bbar_4l_NNPDF30_13TeV.input
@@ -1,0 +1,98 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS                                    ! number of events to be generated
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ndns1 131                                        ! pdf set for hadron 1 (mlm numbering) [if not using LHA pdfs]
+ndns2 131                                        ! pdf set for hadron 2 (mlm numbering) [if not using LHA pdfs]
+ebeam1 6500d0                                    ! energy of beam 1
+ebeam2 6500d0                                    ! energy of beam 2
+lhans1 260000                                     ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 260000                                     ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+#QCDLambda5  0.2                                 ! to be set only if using different pdf sets for the two incoming hadrons
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    1                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   3                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 10000                                    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Some standard optional settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#renscfact  1d0                                  ! (default 1d0) ren scale factor: muren  = muref * renscfact
+#facscfact  1d0                                  ! (default 1d0) fac scale factor: mufact = muref * facscfact
+#bornonly   1                                    ! (default 0) if 1 do Born only
+#smartsig   0                                    ! (default 1) remember equal amplitudes (0 do not remember)
+#ptsqmin    0.8                                  ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5                                  ! (default 1.5 GeV) charm treshold for gluon splitting
+#bottomthr  5.0                                  ! (default 5.0 GeV) bottom treshold for gluon splitting
+#testplots  0                                    ! (default 0, do not) do NLO and PWHG distributions
+#charmthrpdf  1.5                                ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0                                ! (default 5.0 GeV) pdf bottom treshold
+
+#iseed    55                                     ! initialize random number sequence
+#rand1     -1                                    ! initialize random number sequence
+#rand2     -1                                    ! initialize random number sequence
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 172.5                                      ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#tmass      172.5d0                              ! (default 172.5) top quark mass (in the matrix element, should be equal to tmass_phsp unless reweighting to a different top mass)
+#tmass_phsp 172.5d0                              ! (default 172.5) top quark mass (in the phase space)
+#twidth                                          ! (default unset) top quark width (calculated from all the other constants, do not change unless you know what you're doing)
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha calculated, 2... wmass, zmass, alpha input; gfermi calculated
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Other settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# clobberlhe 1                                   ! (default 0, do not) Delete pwgevents.lhe file if it exist, instead of exiting
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 1                                ! (default 0) Modifies subtraction to reduce reweighting factors (for adding the virtual contribution during the reweighing stage only) 
+rwl_file '-'                                     ! If set to '-' read the xml reweighting info from this same file. Otherwise, it specifies the xml file with weight information
+<initrwgt>
+<weight id='1'>default</weight>                  ! With this setting, this weight will have the complete result (including virtual corrections)
+</initrwgt>
+rwl_group_events 100                             ! (default 1000) It keeps 100 events in memory, reprocessing them together for reweighting (see README.Compress-And-Weights) 
+lhapdf6maxsets 1                                 ! (default 10) Maximum number of lhapdf6 sets that it can keep in memory (see README.Compress-And-Weights) 


### PR DESCRIPTION
Added basic functionality to create bb4l tarball

Issues:
- [ ] upper bound calculation not correct yet, probably because most stage3 jobs fail with `cannot open the lock pwg-btilde-fullgrid.lock for deletion`
- [ ] cleanup of tarball needed (currently 1G)
- [ ] runcmsgrid.sh needs to be adapted
- [ ] weights might be specified in new input format; stored in compressed format, need to use Pythia8 to read them