### PR TITLE
fix XSECUP, XERRUP when grepping from pwg-stat.dat

### DIFF
--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -388,8 +388,8 @@ if [ -s pwgstat.dat ]; then
 fi
 
 if [ -s pwg-stat.dat ]; then
-  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+  XSECTION=`tac pwg-stat.dat | grep -m1 in\ pb | awk '{ print $(NF-2) }'`
+  XSECUNC=` tac pwg-stat.dat | grep -m1 in\ pb | awk '{ print $(NF) }'`
   head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
   tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
   tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail

--- a/bin/Powheg/runcmsgrid_powhegjhugen.sh
+++ b/bin/Powheg/runcmsgrid_powhegjhugen.sh
@@ -392,8 +392,8 @@ if [ -s pwgstat.dat ]; then
 fi
 
 if [ -s pwg-stat.dat ]; then
-  XSECTION=`cat pwg-stat.dat | grep total | awk '{print $7}'`
-  XSECUNC=` cat pwg-stat.dat | grep total | awk '{print $9}'`
+  XSECTION=`tac pwg-stat.dat | grep -m1 in\ pb | awk '{ print $(NF-2) }'`
+  XSECUNC=` tac pwg-stat.dat | grep -m1 in\ pb | awk '{ print $(NF) }'`
   head=`cat   cmsgrid_final.lhe | grep -in "<init>" | sed "s@:@ @g" | awk '{print $1+1}' | tail -1`
   tail=`wc -l cmsgrid_final.lhe | awk -v tmp="$head" '{print $1-2-tmp}'`
   tail -${tail} cmsgrid_final.lhe                           >  cmsgrid_final.lhe_tail


### PR DESCRIPTION
grep for the last occurrence of the string "in pb" in pwg-stat.dat
then awk the last but 2nd column as the cross section value and the last column as uncertainty.

in fact, currently the script expects something like   
`total (btilde+remnants) cross section in pb   1872.7129024394619      +-   4.4236794864970204     `
while for some processes like dijett is
` total (btilde+remnants) cross section times `
` suppression factor in pb   4680.9717991349644      +-   9.4260047601070003 `
causing an exception in the CMSSW LHE parser