### PR TITLE
update bbH, H->bb with narrow width

### DIFF
--- a/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-100_TuneCUETP8M1_13TeV-pythia8_cfi.py
+++ b/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-100_TuneCUETP8M1_13TeV-pythia8_cfi.py
@@ -7,19 +7,22 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),                                                                                
     pythiaHepMCVerbosity = cms.untracked.bool(False),                                                                            
     comEnergy = cms.double(13000.0),                                                                                             
-    crossSection = cms.untracked.double(518.3),                                                                                  
+    crossSection = cms.untracked.double(1.0),                                                                                  
     maxEventsToPrint = cms.untracked.int32(1),                                                                                   
     PythiaParameters = cms.PSet(                                                                                                 
             pythia8CommonSettingsBlock,                                                                                          
             pythia8CUEP8M1SettingsBlock, 
                     processParameters = cms.vstring(                                                                     
-                                                    'Higgs:useBSM = on',
-                                                    'HiggsBSM:gg2A3bbbar = on',                                                                   
-                                                    '36:m0 = 100',                                                                           
-                                                    '36:onMode = off',                                                                       
-                                                    '36:onIfMatch = 5 -5',                                                                                                        
-            ),                                                                                                                   
-                                                                                                                                 
+                                'Higgs:useBSM = on',
+                                'HiggsBSM:gg2A3bbbar = on',
+                                'HiggsA3:coup2d  = 20.0',
+            			'HiggsA3:coup2l  = 20.0',
+            			'HiggsA3:coup2u  = 0.05',
+            			'HiggsA3:coup2H1Z = 0.0',
+            			'HiggsA3:coup2H2Z = 1.0',
+                                '36:m0 = 100',                                                                           
+                                '36:onMode = off',                                                    
+                                '36:onIfMatch = 5 -5',                                                                                            	         ),                                                                                                                    
         parameterSets = cms.vstring('pythia8CommonSettings',                                                                     
             'pythia8CUEP8M1Settings',                                                                                            
             'processParameters')                                                                                                 
@@ -31,3 +34,5 @@ configurationMetadata = cms.untracked.PSet(
     name = cms.untracked.string('\$Source$'),
     annotation = cms.untracked.string('gg->bbA, 13TeV, mA = 100GeV, A->bb, TuneCUETP8M1')
 )
+
+

--- a/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-1100_TuneCUETP8M1_13TeV-pythia8_cfi.py
+++ b/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-1100_TuneCUETP8M1_13TeV-pythia8_cfi.py
@@ -7,19 +7,22 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),                                                                                
     pythiaHepMCVerbosity = cms.untracked.bool(False),                                                                            
     comEnergy = cms.double(13000.0),                                                                                             
-    crossSection = cms.untracked.double(518.3),                                                                                  
+    crossSection = cms.untracked.double(1.0),                                                                                  
     maxEventsToPrint = cms.untracked.int32(1),                                                                                   
     PythiaParameters = cms.PSet(                                                                                                 
             pythia8CommonSettingsBlock,                                                                                          
             pythia8CUEP8M1SettingsBlock, 
                     processParameters = cms.vstring(                                                                     
-                                                    'Higgs:useBSM = on',
-                                                    'HiggsBSM:gg2A3bbbar = on',                                                                   
-                                                    '36:m0 = 1100',                                                                           
-                                                    '36:onMode = off',                                                                       
-                                                    '36:onIfMatch = 5 -5',                                                                                                        
-            ),                                                                                                                   
-                                                                                                                                 
+                                'Higgs:useBSM = on',
+                                'HiggsBSM:gg2A3bbbar = on',
+                                'HiggsA3:coup2d  = 20.0',
+            			'HiggsA3:coup2l  = 20.0',
+            			'HiggsA3:coup2u  = 0.05',
+            			'HiggsA3:coup2H1Z = 0.0',
+            			'HiggsA3:coup2H2Z = 1.0',
+                                '36:m0 = 1100',                                                                           
+                                '36:onMode = off',                                                    
+                                '36:onIfMatch = 5 -5',                                                                                            	         ),                                                                                                                    
         parameterSets = cms.vstring('pythia8CommonSettings',                                                                     
             'pythia8CUEP8M1Settings',                                                                                            
             'processParameters')                                                                                                 
