### PR TITLE
add standard hadronizers for CP5 tune

### DIFF
--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_EEFilter_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_EEFilter_LHE_pythia8_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    )
+    )
+)
+
+eeFilter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("source"),
+    NumRequired = cms.int32(2),
+    ParticleID = cms.vint32(11),
+    AcceptLogic = cms.string("EQ") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)                   
+
+ProductionFilterSequence = cms.Sequence(generator+eeFilter)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_EEFilter_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_EEFilter_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_DM_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_DM_LHE_pythia8_cff.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30',  # actual merging scale
+            'JetMatching:nQmatch = 4', # 4: 4-flavor scheme (no matching of b), 5: 5-flavour scheme
+            'JetMatching:nJetMax = 1', # nPartons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+            'Check:epTolErr = 0.0003',
+            '9100000:new  = MED MED 3 0 0 X_MMed_X 0 0 0 99999',
+            '9100022:new  = DM  DM  2 0 0 X_MFM_X  0 0 0 99999',
+            '9100022:mayDecay = off'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_DM_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_DM_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_4f_max1j_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_bEnriched_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_bEnriched_LHE_pythia8_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 14.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 4', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    ),
+    nAttempts = cms.uint32(22),
+    HepMCFilter = cms.PSet(
+      filterName = cms.string('PartonShowerBsHepMCFilter'),
+      filterParameters = cms.PSet(
+      ),
+    ),
+)
+
+LHEfilter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("externalLHEProducer"),
+    NumRequired = cms.int32(0),
+    ParticleID = cms.vint32(5),
+    AcceptLogic = cms.string("EQ") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)
+
+ProductionFilterSequence = cms.Sequence(LHEfilter+generator)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_bEnriched_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_bEnriched_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max1j_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max1j_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_qCut20_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_qCut20_LHE_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 5.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 20.', #this is the actual merging scale
+            'JetMatching:nQmatch = 5', #5 for 5-flavour scheme (matching of b-quarks)
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_qCut20_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MLM_5f_max2j_qCut20_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MuMuFilter_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MuMuFilter_LHE_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    )
+    )
+)
+
+
+mumuFilter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("source"),
+    NumRequired = cms.int32(2),
+    ParticleID = cms.vint32(13),
+    AcceptLogic = cms.string("EQ") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)                          
+
+ProductionFilterSequence = cms.Sequence(generator+mumuFilter)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MuMuFilter_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_MuMuFilter_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SUSYGluGluToBBHToTauTau_M-90-amcatnlo-pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SUSYGluGluToBBHToTauTau_M-90-amcatnlo-pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SUSYGluGluToBBHToTauTau_M-90-amcatnlo-pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SUSYGluGluToBBHToTauTau_M-90-amcatnlo-pythia8_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+          pythia8CommonSettingsBlock,
+          pythia8CP5SettingsBlock,
+          pythia8aMCatNLOSettingsBlock,
+          processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 2', #number of coloured particles (before resonance decays) in born matrix element
+            'SLHA:useDecayTable = off',
+            '25:onMode = off', # turn OFF all H decays
+            '25:onIfAny = 15',    # turn ON H->tautau
+            '25:m0 = 90'         # mass of H
+           ),
+         parameterSets = cms.vstring('pythia8CommonSettings',
+        'pythia8CP5Settings',
+        'pythia8aMCatNLOSettings',
+        'processParameters'
+        )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SeesawTypeIII_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SeesawTypeIII_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     pythiaPylistVerbosity = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SeesawTypeIII_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_SeesawTypeIII_LHE_pythia8_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings', 
+            'pythia8CP5Settings')
+    )
+)
+
+dirhadrongenfilter = cms.EDFilter("MCMultiParticleFilter",
+	src=cms.InputTag("generator"),
+    NumRequired = cms.int32(3),
+    AcceptMore = cms.bool(True),
+	ParticleID = cms.vint32(11,13,15),
+	PtMin = cms.vdouble(4.0, 4.0, 4.0),
+	EtaMax = cms.vdouble(999.0, 999.0, 999.0),
+	Status = cms.vint32(1,1,2)
+	
+)
+
+ProductionFilterSequence = cms.Sequence(generator*dirhadrongenfilter)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 0', #number of coloured particles (before resonance decays) in born matrix element
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_2p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_2p_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_2p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_2p_LHE_pythia8_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 2', #number of coloured particles (before resonance decays) in born matrix element
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_LHE_pythia8_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'TimeShower:mMaxGamma = 4.0',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_generic_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_generic_LHE_pythia8_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    )
+    )
+)
+

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_generic_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_generic_LHE_pythia8_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_HToZZ4nu_M-110_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_HToZZ4nu_M-110_LHE_pythia8_cff.py
@@ -2,7 +2,7 @@
 
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_HToZZ4nu_M-110_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_HToZZ4nu_M-110_LHE_pythia8_cff.py
@@ -1,0 +1,36 @@
+# Based on https://github.com/cms-sw/genproductions/blob/3b33b1e47f34941b84b6a582839bb8e5c5b05c16/python/ThirteenTeV/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 110.0',
+            '25:onMode = off',
+            '25:onIfMatch = 23 23', ## H -> ZZ
+            '23:onMode = off',      # turn OFF all Z decays
+            '23:onIfAny = 12 14 16',# turn ON Z->vv
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+				    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_LHE_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_2p_LHE_pythia8_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToZZ4nu_M-110_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToZZ4nu_M-110_LHE_pythia8_cff.py
@@ -2,7 +2,7 @@
 
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToZZ4nu_M-110_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToZZ4nu_M-110_LHE_pythia8_cff.py
@@ -1,0 +1,36 @@
+# Based on https://github.com/cms-sw/genproductions/blob/3b33b1e47f34941b84b6a582839bb8e5c5b05c16/python/ThirteenTeV/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_1p_LHE_pythia8_cff.py
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.2017MCTunes.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 110.0',
+            '25:onMode = off',
+            '25:onIfMatch = 23 23', ## H -> ZZ
+            '23:onMode = off',      # turn OFF all Z decays
+            '23:onIfAny = 12 14 16',# turn ON Z->vv
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+				    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
cloned existing TuneCUEP8M1 existing files using the command

for f in python/ThirteenTeV/Hadronizer/*.py; do cp "$f" "`echo $f | sed s/TuneCUETP8M1/TuneCP5/`"; done

and replacing CUEP8M1 by CP5