### PR TITLE
Update source_condor.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/source_condor.sh
+++ b/bin/MadGraph5_aMCatNLO/source_condor.sh
@@ -1,4 +1,4 @@
-#! /bin.bash
+#! /bin/bash
 
 # HTCondor python bindings are lost after cmsenv/scram
 # unless PYTHONPATH is set including its location


### PR DESCRIPTION
This is just a typo I noticed. The typo doesn't break anything because we source this script rather than directly executing them though.