@@ -31,3 +34,5 @@ configurationMetadata = cms.untracked.PSet(
     name = cms.untracked.string('\$Source$'),
     annotation = cms.untracked.string('gg->bbA, 13TeV, mA = 1100GeV, A->bb, TuneCUETP8M1')
 )
+
+

--- a/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-300_TuneCUETP8M1_13TeV-pythia8_cfi.py
+++ b/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-300_TuneCUETP8M1_13TeV-pythia8_cfi.py
@@ -7,19 +7,22 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),                                                                                
     pythiaHepMCVerbosity = cms.untracked.bool(False),                                                                            
     comEnergy = cms.double(13000.0),                                                                                             
-    crossSection = cms.untracked.double(518.3),                                                                                  
+    crossSection = cms.untracked.double(1.0),                                                                                  
     maxEventsToPrint = cms.untracked.int32(1),                                                                                   
     PythiaParameters = cms.PSet(                                                                                                 
             pythia8CommonSettingsBlock,                                                                                          
             pythia8CUEP8M1SettingsBlock, 
                     processParameters = cms.vstring(                                                                     
-                                                    'Higgs:useBSM = on',
-                                                    'HiggsBSM:gg2A3bbbar = on',                                                                   
-                                                    '36:m0 = 300',                                                                           
-                                                    '36:onMode = off',                                                                       
-                                                    '36:onIfMatch = 5 -5',                                                                                                        
-            ),                                                                                                                   
-                                                                                                                                 
+                                'Higgs:useBSM = on',
+                                'HiggsBSM:gg2A3bbbar = on',
+                                'HiggsA3:coup2d  = 20.0',
+            			'HiggsA3:coup2l  = 20.0',
+            			'HiggsA3:coup2u  = 0.05',
+            			'HiggsA3:coup2H1Z = 0.0',
+            			'HiggsA3:coup2H2Z = 1.0',
+                                '36:m0 = 300',                                                                           
+                                '36:onMode = off',                                                    
+                                '36:onIfMatch = 5 -5',                                                                                            	         ),                                                                                                                    
         parameterSets = cms.vstring('pythia8CommonSettings',                                                                     
             'pythia8CUEP8M1Settings',                                                                                            
             'processParameters')                                                                                                 
@@ -31,3 +34,5 @@ configurationMetadata = cms.untracked.PSet(
     name = cms.untracked.string('\$Source$'),
     annotation = cms.untracked.string('gg->bbA, 13TeV, mA = 300GeV, A->bb, TuneCUETP8M1')
 )
+
+

--- a/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-500_TuneCUETP8M1_13TeV-pythia8_cfi.py
+++ b/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-500_TuneCUETP8M1_13TeV-pythia8_cfi.py
@@ -7,19 +7,22 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),                                                                                
     pythiaHepMCVerbosity = cms.untracked.bool(False),                                                                            
     comEnergy = cms.double(13000.0),                                                                                             
