### PR TITLE
gridpack_generation: Fix sed expression.

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -492,7 +492,7 @@ if grep -q -e "\$DEFAULT_PDF_SETS" -e "\$DEFAULT_PDF_MEMBERS" $CARDSDIR/${name}_
             # 4F PDF
             sed "s/\$DEFAULT_PDF_SETS/320900/" $CARDSDIR/${name}_run_card.dat > ./Cards/run_card.dat
         fi
-        sed -i "s/ *\$DEFAULT_PDF_MEMBERS = .*//" ./Cards/run_card.dat 
+        sed -i "s/ *\$DEFAULT_PDF_MEMBERS *= .*//" ./Cards/run_card.dat
     fi
 else
     echo ""

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -492,7 +492,7 @@ if grep -q -e "\$DEFAULT_PDF_SETS" -e "\$DEFAULT_PDF_MEMBERS" $CARDSDIR/${name}_
             # 4F PDF
             sed "s/\$DEFAULT_PDF_SETS/320900/" $CARDSDIR/${name}_run_card.dat > ./Cards/run_card.dat
         fi
-        sed -i "s/ *\$DEFAULT_PDF_MEMBERS *= .*//" ./Cards/run_card.dat
+        sed -i "s/ *\$DEFAULT_PDF_MEMBERS.*=.*//" ./Cards/run_card.dat
     fi
 else
     echo ""


### PR DESCRIPTION
The sed expression to remove any lines containing "$DEFAULT_PDF_MEMBERS"
from run_cards in case of LO does now handle additional spaces between around the
equal sign.

This seems like nitpicking, but please note that the example on the twiki [1] actually has an extra space, so the old replacement failed for this example.

[1] https://twiki.cern.ch/twiki/bin/view/CMS/QuickGuideMadGraph5aMCatNLO#PDF_Choice_for_2017_production