### PR TITLE
minlo HJJ cards for H->WW->2L2Nu

### DIFF
--- a/bin/Powheg/production/V2/13TeV/Higgs/HJJ_JHUGenV701_HWW2L2Nu_NNPDF30_13TeV/HJJ_MINLO_M125_NNPDF30_13TeV.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HJJ_JHUGenV701_HWW2L2Nu_NNPDF30_13TeV/HJJ_MINLO_M125_NNPDF30_13TeV.input
@@ -1,0 +1,92 @@
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500     ! energy of beam 1
+ebeam2 6500     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   260000      ! pdf set for hadron 1 (LHA numbering)
+lhans2   260000      ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+hmass  125             ! Higgs mass
+hwidth 0.00407D0            ! Higgs width
+
+bwcutoff 15d0       ! Mass window is hmass +- bwcutoff*hwidth
+
+#higgsfixedwidth 1  ! (default 0), If 1 uses standard, fixed width Breit-Wigner
+                   ! formula, if 0 it uses the running width Breit-Wigner
+
+#ckkwscalup 1 ! (default 1), If 1 compute the scalup scale for subsequent
+              ! shower using the smallest kt in the final state;
+              ! If 0, use the standard POWHEG BOX scalup
+
+#runningscales 1   ! (default 0), if 0 use hmass as central
+                  ! factorization and renormalization scale;
+                  ! if 1 use the Ht scale
+
+# fullphsp 1         ! use ISR/FSR phase space parametrization, default 0, do not
+
+
+ncall1   150000   ! number of calls for initializing the integration grid
+itmx1    3      ! number of iterations for initializing the integration grid
+ncall2   100000     ! number of calls for computing the integral and finding upper bound
+itmx2    3  ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5     ! number of folds on  y  integration
+foldphi   2      ! number of folds on phi integration
+nubound  60000    ! number of bbarra calls to setup norm of upper bounding function
+
+
+! OPTIONAL PARAMETERS
+
+#renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+#facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#bornonly   0      ! (default 0) if 1 do Born only
+#testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+#manyseeds  1      ! Used to perform multiple runs with different random
+                   ! seeds in the same directory.
+                   ! If set to 1, the program asks for an integer j;
+                   ! The file pwgseeds.dat at line j is read, and the
+                   ! integer at line j is used to initialize the random
+                   ! sequence for the generation of the event.
+                   ! The event file is called pwgevents-'j'.lhe
+
+
+
+withnegweights 1   ! (0 default) If 1 output negative weighted events.
+                   ! If 0 descard them
+
+pdfreweight 1       ! PDF reweighting
+storeinfo_rwgt 1
+
+#parallelstage 1
+xgriditeration 1
+fastbtlbound 1
+#storemintupb 1
+
+complexpolescheme 1
+
+minlo 1
+minlo_nnll 1
+
+# if running with minlo, set the following to 0
+massivetop   0
+
+sudscalevar   1
+
+doublefsr 1
+
+nohad   1

--- a/bin/Powheg/production/V2/13TeV/Higgs/HJJ_JHUGenV701_HWW2L2Nu_NNPDF30_13TeV/JHUGen_HJJ_MINLO_H_WW_2L2Nu_M125.input
+++ b/bin/Powheg/production/V2/13TeV/Higgs/HJJ_JHUGenV701_HWW2L2Nu_NNPDF30_13TeV/JHUGen_HJJ_MINLO_H_WW_2L2Nu_M125.input
@@ -1,0 +1,1 @@
+Collider=1 PChannel=0 MReso=125 Process=0 Unweighted=1 DecayMode1=10 DecayMode2=10 OffshellX=1


### PR DESCRIPTION
Powheg and JHUGen cards for the process HJJ MINLO for HWW.

The powheg card is the same as the following HZZ gridpack:
/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/HJJ_NNPDF30_13TeV_M125_JHUGen_ZZ4L/v1/HJJ_NNPDF30_13TeV_M125_JHUGen_ZZ4L_tarball.tar.gz

The JHUGen card has been modified to have H->WW->2L2Nu decays and to use the JHUGen version 701.