-    crossSection = cms.untracked.double(518.3),                                                                                  
+    crossSection = cms.untracked.double(1.0),                                                                                  
     maxEventsToPrint = cms.untracked.int32(1),                                                                                   
     PythiaParameters = cms.PSet(                                                                                                 
             pythia8CommonSettingsBlock,                                                                                          
             pythia8CUEP8M1SettingsBlock, 
-                    processParameters = cms.vstring('Higgs:useBSM = on',                                                                     
-                                                    'HiggsBSM:gg2A3bbbar = on',                                                                   
-                                                    '36:m0 = 500',                                                                           
-                                                    '36:onMode = off',                                                                       
-                                                    '36:onIfMatch = 5 -5'                                                                        
-                                                                                                                                 
-            ),                                                                                                                   
-                                                                                                                                 
+                    processParameters = cms.vstring(                                                                     
+                                'Higgs:useBSM = on',
+                                'HiggsBSM:gg2A3bbbar = on',
+                                'HiggsA3:coup2d  = 20.0',
+            			'HiggsA3:coup2l  = 20.0',
+            			'HiggsA3:coup2u  = 0.05',
+            			'HiggsA3:coup2H1Z = 0.0',
+            			'HiggsA3:coup2H2Z = 1.0',
+                                '36:m0 = 500',                                                                           
+                                '36:onMode = off',                                                    
+                                '36:onIfMatch = 5 -5',                                                                                            	         ),                                                                                                                    
         parameterSets = cms.vstring('pythia8CommonSettings',                                                                     
             'pythia8CUEP8M1Settings',                                                                                            
             'processParameters')                                                                                                 
@@ -31,3 +34,5 @@ configurationMetadata = cms.untracked.PSet(
     name = cms.untracked.string('\$Source$'),
     annotation = cms.untracked.string('gg->bbA, 13TeV, mA = 500GeV, A->bb, TuneCUETP8M1')
 )
+
+

--- a/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-600_TuneCUETP8M1_13TeV-pythia8_cfi.py
+++ b/python/ThirteenTeV/SUSYGluGlu/SUSYGluGluToBBHToBB_M-600_TuneCUETP8M1_13TeV-pythia8_cfi.py
@@ -7,19 +7,22 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),                                                                                
     pythiaHepMCVerbosity = cms.untracked.bool(False),                                                                            
     comEnergy = cms.double(13000.0),                                                                                             
-    crossSection = cms.untracked.double(518.3),                                                                                  
+    crossSection = cms.untracked.double(1.0),                                                                                  
     maxEventsToPrint = cms.untracked.int32(1),                                                                                   
     PythiaParameters = cms.PSet(                                                                                                 
             pythia8CommonSettingsBlock,                                                                                          
             pythia8CUEP8M1SettingsBlock, 
                     processParameters = cms.vstring(                                                                     
-                                                    'Higgs:useBSM = on',
-                                                    'HiggsBSM:gg2A3bbbar = on',                                                                   
-                                                    '36:m0 = 600',                                                                           
-                                                    '36:onMode = off',                                                                       
-                                                    '36:onIfMatch = 5 -5',                                                                                                        
-            ),                                                                                                                   
-                                                                                                                                 
+                                'Higgs:useBSM = on',
+                                'HiggsBSM:gg2A3bbbar = on',
+                                'HiggsA3:coup2d  = 20.0',
+            			'HiggsA3:coup2l  = 20.0',
+            			'HiggsA3:coup2u  = 0.05',
+            			'HiggsA3:coup2H1Z = 0.0',
+            			'HiggsA3:coup2H2Z = 1.0',
+                                '36:m0 = 600',                                                                           
+                                '36:onMode = off',                                                    
+                                '36:onIfMatch = 5 -5',                                                                                            	         ),                                                                                                                    
         parameterSets = cms.vstring('pythia8CommonSettings',                                                                     
             'pythia8CUEP8M1Settings',                                                                                            
             'processParameters')                                                                                                 
@@ -31,3 +34,5 @@ configurationMetadata = cms.untracked.PSet(
     name = cms.untracked.string('\$Source$'),
     annotation = cms.untracked.string('gg->bbA, 13TeV, mA = 600GeV, A->bb, TuneCUETP8M1')
 )
+
+


### PR DESCRIPTION
We have updated the fragment after discussed with Steve to get narrow width resonance and already used for official production in Moriond17 but never committed to github. For the future record, please merge this change. Thank you very much. 

