### PR TITLE
include the SVN revision number in the name of powheg tar ball

### DIFF
--- a/bin/Powheg/source/create_source.sh
+++ b/bin/Powheg/source/create_source.sh
@@ -6,8 +6,8 @@ EXPECTED_ARGS=1
 
 if [ $# -ne $EXPECTED_ARGS ]
 then
-    echo "Usage: `basename $0` outputtarball_prefix"
-    echo "Example: `basename $0` powhegboxV2_Oct2015"
+    echo "Usage: `basename $0` workdir_prefix"
+    echo "Example: `basename $0` my"
     exit 1
 fi
 
@@ -16,8 +16,8 @@ echo "         Running Powheg  "$basename"                         "
 echo "   ______________________________________________________    "
 
 topdir=$PWD
-output=$1
-workdir=$topdir/temp_$output
+prefix=$1
+workdir=$topdir/temp_$prefix
 
 if [[ -e ${workdir} ]]; then
   fail_exit "The directory ${workdir} exists! Please clean up your work directory before running!!"
@@ -30,6 +30,10 @@ cd $workdir
 svn checkout --username anonymous --password anonymous svn://powhegbox.mib.infn.it/trunk/POWHEG-BOX-V2 POWHEG-BOX
 
 powhegdir=$workdir/POWHEG-BOX
+cd $powhegdir
+version=`svn info | grep -a "Revision" | awk '{print $2}'`
+cd -
+output=powhegboxV2_rev${version}
 
 ### Check out user process
 svn co --username anonymous --password anonymous svn://powhegbox.mib.infn.it/trunk/User-Processes-V2 

--- a/bin/Powheg/source/create_source.sh
+++ b/bin/Powheg/source/create_source.sh
@@ -32,8 +32,9 @@ svn checkout --username anonymous --password anonymous svn://powhegbox.mib.infn.
 powhegdir=$workdir/POWHEG-BOX
 cd $powhegdir
 version=`svn info | grep -a "Revision" | awk '{print $2}'`
+date=`date +%Y%m%d`
 cd -
-output=powhegboxV2_rev${version}
+output=powhegboxV2_rev${version}_date${date}
 
 ### Check out user process
 svn co --username anonymous --password anonymous svn://powhegbox.mib.infn.it/trunk/User-Processes-V2 

--- a/bin/Powheg/source/create_source.sh
+++ b/bin/Powheg/source/create_source.sh
@@ -47,8 +47,8 @@ do
 done
 
 cd $workdir
-tar cspzf ${output}.tar.gz --exclude .svn POWHEG-BOX
-
+#tar cspzf ${output}.tar.gz --exclude .svn POWHEG-BOX
+tar cspzf ${output}.tar.gz POWHEG-BOX
 sourcedir=/afs/cern.ch/cms/generators/www/slc6_amd64_gcc481/powheg/V2.0/src
 
 mv ${output}.tar.gz $sourcedir/${output}.tar.gz 


### PR DESCRIPTION
Instead of using any random name for the powheg tar ball, we include the SVN revision of POWHEG BOX V2 in the name.
