### PR TITLE
ttb_NLO_dec with meta gridpack including all decay channels

### DIFF
--- a/bin/Powheg/patches/pwhg_rad_kinreg.patch
+++ b/bin/Powheg/patches/pwhg_rad_kinreg.patch
@@ -1,0 +1,21 @@
+--- POWHEG-BOX/gen_radiation.f	(Revision 3334)
++++ POWHEG-BOX/gen_radiation.f	(Revision 3335)
+@@ -195,7 +195,7 @@
+       real * 8 t,csi,y,azi,sig,born
+       real * 8 tmax
+       common/ctmax/tmax
+-      integer kinreg,firstreg,lastreg,fl1,fl2,flemitter
++      integer kinreg,jkinreg,firstreg,lastreg,fl1,fl2,flemitter
+       logical ini
+       data ini/.true./
+       real * 8 pwhg_pt2,powheginput
+@@ -216,7 +216,8 @@
+ c Use highest bid procedure (see appendix B of FNO2006)
+       tmax=0
+       kinreg=0
+-      do rad_kinreg=firstreg,lastreg
++      do jkinreg=firstreg,lastreg
++         rad_kinreg = jkinreg
+          if(rad_kinreg_on(rad_kinreg)) then
+             if(rad_kinreg.eq.1) then
+ c     initial state radiation

