### PR TITLE
bb4l: use relative lib paths, ship all needed libs

### DIFF
--- a/bin/Powheg/patches/res_openloops_long_install_dir.patch
+++ b/bin/Powheg/patches/res_openloops_long_install_dir.patch
@@ -21,4 +21,15 @@ Index: OpenLoopsStuff/OpenLoops/lib_src/openloops/src/parameters.F90
    ! Mode for check_last_[...] in laststep and tensor integral routine in looproutines
    integer, save :: l_switch = 1, a_switch = 5, a_switch_rescue = 5, redlib_qp = 5
    ! switchers for checking Ward identities at tree/loop level
+===================================================================
+--- b_bbar_4l/Makefile	(revision 3388)
++++ b_bbar_4l/Makefile	(working copy)
+@@ -149,7 +149,7 @@
+ 
+ ifdef OLPATH
+ FF+= -I$(OLPATH)/lib_src/openloops/mod
+-LIBSOPENLOOPS= -Wl,-rpath=$(PWD)/$(OBJDIR) -L$(PWD)/$(OBJDIR) -lopenloops
++LIBSOPENLOOPS= -Wl,-rpath=$(OBJDIR) -L$(OBJDIR) -lopenloops
+ USER+=openloops.o
+ endif
 

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -78,6 +78,7 @@ def prepareJob(tag, i, folderName) :
     f.write ('if [ -e '+ rootfolder + '/' + folderName + '/obj-gfortran/proclib ]; then    \n')
     f.write ('  mkdir ./obj-gfortran/' + '\n')
     f.write ('  cp -pr ' + rootfolder + '/' + folderName + '/obj-gfortran/proclib  ./obj-gfortran/' + '\n')
+    f.write ('  cp -pr ' + rootfolder + '/' + folderName + '/obj-gfortran/*.so  ./obj-gfortran/' + '\n')
     f.write ('fi    \n')
 
     f.write('\n')
@@ -102,6 +103,7 @@ def prepareJobForEvents (tag, i, folderName, EOSfolder) :
     f.write ('if [ -e '+ rootfolder + '/' + folderName + '/obj-gfortran/proclib ]; then    \n')
     f.write ('  mkdir ./obj-gfortran/' + '\n')
     f.write ('  cp -pr ' + rootfolder + '/' + folderName + '/obj-gfortran/proclib  ./obj-gfortran/' + '\n')
+    f.write ('  cp -pr ' + rootfolder + '/' + folderName + '/obj-gfortran/*.so  ./obj-gfortran/' + '\n')
     f.write ('fi    \n')
 
     f.write ('cd -' + '\n')
@@ -533,6 +535,7 @@ fi
 if [ -d ./obj-gfortran/proclib ]; then
   mkdir ${WORKDIR}/${name}/obj-gfortran/
   cp -a ./obj-gfortran/proclib ${WORKDIR}/${name}/obj-gfortran/.
+  cp -a ./obj-gfortran/*.so ${WORKDIR}/${name}/obj-gfortran/.
 fi
 
 cd ${WORKDIR}/${name}


### PR DESCRIPTION
* Use relative lib paths, otherwise the gridpack works only for the creator...
* Ship openloops and other libs (modified by Powheg authors -> errors when falling back to libs in cmssw)