### PR TITLE
D/L QCDLoop-1.9 for ST_wtch_DR and ST_wtch_DS

### DIFF
--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -539,6 +539,18 @@ if [ "$process" = "HJ" ]; then
   sed -i "s/getq2min(1,tmp)/getq2min(0,tmp)/g" setlocalscales.f
 fi  
 
+if [ "$process" = "ST_wtch_DR" ] || [ "$process" = "ST_wtch_DS" ]; then   
+  echo "D/L QCDLoop-1.9 library"                            
+  if [ ! -f FeynHiggs-2.10.2.tar.gz ]; then                 
+    wget http://qcdloop.fnal.gov/QCDLoop-1.96.tar.gz || fail_exit "Failed to get QCDLoop tar ball"
+  fi                                                        
+  tar xvf QCDLoop-1.96.tar.gz                               
+  mv QCDLoop-1.96 QCDLoop-1.9                               
+  cd QCDLoop-1.9                                            
+  make                                                      
+  cd ..                                                     
+fi                                                          
+
 
 make pwhg_main || fail_exit "Failed to compile pwhg_main"
 
@@ -555,6 +567,10 @@ if [ -d ./obj-gfortran/proclib ]; then
   mkdir ${WORKDIR}/${name}/obj-gfortran/
   cp -a ./obj-gfortran/proclib ${WORKDIR}/${name}/obj-gfortran/.
   cp -a ./obj-gfortran/*.so ${WORKDIR}/${name}/obj-gfortran/.
+fi
+if [ -d ./QCDLoop-1.9 ]; then                                 
+  cp -a ./QCDLoop-1.9 ${WORKDIR}/${name}/.                    
+  cp -a ./QCDLoop-1.9/ff/ff*.dat ${WORKDIR}/${name}/.      
 fi
 
 cd ${WORKDIR}/${name}


### PR DESCRIPTION
As risen by Alexander Grohsjean, powheg single top tW channel DR and DS processes failed to build due to a missing library QCDLoop. The package needs to be d/l manually and built in advance. This PR does the job and fix the issue.

Alexander is helping on testing the patch. So once he finished, please merge this PR.