--- a/bin/Powheg/patches/pwhg_ttb_NLO_dec_gen_radiation_hook.patch
+++ b/bin/Powheg/patches/pwhg_ttb_NLO_dec_gen_radiation_hook.patch
@@ -1,0 +1,363 @@
+--- POWHEG-BOX/Bornzerodamp.f 2016-09-23 15:15:29.000000001 +0200
++++ POWHEG-BOX/Bornzerodamp.f 2017-06-21 18:53:35.000000001 +0200
+@@ -30,19 +30,22 @@
+          endif
+          if(h.gt.0) then
+             write(*,*)'***************************************'
+-            write(*,*)' Using a damping factor h**2/(pt2+h**2)'
++            write(*,*)' Using a damping factor h^2/(pt2+h^2)'
+             write(*,*)' to separate real contributions between'
+-            write(*,*)' Sudakov and remnants    h=',h,' GeV   ' 
++            write(*,*)' Sudakov and remnants    h=',h
+             write(*,*)'***************************************'
+          endif
+          ini=.false.
+       endif
+-c local variables
+-      if(h.gt.0) then
+-         pt2=pwhg_pt2()
+-         dampfac=h**2/(pt2+h**2)
+-      else
+-         dampfac=1
++c
++      dampfac = 1
++      if(flst_alrres(nlegreal,alr).eq.0) then
++c hfact applied only for radiation in production
++         if(h.gt.0) then
++            
++            pt2 = kn_cmpreal(1,nlegreal)**2+kn_cmpreal(2,nlegreal)**2
++            dampfac=h**2/(pt2+h**2)
++         endif
+       endif
+ 
+       if(flg_bornzerodamp.and.r0.gt.5*rc.and.r0.gt.5*rs) then
+
+--- POWHEG-BOX/ttb_NLO_dec/gen_radiation_hook.f	2017-04-11 09:27:23.000000001 +0200
++++ POWHEG-BOX/ttb_NLO_dec/gen_radiation_hook.f 2017-06-23 11:31:46.000000001 +0200
+@@ -3,40 +3,131 @@
+       include 'nlegborn.h'
+       include 'pwhg_rad.h'
+       include 'pwhg_kn.h'
++      include 'pwhg_flg.h'
++      include 'pwhg_flst.h'
+       real * 8 t,tmax
+-      integer save_rad_kinreg
++      integer save_rad_kinreg,save_rad_realalr,save_kn_emitter,save_rad_alr_nlist 
+       logical save_on
+-      real * 8 save_kn_csi,save_kn_y,save_kn_azi,save_kn_emitter
+-      integer jnlowhich,allrad,fladec,fltdec
++      real * 8 save_kn_csi,save_kn_y,save_kn_azi
++      integer jnlowhich,allrad,fladec,fltdec,alr,em,j,local_alr_nlist
+       common/cjnlowhich/jnlowhich,allrad,fladec,fltdec
++
++c     this subroutine is called just after a gen_remnant call.  If it's
++c     a genuine remnant (not a regular), then an emitter has been
++c     selected. Since for this process we are only allowing remnants
++c     from radiation from production (hdamp), check that the emitter and
++c     rad_kinreg are compatible.
++c      print*, 'rad_kinreg,kn_csi = ',rad_kinreg,kn_csi
++      if(kn_emitter.gt.2.or.rad_kinreg.ne.1.or.kn_csi.eq.0d0) then
++         write(*,*) 'error in gen_remnant_hook: kn_emitter,rad_kinreg,kn_csi '
++     $        ,kn_emitter,rad_kinreg,kn_csi
++         call exit(-1)
++      endif
++c     We are not allowing bornzerodamp for this process (see
++c     init_couplings.f).
++      if(flg_bornzerodamp) then
++         write(*,*) 'error in gen_remnant_hook: flg_bornzerodamp'
++         call exit(-1)
++      endif
++
++c     if we are not doing allrad, we are done. Just keep doing what
++c     normal powheg would do (which in this case is writing a remmant
++c     event with just radiation from production).
+       if(allrad.ne.1) return
+ 
++c     first, save the current kinematics (remnant configuration).
++c      print*, 'UB PROCESS ',flst_born(:,rad_ubornidx)
++c      print*, 'REMN PROCESS ',flst_alr(:,rad_realalr)
++
+       save_kn_emitter = kn_emitter
+       save_rad_kinreg = rad_kinreg
+       save_kn_csi = kn_csi
+       save_kn_y = kn_y
+       save_kn_azi = kn_azi
++      save_rad_realalr = rad_realalr
++      save_rad_alr_nlist = rad_alr_nlist
++      save_on = rad_kinreg_on(1)
++
++cccccccccc      
++c     No need to reset rad_kinreg to 1 (as if we are here, it must be
++c     1, see above).  However, let's do it explicitly, helps reading the code.
+       rad_kinreg = 1
+       call gen_radiation_hook(t,tmax)
++cccccccccc
++      
++c     At this point, there has not been any loop on other emissions
++c     (from resonances). The (remnant) ISR has just been stored by means
++c     of the previous variables, and the previous call to
++c     gen_radiation_hook makes sure that the skn_cmpreal for ISR is
++c     filled properly starting from the true remnant kinematics. I now
++c     need to loop over all other regions, as allrad=1. However at this
++c     point, rad_kinreg_on(*) is all set to false, as the place where
++c     it's filled properly is gen_uborn_idx (but we haven't called it
++c     here, we are generating a remnant event).  To fill it properly, we
++c     repeat here what we would do in gen_uborn_idx, recalling that
++c     rad_ubornidx has just been set in gen_remnant. Moreover, to
++c     generate radiation properly, I need to have rad_alr_nlist
++c     set.
++      rad_alr_nlist=flst_born2alr(0,rad_ubornidx)
++      do j=1,rad_alr_nlist
++         alr=flst_born2alr(j,rad_ubornidx)
++         em=flst_emitter(alr)
++         rad_alr_list(j)=alr
++         if(em.le.2) then
++            rad_kinreg_on(1)=.true.
++         else
++            rad_kinreg_on(em-flst_lightpart+2)=.true.
++         endif
++      enddo
+ 
+-      save_on = rad_kinreg_on(1)
+-      rad_kinreg_on(1) = .false.
++c     overwrite rad_kinreg_on(1)=false, as I don't want to generate that
++c     again (we are in a remnant event, it has been already generated!)
++      rad_kinreg_on(1)=.false.
++c     If I allow the code to re-generate the ISR for a remnant, I'll end
++c     up with a wrong LHE file (for instance, scalup will not match).
++c     This is because I would put in sn_kncmpreal the wrong kinematics,
++c     rather than the correct, original, one. Calling the radiation_hook
++c     on the correct kinematics (see above), and setting
++c     rad_kinreg_on(1)=false, prevents this error to happen.
++
++c     Now generate all other possible emissions (emissions from the
++c     decay(s)).
++      
+       call gen_radiation
+-      rad_kinreg_on(1) = save_on
+-c gen_radiation has certainly changed the following variables,
+-c since it has computed radiation from resonances. Must put back
+-c the remnant ISR type event.
++
++c     gen_radiation has certainly changed the following variables, since
++c     it has computed radiation from resonances. Must put back the
++c     remnant ISR type event.  Before doing so, check that rad_kinreg
++c     was set to zero. This is the case due to the fact that, because of
++c     the hook, t is never bigger than tmax, so in gen_radiation, kinreg
++c     stays equal to zero (whilst rad_kinreg is changing...)
++      if(rad_kinreg.ne.0) then
++         write(*,*) 'error in gen_remnant_hook, rad_kinreg = ',rad_kinreg
++         call exit(-1)
++      endif
++      
+       rad_kinreg = save_rad_kinreg
+       kn_emitter = save_kn_emitter
+       kn_csi = save_kn_csi
+       kn_y = save_kn_y
+       kn_azi = save_kn_azi
+-
++      rad_realalr = save_rad_realalr
++      rad_alr_nlist = save_rad_alr_nlist 
++      rad_kinreg_on(1) = save_on
++      
+ c generate again the remnant phase space;
+ c the LH routines assumes that the initial state
+-c radiation configuration is in the kn block.
++c radiation configuration is in the kn block. 
+       call gen_real_phsp_isr_rad
+ 
++c     The above is needed as if we are in the allrad+remnant
++c     configuration, then in the gen_radiation subroutine I don't rech
++c     the call to gen_real_phsp_isr_rad (because kinreg stays equal to
++c     zero). The call to set_rad_scales is taken care of in pwhgevent
++c     (as usual for a remnant, in the remnant branch of the main if
++c     block). The flavour configuration was already decided by
++c     gen_remnant, and it's saved via rad_realalr.
++
+       end
+       
+       subroutine gen_radiation_hook(t,tmax)
+@@ -61,6 +152,7 @@
+       integer o_radkinreg
+       data o_radkinreg/100/
+       save o_radkinreg
++c      print*, '    in gen_radiation_hook: csi = ',kn_csi
+       if(allrad.ne.1) return
+       if(rad_kinreg.lt.o_radkinreg) then
+          radres = 0
+@@ -69,11 +161,12 @@
+          index = 0
+       endif
+       o_radkinreg = rad_kinreg
+-c if no radiation was generted at this stage, skip;
++c if no radiation was generated at this stage, skip;
+ c but go to last lines to setup output values of t, tmax and rad_kinreg
+       if(kn_csi.eq.0) goto 998
+       index = index + 1
+       if(rad_kinreg.eq.1) then
++c         print*, '       --> hook: emission from production,index= ',index
+          indcur = index
+          res = 1
+       else
+@@ -95,22 +188,27 @@
+             endif
+          enddo
+       endif
++c      print*, '       --> hook: emission from resonance (res,index) = ',res,index
+       if(index.gt.5) then
+          write(*,*) ' gen_radiation_hook: got more than 5 regions!'
+          call exit(-1)
+       endif
+       radres(indcur) = res
+       tgen(indcur)   = t
++c      print*, 'calling offshellmapreal in gen_rad_hook, res= ',res
++c     $     ,' 3,4,5,6=t,tb,wp,wm'
++c      print*, 'csi for this emission: ',kn_csi
+       call offshellmapreal
+       vecl = (/ 0,0,1 /)
+       betal = ( kn_x1 - kn_x2 )/( kn_x1 + kn_x2 )
+       call mboost(nlegreal,vecl,-betal,preal_os,
+      1     skn_cmpreal(0:3,1:nlegreal,indcur))
++c      print*, '       --> saved kinematics skn_cmpreal for indcur,t = ',indcur,tgen(indcur)
+  998  if(rad_kinreg.eq.1) then
+ c make sure that ISR always wins, since t>tmax
+ c with this settings, tmax will be still 0 at the first
+-c round (we want all regions to try to radiate down to 0
+-         if(kn_csi.eq.0) rad_kinreg = 0
++c round (we want all regions to try to radiate down to 0)
++         if(kn_csi.eq.0) rad_kinreg = 0 !ER: I am not sure I understand this line. Maybe it's just to make sure that when I pass through this hook, if I was in a Btilde event without ISR radiation, I save that information.
+          t    =  0
+          tmax = -1
+       else
+@@ -141,6 +239,7 @@
+       integer ii1,ii2,it,itb,iwp,iwm,iwpa,iwpf,iwmf,iwma,ib,ibb,ip
+       common/inputprocind/ii1,ii2,it,itb,iwp,iwm,iwpa,iwpf,iwmf,iwma,
+      1     ib,ibb,ip
++      real *8 wmom_tdec(0:3),wmom_wdec(0:3),dotp
+ c No emissions or a single emission; nothing to do
+       if(index.lt.1) then
+          if(rad_kinreg.ne.0) then
+@@ -160,6 +259,7 @@
+       kwp = 0
+ c radiation from w-
+       kwm = 0
++
+       do j=1,index
+          if(radres(j).eq.1) then
+             kir = j
+@@ -173,8 +273,12 @@
+             kwm = j
+          endif
+       enddo
++c      print*, 'combine emission: index,kir,ktp,ktm,kwp,kwm ',index,kir
++c     $     ,ktp,ktm,kwp,kwm
++c      print*, skn_cmpreal(0,:,index)
+       if(ktp.ne.0.or.kwp.ne.0) then
+          if(ktp.eq.0) then
++c            print*, '>>>>> WP, no top'
+             tpmoms(:,1) = skn_cmpreal(:,it,kwp)
+             tpmoms(:,2) = skn_cmpreal(:,ib,kwp)
+             tpmoms(:,3) = 0
+@@ -183,6 +287,7 @@
+             tpmoms(:,6) = skn_cmpreal(:,iwpa,kwp)
+             tpmoms(:,7) = skn_cmpreal(:,nlegreal,kwp)
+          elseif(kwp.eq.0) then
++c            print*, '>>>>> top, no WP'
+             tpmoms(:,1) = skn_cmpreal(:,it,ktp)
+             tpmoms(:,2) = skn_cmpreal(:,ib,ktp)
+             tpmoms(:,3) = skn_cmpreal(:,nlegreal,ktp)
+@@ -191,21 +296,27 @@
+             tpmoms(:,6) = skn_cmpreal(:,iwpa,ktp)
+             tpmoms(:,7) = 0
+          else
++c            print*, '>>>>> top, WP'
+             tpmoms(:,1) = skn_cmpreal(:,it,ktp)
+             tpmoms(:,2) = skn_cmpreal(:,ib,ktp)
+             tpmoms(:,3) = skn_cmpreal(:,nlegreal,ktp)
+             
+             tpmoms(:,4) = skn_cmpreal(:,iwp,ktp)
++c            wmom_tdec(:) = tpmoms(:,4) !ER:
+             tpmoms(:,5) = skn_cmpreal(:,iwpf,kwp)
+             tpmoms(:,6) = skn_cmpreal(:,iwpa,kwp)
+             tpmoms(:,7) = skn_cmpreal(:,nlegreal,kwp)
++            wmom_wdec(:) = tpmoms(:,5)+tpmoms(:,6)+tpmoms(:,7)
++            !print*, 'virtualities ',dotp(wmom_tdec,wmom_tdec)
++!     $           ,dotp(wmom_wdec,wmom_wdec)
++            
+ c boost first to top rest frame            
+             call boost2reson(tpmoms(:,1),4,tpmoms(:,4:7),tpmoms(:,4:7))
+ c next boost to their own rest frame
+-            call boost2reson(tpmoms(:,5)+tpmoms(:,6)+tpmoms(:,7),4,
++            call boost2reson(tpmoms(:,5)+tpmoms(:,6)+tpmoms(:,7),3,
+      1           tpmoms(:,5:7),tpmoms(:,5:7))
+ c boost W decay products to W frame
+-            call boost2resoninv(tpmoms(:,4),4,
++            call boost2resoninv(tpmoms(:,4),3,
+      1           tpmoms(:,5:7),tpmoms(:,5:7))
+ c boost back to top frame
+             call boost2resoninv(tpmoms(:,1),4,tpmoms(:,4:7),
+@@ -214,6 +325,7 @@
+       endif
+       if(ktm.ne.0.or.kwm.ne.0) then
+          if(ktm.eq.0) then
++c            print*, '>>>>> WM, no atop'
+             tmmoms(:,1) = skn_cmpreal(:,itb,kwm)
+             tmmoms(:,2) = skn_cmpreal(:,ibb,kwm)
+             tmmoms(:,3) = 0
+@@ -222,6 +334,7 @@
+             tmmoms(:,6) = skn_cmpreal(:,iwma,kwm)
+             tmmoms(:,7) = skn_cmpreal(:,nlegreal,kwm)
+          elseif(kwm.eq.0) then
++c            print*, '>>>>> atop, no WM'
+             tmmoms(:,1) = skn_cmpreal(:,itb,ktm)
+             tmmoms(:,2) = skn_cmpreal(:,ibb,ktm)
+             tmmoms(:,3) = skn_cmpreal(:,nlegreal,ktm)
+@@ -230,6 +343,7 @@
+             tmmoms(:,6) = skn_cmpreal(:,iwma,ktm)
+             tmmoms(:,7) = 0
+          else
++c            print*, '>>>>> atop, WM'
+             tmmoms(:,1) = skn_cmpreal(:,itb,ktm)
+             tmmoms(:,2) = skn_cmpreal(:,ibb,ktm)
+             tmmoms(:,3) = skn_cmpreal(:,nlegreal,ktm)
+@@ -241,10 +355,10 @@
+ c boost first to top rest frame            
+             call boost2reson(tmmoms(:,1),4,tmmoms(:,4:7),tmmoms(:,4:7))
+ c next boost to their own rest frame
+-            call boost2reson(tmmoms(:,5)+tmmoms(:,6)+tmmoms(:,7),4,
++            call boost2reson(tmmoms(:,5)+tmmoms(:,6)+tmmoms(:,7),3,
+      1           tmmoms(:,5:7),tmmoms(:,5:7))
+ c boost W decay products to W frame
+-            call boost2resoninv(tmmoms(:,4),4,
++            call boost2resoninv(tmmoms(:,4),3,
+      1           tmmoms(:,5:7),tmmoms(:,5:7))
+ c boost back to top frame
+             call boost2resoninv(tmmoms(:,1),4,tmmoms(:,4:7),
+@@ -282,7 +396,8 @@
+          if(tmperr.gt.1d-6) then
+             write(*,*) ' tpmoms'
+             call checktp(tpmoms)
+-            write(*,*) sum(abs(final_cm(:,it)-tpmoms(:,1)))
++            write(*,*) final_cm(:,it)-tpmoms(:,1)
++            stop
+          endif
+          final_cm(:,ib) = tpmoms(:,2)
+          final_cm(:,iwp) = tpmoms(:,4)
+@@ -296,7 +411,8 @@
+          if(tmperr.gt.1d-6) then
+             write(*,*) ' tmmoms'
+             call checktp(tmmoms)
+-            write(*,*) sum(abs(final_cm(:,itb)-tmmoms(:,1)))
++            write(*,*) final_cm(:,itb)-tmmoms(:,1)
++            stop
+          endif
+          final_cm(:,ibb) = tmmoms(:,2)
+          final_cm(:,iwm) = tmmoms(:,4)
+@@ -358,6 +474,7 @@
+             endif
+          endif
+       enddo
++c      print*, 'CHECKING MOM CONS AT THE END'
+       call check_leshouches
+       end
+ 

--- a/bin/Powheg/patches/pwhg_ttb_NLO_dec_gen_radiation_hook.patch
+++ b/bin/Powheg/patches/pwhg_ttb_NLO_dec_gen_radiation_hook.patch
@@ -1,36 +1,14 @@
---- POWHEG-BOX/Bornzerodamp.f 2016-09-23 15:15:29.000000001 +0200
-+++ POWHEG-BOX/Bornzerodamp.f 2017-06-21 18:53:35.000000001 +0200
-@@ -30,19 +30,22 @@
-          endif
-          if(h.gt.0) then
-             write(*,*)'***************************************'
--            write(*,*)' Using a damping factor h**2/(pt2+h**2)'
-+            write(*,*)' Using a damping factor h^2/(pt2+h^2)'
-             write(*,*)' to separate real contributions between'
--            write(*,*)' Sudakov and remnants    h=',h,' GeV   ' 
-+            write(*,*)' Sudakov and remnants    h=',h
-             write(*,*)'***************************************'
-          endif
-          ini=.false.
+--- POWHEG-BOX/ttb_NLO_dec/Bornzerodamp.f	2016-09-23 15:22:09.000000000 +0200
++++ POWHEG-BOX/ttb_NLO_dec/Bornzerodamp.f	2017-06-21 18:53:35.000000000 +0200
+@@ -39,7 +39,7 @@
        endif
--c local variables
--      if(h.gt.0) then
--         pt2=pwhg_pt2()
--         dampfac=h**2/(pt2+h**2)
--      else
--         dampfac=1
-+c
-+      dampfac = 1
+ c
+       dampfac = 1
+-      if(flst_realres(nlegreal,alr).eq.0) then
 +      if(flst_alrres(nlegreal,alr).eq.0) then
-+c hfact applied only for radiation in production
-+         if(h.gt.0) then
-+            
-+            pt2 = kn_cmpreal(1,nlegreal)**2+kn_cmpreal(2,nlegreal)**2
-+            dampfac=h**2/(pt2+h**2)
-+         endif
-       endif
- 
-       if(flg_bornzerodamp.and.r0.gt.5*rc.and.r0.gt.5*rs) then
+ c hfact applied only for radiation in production
+          if(h.gt.0) then
+
 
 --- POWHEG-BOX/ttb_NLO_dec/gen_radiation_hook.f	2017-04-11 09:27:23.000000001 +0200
 +++ POWHEG-BOX/ttb_NLO_dec/gen_radiation_hook.f 2017-06-23 11:31:46.000000001 +0200

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/generate_all_ttb_NLO_dec.py
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/generate_all_ttb_NLO_dec.py
@@ -16,10 +16,10 @@ def main():
                         elif 'tbardec' in line:
                             f.write('tbardec ' + str(modes[tbarmode]) + ' ! 11, 13 and 15 for e+,mu+,tau+, 1 for hadrons\n')
                         else: f.write(line)
-            cmd = 'python ./run_pwg.py -p f -i ttb_NLO_dec_%s_%s_NNPDF30_13TeV.input -f ttb_NLO_dec_%s_%s_NNPDF30_13TeV -m ttb_NLO_dec -n 1000'%(topmode,tbarmode,topmode,tbarmode)
+            cmd = 'python ./run_pwg_parallel.py -i ttb_NLO_dec_%s_%s_NNPDF30_13TeV.input -f ttb_NLO_dec_%s_%s_NNPDF30_13TeV -m ttb_NLO_dec -q 2nd -j 24 -x 2 --step3pilot'%(topmode,tbarmode,topmode,tbarmode)
             print(cmd)
             if os.path.isfile('ttb_NLO_dec_%s_%s_NNPDF30_13TeV/pwgevents.lhe'%(topmode,tbarmode)):
-                print('Skipping as pwgevent.lhe is present')
+                print('Skipping %s_%s as pwgevent.lhe is present'%(topmode,tbarmode))
             else:
                 os.system(cmd)
 

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/generate_all_ttb_NLO_dec.py
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/generate_all_ttb_NLO_dec.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python
+import sys
+import os
+
+def main():
+
+    modes = {'e': 11, 'mu': 13, 'tau': 15, 'had': 1}
+    
+    for topmode in modes:
+        for tbarmode in modes:
+            with open('ttb_NLO_dec_%s_%s_NNPDF30_13TeV.input'%(topmode,tbarmode), 'w') as f:
+                with open('ttb_NLO_dec_template_NNPDF30_13TeV.input', 'r') as template:
+                    for line in template:
+                        if 'topdec' in line:
+                            f.write('topdec ' + str(modes[topmode]) + ' ! 11, 13 and 15 for e+,mu+,tau+, 1 for hadrons\n')
+                        elif 'tbardec' in line:
+                            f.write('tbardec ' + str(modes[tbarmode]) + ' ! 11, 13 and 15 for e+,mu+,tau+, 1 for hadrons\n')
+                        else: f.write(line)
+            cmd = 'python ./run_pwg.py -p f -i ttb_NLO_dec_%s_%s_NNPDF30_13TeV.input -f ttb_NLO_dec_%s_%s_NNPDF30_13TeV -m ttb_NLO_dec -n 1000'%(topmode,tbarmode,topmode,tbarmode)
+            print(cmd)
+            if os.path.isfile('ttb_NLO_dec_%s_%s_NNPDF30_13TeV/pwgevents.lhe'%(topmode,tbarmode)):
+                print('Skipping as pwgevent.lhe is present')
+            else:
+                os.system(cmd)
+
+
+"""
+for execution from another script
+"""
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/multipack_ttb_nlo_dec.py
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/multipack_ttb_nlo_dec.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+import sys
+import optparse
+import os
+import random
+import re
+
+def main():
+
+    #configuration
+    usage = 'usage: %prog [options]'
+    parser = optparse.OptionParser(usage)
+    parser.add_option('--nevents', dest='nevents', help='Number of events [%default]', default=1,  type=int)
+    parser.add_option('--seed', dest='seed', help='Random seed [%default]', default=1,  type=int)
+    (opt, args) = parser.parse_args()
+    
+    #branching ratios
+    lep = 0.108
+    had = 2*0.337
+
+    samples = {}
+    
+    gridpackpath = '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/TT_NLO_dec_hdamp_Tune4_NNPDF30/'    
+    samples['ttb_NLO_dec_e_e_NNPDF30_13TeV_ttb_NLO_dec.tgz']     = { 'br': lep*lep, 'enhance': 2.0 }
+    samples['ttb_NLO_dec_e_mu_NNPDF30_13TeV_ttb_NLO_dec.tgz']    = { 'br': lep*lep, 'enhance': 2.0 }
+    samples['ttb_NLO_dec_e_tau_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': lep*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_e_had_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': lep*had, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_mu_e_NNPDF30_13TeV_ttb_NLO_dec.tgz']    = { 'br': lep*lep, 'enhance': 2.0 }
+    samples['ttb_NLO_dec_mu_mu_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': lep*lep, 'enhance': 2.0 }
+    samples['ttb_NLO_dec_mu_tau_NNPDF30_13TeV_ttb_NLO_dec.tgz']  = { 'br': lep*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_mu_had_NNPDF30_13TeV_ttb_NLO_dec.tgz']  = { 'br': lep*had, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_tau_e_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': lep*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_tau_mu_NNPDF30_13TeV_ttb_NLO_dec.tgz']  = { 'br': lep*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_tau_tau_NNPDF30_13TeV_ttb_NLO_dec.tgz'] = { 'br': lep*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_tau_had_NNPDF30_13TeV_ttb_NLO_dec.tgz'] = { 'br': lep*had, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_had_e_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': had*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_had_mu_NNPDF30_13TeV_ttb_NLO_dec.tgz']  = { 'br': had*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_had_tau_NNPDF30_13TeV_ttb_NLO_dec.tgz'] = { 'br': had*lep, 'enhance': 1.0 }
+    samples['ttb_NLO_dec_had_had_NNPDF30_13TeV_ttb_NLO_dec.tgz'] = { 'br': had*had, 'enhance': 1.0 }
+    
+    sumbr = 0.
+    for sample,data in samples.iteritems():
+        sumbr += data['br'] * data['enhance']
+        data['nevt'] = 0
+    
+    random.seed(opt.seed)
+    for i in range(opt.nevents):
+        pick = random.uniform(0.,sumbr)
+        test = 0
+        for sample,data in samples.iteritems():
+            test += data['br'] * data['enhance']
+            if pick < test:
+                data['nevt'] += 1
+                break
+    
+    print(samples)
+    
+    with open('merged.lhe', 'w') as merged:
+        firstSample = True
+        for sample,data in samples.iteritems():
+            if (data['nevt'] == 0): continue
+            os.system('sh run_generic_tarball_cvmfs.sh %s/%s %s %s'%(gridpackpath, sample, str(data['nevt']), str(opt.seed)))
+            os.system('sed -i \'/<\/LesHouchesEvents>/d\' cmsgrid_final.lhe')
+            if firstSample:
+                firstSample = False
+            else: #remove lhe header
+                os.system('sed -i \'1,/<\/init>/d\' cmsgrid_final.lhe')
+            with open('cmsgrid_final.lhe', 'r') as chunk:
+                hasWeights = False
+                for line in chunk:
+                    m = re.match('<wgt id=\'(\d*)\'>(.*)<\/wgt>', line)
+                    if m: #modify weight with 1/(enhancement factor)
+                        weight = float(m.group(2))/data['enhance']
+                        merged.write('<wgt id=\'%s\'>%s</wgt>\n'%(m.group(1), str(weight)))
+                        hasWeights = True
+                    elif '</event>' in line and hasWeights == False:
+                        merged.write('<rwgt>\n')
+                        merged.write('<wgt id=\'1001\'>%s</wgt>\n'%(str(1./data['enhance'])))
+                        merged.write('</rwgt>\n</event>\n')
+                    else:
+                        merged.write(line)
+    os.system('echo "</LesHouchesEvents>" >> merged.lhe')
+    os.system('mv merged.lhe cmsgrid_final.lhe')
+
+"""
+for execution from another script
+"""
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/multipack_ttb_nlo_dec.py
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/multipack_ttb_nlo_dec.py
@@ -10,7 +10,7 @@ def main():
     #configuration
     usage = 'usage: %prog [options]'
     parser = optparse.OptionParser(usage)
-    parser.add_option('--nevents', dest='nevents', help='Number of events [%default]', default=1,  type=int)
+    parser.add_option('--nevents', dest='nevents', help='Number of events [%default]', default=10,  type=int)
     parser.add_option('--seed', dest='seed', help='Random seed [%default]', default=1,  type=int)
     (opt, args) = parser.parse_args()
     
@@ -20,7 +20,7 @@ def main():
 
     samples = {}
     
-    gridpackpath = '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/TT_NLO_dec_hdamp_Tune4_NNPDF30/'    
+    gridpackpath = '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/TT_NLO_dec_hdamp_Tune4_NNPDF30/'
     samples['ttb_NLO_dec_e_e_NNPDF30_13TeV_ttb_NLO_dec.tgz']     = { 'br': lep*lep, 'enhance': 2.0 }
     samples['ttb_NLO_dec_e_mu_NNPDF30_13TeV_ttb_NLO_dec.tgz']    = { 'br': lep*lep, 'enhance': 2.0 }
     samples['ttb_NLO_dec_e_tau_NNPDF30_13TeV_ttb_NLO_dec.tgz']   = { 'br': lep*lep, 'enhance': 1.0 }
@@ -55,6 +55,8 @@ def main():
     
     print(samples)
     
+    events = []
+    
     with open('merged.lhe', 'w') as merged:
         firstSample = True
         for sample,data in samples.iteritems():
@@ -67,18 +69,30 @@ def main():
                 os.system('sed -i \'1,/<\/init>/d\' cmsgrid_final.lhe')
             with open('cmsgrid_final.lhe', 'r') as chunk:
                 hasWeights = False
+                event = []
                 for line in chunk:
-                    m = re.match('<wgt id=\'(\d*)\'>(.*)<\/wgt>', line)
-                    if m: #modify weight with 1/(enhancement factor)
-                        weight = float(m.group(2))/data['enhance']
-                        merged.write('<wgt id=\'%s\'>%s</wgt>\n'%(m.group(1), str(weight)))
-                        hasWeights = True
-                    elif '</event>' in line and hasWeights == False:
-                        merged.write('<rwgt>\n')
-                        merged.write('<wgt id=\'1001\'>%s</wgt>\n'%(str(1./data['enhance'])))
-                        merged.write('</rwgt>\n</event>\n')
+                    if '</event>' in line:
+                        if hasWeights == False:
+                            event.append('<rwgt>\n')
+                            event.append('<wgt id=\'1001\'>%s</wgt>\n'%(str(1./data['enhance'])))
+                            event.append('</rwgt>\n</event>\n')
+                        event.append(line)
+                        events.append(event)
+                        event = []
+                    elif '<event>' in line or len(event) > 0:
+                        m = re.match('<wgt id=\'(\d*)\'>(.*)<\/wgt>', line)
+                        if m: #modify weight with 1/(enhancement factor)
+                            weight = float(m.group(2))/data['enhance']
+                            event.append('<wgt id=\'%s\'>%s</wgt>\n'%(m.group(1), str(weight)))
+                            hasWeights = True
+                        else:
+                            event.append(line)
                     else:
                         merged.write(line)
+        random.shuffle(events)
+        for event in events:
+            for line in event:
+                merged.write(line)
     os.system('echo "</LesHouchesEvents>" >> merged.lhe')
     os.system('mv merged.lhe cmsgrid_final.lhe')
 

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/runcmsgrid.sh
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/runcmsgrid.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+fail_exit() { echo "$@"; exit 1; }
+
+#set -o verbose
+EXPECTED_ARGS=3
+
+if [ $# -ne $EXPECTED_ARGS ]
+then
+    echo "Usage: `basename $0` Nevents RandomSeed cpu"
+    echo "Example: `basename $0` 1000 1212 cpu" 
+    exit 1
+fi
+
+echo "   ______________________________________     "
+echo "      Running multiple Powheg tarballs        "
+echo "              for ttb_nlo_dec                 "
+echo "   ______________________________________     "
+
+nevt=${1}
+echo "%MSG-POWHEG number of events requested = $nevt"
+
+rnum=${2}
+echo "%MSG-POWHEG random seed used for the run = $rnum"
+
+ncpu=${3}
+echo "%MSG-POWHEG number of cputs for the run = $ncpu"
+
+seed=$rnum
+file="cmsgrid"
+
+process="hvq"
+
+# Release to be used to define the environment and the compiler needed
+export WORKDIR=`pwd`
+
+# Call python script to run gridpacks for multiple decay channels
+python multipack_ttb_nlo_dec.py --nevents $nevt --seed $rnum
+
+echo "Output ready with ${file}_final.lhe at $WORKDIR"
+echo "End of job on " `date`
+exit 0;

--- a/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/ttb_NLO_dec_template_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/TT_NLO_dec_hdamp_Tune4_NNPDF30/ttb_NLO_dec_template_NNPDF30_13TeV.input
@@ -1,0 +1,66 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+lhans1 260000
+lhans2 260000
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+topdec 11         ! 11, 13 and 15 for e+,mu+,tau+, 1 for hadrons
+tbardec 11        ! 11, 13 and 15 for e-,mu-,tau-, 1 for hadrons
+
+#nospincorr 1     ! if 1 wash out spin correlations
+
+tmass 172.5        ! top mass (default: 172)
+bmass 4.8       ! bottom mass (default: 4.75)
+
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1  500000  ! number of calls for initializing the integration grid
+itmx1    1    ! number of iterations for initializing the integration grid
+ncall2  500000  ! number of calls for computing the integral and finding upper bound
+itmx2    1     ! number of iterations for computing the integral and finding upper bound
+foldcsi   1    ! number of folds on csi integration
+foldy     1    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+#testplots 1
+
+# bornonly 1    ! uncomment to do only Born
+
+# offshelltop 1 ! default is now 1; set to zero to do simple on-shell computation
+
+# nlowhich 0    ! default is 0; set to 1 for no NLO corrections in decay
+
+# allrad 1      ! default is 1; set to 0 for standard POWHEG behaviour (see reference paper)
+iseed     SEED    ! initialize random number sequence
+
+
+# hdamp has the same meaning as in POWHEG (old) hvq generator.
+# It only acts on initial state radiation. If not set, it will
+# not be applied
+hdamp 272.7225
+
+
+# uncomment the following three options for parallel runs
+# manyseeds 1
+# parallelstage 1
+# xgriditeration 1
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+     
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1    ! store weight information
+withnegweights 0 ! default 0, 
+
+#pyMEC 0      ! Discussion with Pythia developers has led us to try this
+              ! flag if we generate the corrections in decays (our default setting)
+

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -369,6 +369,7 @@ fi
 
 patch -l -p0 -i ${WORKDIR}/patches/pdfweights.patch
 patch -l -p0 -i ${WORKDIR}/patches/pwhg_lhepdf.patch
+patch -l -p0 -i ${WORKDIR}/patches/pwhg_rad_kinreg.patch
 if [ "$process" = "b_bbar_4l" ]; then
     cd POWHEG-BOX
     patch -l -p0 -i ${WORKDIR}/patches/res_openloops_long_install_dir.patch

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -369,7 +369,6 @@ fi
 
 patch -l -p0 -i ${WORKDIR}/patches/pdfweights.patch
 patch -l -p0 -i ${WORKDIR}/patches/pwhg_lhepdf.patch
-patch -l -p0 -i ${WORKDIR}/patches/pwhg_rad_kinreg.patch
 if [ "$process" = "b_bbar_4l" ]; then
     cd POWHEG-BOX
     patch -l -p0 -i ${WORKDIR}/patches/res_openloops_long_install_dir.patch

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -376,6 +376,10 @@ if [ "$process" = "b_bbar_4l" ]; then
     patch -l -p0 -i ${WORKDIR}/patches/res_gfortran48.patch
     cd ..
 fi
+if [ "$process" = "ttb_NLO_dec" ]; then
+    patch -l -p0 -i ${WORKDIR}/patches/pwhg_ttb_NLO_dec_gen_radiation_hook.patch
+fi
+
 
 echo ${POWHEGSRC} > VERSION
 
@@ -996,6 +1000,7 @@ if __name__ == "__main__":
             fseed = open(args.folderName + '/pwgseeds.dat', 'w')
             for ii in range(1, 10000) :
                 fseed.write(str(ii)+'\n')
+            fseed.close()
 #        #FIXME this is a crude hardcoded trick to overcome some problems in LHAPDF usage
 #        runCommand ('ln -s /afs/cern.ch/user/g/govoni/work/HiggsPlusJets/lhapdf/share/lhapdf/PDFsets/CT10.LHgrid ./'  + args.folderName)
 


### PR DESCRIPTION
- generate_all_[process].py creates gridpacks for all decay channels from template input file.

Meta gridpack needs to include:
- multipack_[process].py
- modified runcmsgrid.sh
- copy of run_generic_tarball_cvmfs.sh

CMSSW is completely agnostic of this, so it should work in every version :-)