### PR TITLE
AtoZh, ZtoLL, htoTauTau signals for 2016 data, Moriond17

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -0.677309002
+set param_card higgs 2 -1.09493832
+set param_card higgs 3 0.971848551
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.172352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 239.7
+set param_card mass 36 220.0
+set param_card mass 37 233.4
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.899433877
+set param_card loop 3 -0.664092388
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.32818478
+set param_card loop 7 1.79886775
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.985184057
+set param_card loop 11 -0.17150036
+set param_card loop 12 306.64018
+set param_card loop 13 189.507941
+set param_card decay 35 1.13202522e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 2.06849263e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 8.12273125e-01 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M220 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -0.795702329
+set param_card higgs 2 -1.30412542
+set param_card higgs 3 1.12484759
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.144352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 257.9
+set param_card mass 36 240.0
+set param_card mass 37 252.3
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.91767348
+set param_card loop 3 -0.638651223
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.27730245
+set param_card loop 7 1.83534696
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.989599273
+set param_card loop 11 -0.143851587
+set param_card loop 12 357.604027
+set param_card loop 13 227.888918
+set param_card decay 35 5.41283368e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 2.93389584e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 1.17688231e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M240 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -0.926379942
+set param_card higgs 2 -1.53184696
+set param_card higgs 3 1.29552084
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.122352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 276.4
+set param_card mass 36 260.0
+set param_card mass 37 271.6
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.931500605
+set param_card loop 3 -0.618309488
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.23661898
+set param_card loop 7 1.86300121
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.992524279
+set param_card loop 11 -0.122047348
+set param_card loop 12 413.283731
+set param_card loop 13 270.566373
+set param_card decay 35 7.86882681e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 3.81945409e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 1.54967073e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M260 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -1.06358998
+set param_card higgs 2 -1.77397898
+set param_card higgs 3 1.47536859
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.105352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 295.1
+set param_card mass 36 280.0
+set param_card mass 37 290.8
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.941876762
+set param_card loop 3 -0.602385396
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.20477079
+set param_card loop 7 1.88375352
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.994455568
+set param_card loop 11 -0.105157613
+set param_card loop 12 472.568557
+set param_card loop 13 315.320184
+set param_card decay 35 8.81377996e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 4.60685849e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 1.91418825e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M280 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -1.21114255
+set param_card higgs 2 -2.03365868
+set param_card higgs 3 1.66994155
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.091352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 314.0
+set param_card mass 36 300.0
+set param_card mass 37 310.2
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.950217579
+set param_card loop 3 -0.58914052
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.17828104
+set param_card loop 7 1.90043516
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.995830271
+set param_card loop 11 -0.0912253841
+set param_card loop 12 536.150197
+set param_card loop 13 363.780317
+set param_card decay 35 9.13678508e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 5.33353819e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 2.27291084e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M300 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -1.36913504
+set param_card higgs 2 -2.31155972
+set param_card higgs 3 1.87828087
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.080352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 333.1
+set param_card mass 36 320.0
+set param_card mass 37 329.7
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.956640507
+set param_card loop 3 -0.578652695
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.15730539
+set param_card loop 7 1.91328101
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.996773483
+set param_card loop 11 -0.0802659529
+set param_card loop 12 604.437874
+set param_card loop 13 415.29556
+set param_card decay 35 9.28837910e-01 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 6.35568561e-02 # h3 decays, CP-odd Higgs
+set param_card decay 37 2.62332713e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M320 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -1.54152789
+set param_card higgs 2 -2.61144051
+set param_card higgs 3 2.10744914
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.070352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 352.5
+set param_card mass 36 340.0
+set param_card mass 37 349.7
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.962379106
+set param_card loop 3 -0.569057517
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.13811503
+set param_card loop 7 1.92475821
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.997526291
+set param_card loop 11 -0.070294371
+set param_card loop 12 677.875358
+set param_card loop 13 472.415122
+set param_card decay 35 1.00582435e+00 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 1.09329924e-01 # h3 decays, CP-odd Higgs
+set param_card decay 37 2.97106493e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M340 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -1.62845682
+set param_card higgs 2 -2.76365974
+set param_card higgs 3 2.22272465
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.066352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 362.0
+set param_card mass 36 350.0
+set param_card mass 37 359.4
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.964647631
+set param_card loop 3 -0.565203458
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.13040692
+set param_card loop 7 1.92929526
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.997799488
+set param_card loop 11 -0.0663037141
+set param_card loop 12 715.259224
+set param_card loop 13 500.95855
+set param_card decay 35 1.19850489e+00 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 1.68629367e+00 # h3 decays, CP-odd Higgs
+set param_card decay 37 3.13607304e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M350 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_customizecards.dat
@@ -1,0 +1,122 @@
+set param_card QNUMBERS 35 1 0.0
+set param_card QNUMBERS 35 2 1.0
+set param_card QNUMBERS 35 3 1.0
+set param_card QNUMBERS 35 4 0.0
+set param_card QNUMBERS 37 1 3.0
+set param_card QNUMBERS 37 2 1.0
+set param_card QNUMBERS 37 3 1.0
+set param_card QNUMBERS 37 4 1.0
+set param_card yukawagui 1 1 0.0
+set param_card yukawagui 1 2 0.0
+set param_card yukawagui 1 3 0.0
+set param_card yukawagui 2 1 0.0
+set param_card yukawagui 2 2 0.0
+set param_card yukawagui 2 3 0.0
+set param_card yukawagui 3 1 0.0
+set param_card yukawagui 3 2 0.0
+set param_card yukawagui 3 3 0.0
+set param_card QNUMBERS 36 1 0.0
+set param_card QNUMBERS 36 2 1.0
+set param_card QNUMBERS 36 3 1.0
+set param_card QNUMBERS 36 4 0.0
+set param_card yukawa 1 0.0
+set param_card yukawa 2 0.0
+set param_card yukawa 3 0.0
+set param_card yukawa 4 0.0
+set param_card yukawa 5 4.78
+set param_card yukawa 6 173.07
+set param_card yukawa 11 0.0
+set param_card yukawa 13 0.0
+set param_card yukawa 15 1.77684
+set param_card higgs 1 -2.09579386
+set param_card higgs 2 -3.58254055
+set param_card higgs 3 2.84436434
+set param_card higgs 4 0.0
+set param_card higgs 5 -0.050352391
+set param_card higgs 6 0.0
+set param_card higgs 7 0.0
+set param_card ckmblock 1 0.227736
+set param_card yukawagli 1 1 0.0
+set param_card yukawagli 1 2 0.0
+set param_card yukawagli 1 3 0.0
+set param_card yukawagli 2 1 0.0
+set param_card yukawagli 2 2 0.0
+set param_card yukawagli 2 3 0.0
+set param_card yukawagli 3 1 0.0
+set param_card yukawagli 3 2 0.0
+set param_card yukawagli 3 3 0.0
+set param_card yukawagdr 1 1 0.0
+set param_card yukawagdr 1 2 0.0
+set param_card yukawagdr 1 3 0.0
+set param_card yukawagdr 2 1 0.0
+set param_card yukawagdr 2 2 0.0
+set param_card yukawagdr 2 3 0.0
+set param_card yukawagdr 3 1 0.0
+set param_card yukawagdr 3 2 0.0
+set param_card yukawagdr 3 3 -0.0549096353
+set param_card mass 1 0.0
+set param_card mass 2 0.0
+set param_card mass 3 0.0
+set param_card mass 4 0.0
+set param_card mass 5 4.78
+set param_card mass 6 173.07
+set param_card mass 11 0.000510998918
+set param_card mass 13 0.105658367
+set param_card mass 15 1.77684
+set param_card mass 23 91.188
+set param_card mass 24 80.385
+set param_card mass 12 0.0
+set param_card mass 14 0.0
+set param_card mass 16 0.0
+set param_card mass 21 0.0
+set param_card mass 22 0.0
+set param_card mass 25 125.0
+set param_card mass 35 409.5
+set param_card mass 36 400.0
+set param_card mass 37 407.8
+set param_card yukawagdi 1 1 0.0
+set param_card yukawagdi 1 2 0.0
+set param_card yukawagdi 1 3 0.0
+set param_card yukawagdi 2 1 0.0
+set param_card yukawagdi 2 2 0.0
+set param_card yukawagdi 2 3 0.0
+set param_card yukawagdi 3 1 0.0
+set param_card yukawagdi 3 2 0.0
+set param_card yukawagdi 3 3 0.0
+set param_card yukawaglr 1 1 0.0
+set param_card yukawaglr 1 2 0.0
+set param_card yukawaglr 1 3 0.0
+set param_card yukawaglr 2 1 0.0
+set param_card yukawaglr 2 2 0.0
+set param_card yukawaglr 2 3 0.0
+set param_card yukawaglr 3 1 0.0
+set param_card yukawaglr 3 2 0.0
+set param_card yukawaglr 3 3 -0.020411221
+set param_card yukawagur 1 1 0.0
+set param_card yukawagur 1 2 0.0
+set param_card yukawagur 1 3 0.0
+set param_card yukawagur 2 1 0.0
+set param_card yukawagur 2 2 0.0
+set param_card yukawagur 2 3 0.0
+set param_card yukawagur 3 1 0.0
+set param_card yukawagur 3 2 0.0
+set param_card yukawagur 3 3 0.497029842
+set param_card SMINPUTS 1 127.934
+set param_card SMINPUTS 2 1.16637e-05
+set param_card SMINPUTS 3 0.119
+set param_card loop 1 91.188
+set param_card loop 2 0.973567028
+set param_card loop 3 -0.54969741
+set param_card loop 4 0.5
+set param_card loop 5 0.5
+set param_card loop 6 1.09939482
+set param_card loop 7 1.94713406
+set param_card loop 8 2.0
+set param_card loop 9 2.0
+set param_card loop 10 0.998732586
+set param_card loop 11 -0.0503311168
+set param_card loop 12 916.226138
+set param_card loop 13 655.056549
+set param_card decay 35 2.33323671e+00 # h2 decays, heaviest CP-even Higgs
+set param_card decay 36 3.82011292e+00 # h3 decays, CP-odd Higgs
+set param_card decay 37 3.92439730e+00 # Charged Higgs decays

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_extramodels.dat
@@ -1,0 +1,1 @@
+2HDM4MG5-may15.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_proc_card.dat
@@ -1,0 +1,37 @@
+#************************************************************
+#*                     MadGraph5_aMC@NLO                    *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 2.2.3                 2015-02-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph5_aMC@NLO         *
+#*                                                          *
+#*     run as ./bin/mg5_aMC  filename                       *
+#*                                                          *
+#************************************************************
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model 2HDM4MG5-may15
+set gauge unitary
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+generate g g > z h1, z > l+ l-, h1 > ta+ ta-
+
+output AtoZh_M400 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_run_card.dat
@@ -1,0 +1,270 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************


### PR DESCRIPTION
AtoZh, ZtoLL, htoTauTau signals for 2016 data, Moriond17:
Correction to original cards used to produce AtoZh LLTauTau signals for Moriond17 campaign.  Needed to incorporate the decay widths of the non SM-Higgs bosons