### PR TITLE
add additional command line parameter to allow simple inclusion of ex…

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -32,9 +32,12 @@ carddir=${2}
 # which queue
 queue=${3}
 
+# provide new model files
+modeldir=${4}
+
 if [ -z "$PRODHOME" ]; then
   PRODHOME=`pwd`
-fi 
+fi
 
 if [ ! -z ${CMSSW_BASE} ]; then
   echo "Error: This script must be run in a clean environment as it sets up CMSSW itself.  You already have a CMSSW environment set up for ${CMSSW_VERSION}."
@@ -75,6 +78,9 @@ echo "System release " `cat /etc/redhat-release` #And the system release
 echo "name: ${name}"
 echo "carddir: ${carddir}"
 echo "queue: ${queue}"
+if [ -n "${modeldir}" ]; then
+    echo "modeldir: ${modeldir}"
+fi
 
 cd $PRODHOME
 git status
@@ -149,9 +155,20 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
   cd $MGBASEDIRORIG
   cat $PRODHOME/patches/*.patch | patch -p1
 
+  # copy model provided to model directory
+  if [ -n "${modeldir}" ]; then
+      if [ "${modeldir[0]}" == '/' ]; then
+          # absolute path
+          cp -r ${modeldir} models/
+      else
+          # relative path
+          cp -r ${RUNHOME}/${modeldir} models/
+      fi
+  fi
+
   #if lhapdf6 external is available then above points to lhapdf5 and needs to be overridden
   LHAPDF6TOOLFILE=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/available/lhapdf6.xml
-    
+
   if [ -e $LHAPDF6TOOLFILE ]; then
     LHAPDFCONFIG=`cat $LHAPDF6TOOLFILE | grep "<environment name=\"LHAPDF6_BASE\"" | cut -d \" -f 4`/bin/lhapdf-config
   else


### PR DESCRIPTION
…ternal models for MadGraph5_aMCatNLO gridpack generation.

This is what I referred to in #1135. I actually just found that something in the line of that is already possible (but unfortunately not documented):
https://github.com/cms-sw/genproductions/blob/master/bin/MadGraph5_aMCatNLO/gridpack_generation.sh#L217-L240

The external models need to be available from https://cms-project-generators.web.cern.ch/cms-project-generators/ though - which is not the case for the model in #1135.

The changes I implemented simply allow to provide a directory containing the model as additional parameter (`$4`) after the choice of the batch queue. I agree that all models that are used in CMS should be stored centrally, so maybe the existing approach is better. However, mind that for basically all BulkGraviton samples `*_extramodels.dat` files need to be created, otherwise the gridpack generation won't work.