### PR TITLE
update cross sections for Qstar to qV samples

### DIFF
--- a/python/ThirteenTeV/QstarToQW_M_1000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_1000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(108.7),
+	crossSection = cms.untracked.double(1.059e+02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_1200_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_1200_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(65.84),
+	crossSection = cms.untracked.double(4.602e+01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_1400_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_1400_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(41.76),
+	crossSection = cms.untracked.double(2.172e+01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_1600_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_1600_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(26.81),
+	crossSection = cms.untracked.double(1.106e+01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_1800_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_1800_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(18.12),
+	crossSection = cms.untracked.double(6.002e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_2000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_2000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(12.19),
+	crossSection = cms.untracked.double(3.306e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_2500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_2500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(4.835),
+	crossSection = cms.untracked.double(8.839e-01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(2.016),
+	crossSection = cms.untracked.double(2.670e-01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_3500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_3500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.8733),
+	crossSection = cms.untracked.double(8.597e-02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_4000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_4000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.4255),
+	crossSection = cms.untracked.double(2.913e-02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_4500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_4500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.2199),
+	crossSection = cms.untracked.double(9.895e-03),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.1244),
+	crossSection = cms.untracked.double(3.453e-03),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_5500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_5500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.07386),
+	crossSection = cms.untracked.double(1.208e-03),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_6000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_6000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.04891),
+	crossSection = cms.untracked.double(4.144e-04),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_600_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_600_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(346.2),
+	crossSection = cms.untracked.double(9.554e+02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_6500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_6500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.0317),
+	crossSection = cms.untracked.double(1.445e-04),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_7000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_7000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.02254),
+	crossSection = cms.untracked.double(5.091e-05),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_7500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_7500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.01638),
+	crossSection = cms.untracked.double(1.891e-05),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQW_M_800_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW_M_800_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(183.7),
+	crossSection = cms.untracked.double(2.896e+02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_1000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_1000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(39.03),
+	crossSection = cms.untracked.double(3.906e+01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_1200_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_1200_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(23.65),
+	crossSection = cms.untracked.double(1.676e+01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_1400_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_1400_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(15.21),
+	crossSection = cms.untracked.double(7.954e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_1600_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_1600_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(9.986),
+	crossSection = cms.untracked.double(3.971e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_1800_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_1800_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(6.537),
+	crossSection = cms.untracked.double(2.164e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_2000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_2000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(4.439),
+	crossSection = cms.untracked.double(1.200e+00),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_2500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_2500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(1.72),
+	crossSection = cms.untracked.double(3.168e-01),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_3000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.715),
+	crossSection = cms.untracked.double(9.440e-02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_3500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_3500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.3164),
+	crossSection = cms.untracked.double(3.035e-02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_4000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_4000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.1526),
+	crossSection = cms.untracked.double(1.019e-02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_4500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_4500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.07724),
+	crossSection = cms.untracked.double(3.495e-03),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_5000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.04351),
+	crossSection = cms.untracked.double(1.210e-03),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_5500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_5500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.02666),
+	crossSection = cms.untracked.double(4.161e-04),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_6000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_6000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.01695),
+	crossSection = cms.untracked.double(1.439e-04),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_600_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_600_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(125.4),
+	crossSection = cms.untracked.double(3.510e+02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_6500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_6500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.01162),
+	crossSection = cms.untracked.double(5.035e-05),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_7000_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_7000_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.008152),
+	crossSection = cms.untracked.double(1.772e-05),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_7500_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_7500_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(0.005915),
+	crossSection = cms.untracked.double(6.632e-06),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/python/ThirteenTeV/QstarToQZ_M_800_TuneCUETP8M1_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ_M_800_TuneCUETP8M1_13TeV_pythia8_cfi.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
 	comEnergy = cms.double(13000.0),
-	crossSection = cms.untracked.double(66.86),
+	crossSection = cms.untracked.double(1.056e+02),
 	filterEfficiency = cms.untracked.double(1),
 	maxEventsToPrint = cms.untracked.int32(0),
 	pythiaHepMCVerbosity = cms.untracked.bool(False),


### PR DESCRIPTION
These have been calculated using 10,000 events each. Unfortunately, we realised that these values are the ones returned by DAS/MCM, so this is just in case a new production will be done in the future and also for documentation.