### PR TITLE
Settings for ttbar with hdamp UP and DOWN

### DIFF
--- a/bin/Powheg/production/TT_hdampDOWN_TuneT4_NNPDF30_13TeV_powheg/TT_hdampDOWN_TuneT4_NNPDF30_13TeV_powheg.input
+++ b/bin/Powheg/production/TT_hdampDOWN_TuneT4_NNPDF30_13TeV_powheg/TT_hdampDOWN_TuneT4_NNPDF30_13TeV_powheg.input
@@ -1,0 +1,79 @@
+! TTbar production parameters
+!randomseed 352345 ! uncomment to set the random seed to a value of your choice.
+                   ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
+                   ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
+                   ! If POWHEG is interfaced to a shower MC, refer to the shower MC
+                   ! documentation to set its seed.
+
+!Heavy flavour production parameters
+
+numevts NEVENTS    ! number of events to be generated
+iseed   SEED       ! Start the random number generator with seed iseed 
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+#ndns1 131      ! pdf for hadron 1 (hvqpdf numbering)
+#ndns2 131      ! pdf for hadron 2
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+qmass  172.5     ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+#fixedscale 1    ! use ref. scale=qmass (default 0, use running scale)
+hdamp 171.79275
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into b l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+!semileptonic 1      ! uncomment if you want to filter out only semileptonic events. For example,
+                     ! with topdecaymode 10011 and semileptonic 1 you get only events with one top going
+                     ! to an electron or positron, and the other into any hadron.
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.4  ! W mass for top decay
+tdec/wwidth 2.141
+tdec/bmass 4.8
+tdec/twidth  1.31 ! 1.33 using PDG LO formula
+tdec/elbranching 0.108
+tdec/emass 0.00051
+tdec/mumass 0.1057
+tdec/taumass 1.777
+tdec/dmass   0.100
+tdec/umass   0.100
+tdec/smass   0.200
+tdec/cmass   1.5
+tdec/sin2cabibbo 0.051
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 10000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+ixmax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 1       ! PDF reweighting
+dampreweight 1      ! h_damp reweighting (0.9959*mt, 1.581*mt, mt*2.239)
+storeinfo_rwgt 1    ! store weight information
+withnegweights 0    ! default 0

--- a/bin/Powheg/production/TT_hdampUP_TuneT4_NNPDF30_13TeV_powheg/TT_hdampUP_TuneT4_NNPDF30_13TeV_powheg.input
+++ b/bin/Powheg/production/TT_hdampUP_TuneT4_NNPDF30_13TeV_powheg/TT_hdampUP_TuneT4_NNPDF30_13TeV_powheg.input
@@ -1,0 +1,79 @@
+! TTbar production parameters
+!randomseed 352345 ! uncomment to set the random seed to a value of your choice.
+                   ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
+                   ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
+                   ! If POWHEG is interfaced to a shower MC, refer to the shower MC
+                   ! documentation to set its seed.
+
+!Heavy flavour production parameters
+
+numevts NEVENTS    ! number of events to be generated
+iseed   SEED       ! Start the random number generator with seed iseed 
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+#ndns1 131      ! pdf for hadron 1 (hvqpdf numbering)
+#ndns2 131      ! pdf for hadron 2
+! To be set only if using LHA pdfs
+lhans1 260000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+qmass  172.5     ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+#fixedscale 1    ! use ref. scale=qmass (default 0, use running scale)
+hdamp 386.2275
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into b l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+!semileptonic 1      ! uncomment if you want to filter out only semileptonic events. For example,
+                     ! with topdecaymode 10011 and semileptonic 1 you get only events with one top going
+                     ! to an electron or positron, and the other into any hadron.
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.4  ! W mass for top decay
+tdec/wwidth 2.141
+tdec/bmass 4.8
+tdec/twidth  1.31 ! 1.33 using PDG LO formula
+tdec/elbranching 0.108
+tdec/emass 0.00051
+tdec/mumass 0.1057
+tdec/taumass 1.777
+tdec/dmass   0.100
+tdec/umass   0.100
+tdec/smass   0.200
+tdec/cmass   1.5
+tdec/sin2cabibbo 0.051
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 10000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+ixmax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 1       ! PDF reweighting
+dampreweight 1      ! h_damp reweighting (0.9959*mt, 1.581*mt, mt*2.239)
+storeinfo_rwgt 1    ! store weight information
+withnegweights 0    ! default 0


### PR DESCRIPTION
Hdamp varied up and down 1 sigma around the central TuneCUETP8M2T4 value (hdamp = 1.5*mtop  = 272.7225) used in production/TT_hdamp_TuneT4_NNPDF30_13TeV_powheg/TT_hdamp_TuneT4_NNPDF30_13TeV_powheg.input

Value UP = 386.2275, 
Value DOWN = 171.79275
These settings are needed in the context of the issue found in the hdamp POWHEG reweighing (see https://groups.cern.ch/group/cms-top-generator/Lists/Archive/Flat.aspx?RootFolder=%2Fgroup%2Fcms-top-generator%2FLists%2FArchive%2FNew%20POWHEG%20reweighting%20and%20hdamp&FolderCTID=0x01200200442BB355AC2B2843B16F88D99458A0EC )