### PR TITLE
Settings for ttbar Tune validation using NNPDF3.1 NNLO as central PDF

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/TuneValidation/ttbar_FxFx/tt012j_5f_ckm_NLO_FXFX/tt012j_5f_ckm_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/TuneValidation/ttbar_FxFx/tt012j_5f_ckm_NLO_FXFX/tt012j_5f_ckm_NLO_FXFX_run_card.dat
@@ -55,7 +55,8 @@ average = event_norm ! Normalize events to sum or average to the X sect.
 # PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
 #***********************************************************************
  lhapdf    = pdlabel   ! PDF set                                     
- 292200    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+ 303600    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# NNPDF31_nnlo_as0118
 #***********************************************************************
 # Include the NLO Monte Carlo subtr. terms for the following parton    *
 # shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
@@ -93,8 +94,9 @@ average = event_norm ! Normalize events to sum or average to the X sect.
   0.5     = rw_Fscale_down   ! lower bound for fact scale variations
   2.0     = rw_Fscale_up     ! upper bound for fact scale variations
  .true.  = reweight_PDF     ! reweight to get PDF uncertainty
- 292201   = PDF_set_min      ! First of the error PDF sets 
- 292302   = PDF_set_max      ! Last of the error PDF sets
+ 303400   = PDF_set_min      ! First of the error PDF sets 
+#ids 303501-303599 do not exist
+ 303700   = PDF_set_max      ! Last of the error PDF sets
 #***********************************************************************
 # Merging - WARNING! Applies merging only at the hard-event level.     *
 # After showering an MLM-type merging should be applied as well.       *

--- a/bin/MadGraph5_aMCatNLO/cards/TuneValidation/ttbar_MLM/tt0123j_5f_ckm_LO_MLM/tt0123j_5f_ckm_LO_MLM_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/TuneValidation/ttbar_MLM/tt0123j_5f_ckm_LO_MLM/tt0123j_5f_ckm_LO_MLM_run_card.dat
@@ -49,7 +49,8 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
  'lhapdf'    = pdlabel     ! PDF set                                  
-  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+  303600    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+# NNPDF31_nnlo_as0118
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************

--- a/bin/Powheg/TuneValidation/ttbar/TT_hdamp_TuneT4_NNPDF31_NNLO_13TeV_powheg.input
+++ b/bin/Powheg/TuneValidation/ttbar/TT_hdamp_TuneT4_NNPDF31_NNLO_13TeV_powheg.input
@@ -1,0 +1,80 @@
+! TTbar production parameters
+!randomseed 352345 ! uncomment to set the random seed to a value of your choice.
+                   ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
+                   ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
+                   ! If POWHEG is interfaced to a shower MC, refer to the shower MC
+                   ! documentation to set its seed.
+
+!Heavy flavour production parameters
+
+numevts NEVENTS    ! number of events to be generated
+iseed   SEED       ! Start the random number generator with seed iseed 
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+#ndns1 131      ! pdf for hadron 1 (hvqpdf numbering)
+#ndns2 131      ! pdf for hadron 2
+! To be set only if using LHA pdfs
+lhans1 306000       ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000       ! pdf set for hadron 2 (LHA numbering)
+! NNPDF31_nnlo_as_0118
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+qmass  172.5     ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+#fixedscale 1    ! use ref. scale=qmass (default 0, use running scale)
+hdamp 272.7225
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into b l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+!semileptonic 1      ! uncomment if you want to filter out only semileptonic events. For example,
+                     ! with topdecaymode 10011 and semileptonic 1 you get only events with one top going
+                     ! to an electron or positron, and the other into any hadron.
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.4  ! W mass for top decay
+tdec/wwidth 2.141
+tdec/bmass 4.8
+tdec/twidth  1.31 ! 1.33 using PDG LO formula
+tdec/elbranching 0.108
+tdec/emass 0.00051
+tdec/mumass 0.1057
+tdec/taumass 1.777
+tdec/dmass   0.100
+tdec/umass   0.100
+tdec/smass   0.200
+tdec/cmass   1.5
+tdec/sin2cabibbo 0.051
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 10000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+ixmax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 1       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (0.9959*mt, 1.581*mt, mt*2.239)
+storeinfo_rwgt 1    ! store weight information
+withnegweights 0    ! default 0


### PR DESCRIPTION
Notes:
- Powheg crashes when asking for reweighting of NNPDF3.1_LO_as0118
- FxFx only allows consecutive pdf lha ids reweighting, since NNLO, NLO and LO ids are not consecutive, only NLO will be used for reweighting and NNLO as central PDF
- MLM has NNPDF3.1 NNLO as central PDF, and any other PDF as reweighting thanks to syscalc