### PR TITLE
Fix compilation error for CMS connect

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -399,6 +399,7 @@ elif [ "${jobstep}" = "INTEGRATE" ] || [ "${jobstep}" = "ALL" ]; then
   cd $WORKDIR
 
   eval `scram runtime -sh`
+  export BOOSTINCLUDES=`scram tool tag boost INCLUDE`
 
   #LHAPDFCONFIG=`echo "$LHAPDF_DATA_PATH/../../bin/lhapdf-config"`
 


### PR DESCRIPTION
Separately export BOOSTINCLUDES at integration step. Needed for CMSConnect, which runs separate jobs on different machines and therefore needs the environment setup at each point