### PR TITLE
related to NLO PDF reweighting: 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0016-VERBOSE.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0016-VERBOSE.patch
@@ -1,0 +1,12 @@
+--- a/madgraph/various/banner.py        2016-06-11 00:38:14.000000000 +0800
++++ b/madgraph/various/banner.py        2017-10-05 21:28:40.794461532 +0800
+@@ -982,7 +982,7 @@
+                 value = value.strip()
+                 if value.startswith('[') and value.endswith(']'):
+                     value = value[1:-1]
+-                value = filter(None, re.split(r'(?:(?<!\\)\s)|,', value, re.VERBOSE)) 
++                value = filter(None, re.split(r'(?:(?<!\\)\s)|,', value, flags=re.VERBOSE)) 
+             elif not hasattr(value, '__iter__'):
+                 value = [value]
+             elif isinstance(value, dict):
+


### PR DESCRIPTION
See [1].   Gridpack producing is totally ok. Instead, the problem appears when testing NLO gridpack to produce events.  And it seems to be related to MG242/madgraph/various/banner.py 

The proposed resolution here is to simply remove "re.VERBOSE" in banner.py , and this has been tested with wplustest_5f_NLO successfully

To see the problem more clearly, you can play with the following python code.  Note in MG25X afterwards, banner.py  has been modified a lot.

Would appreciate if someone recheck on this.

--------------------------
#process/bin/internal/banner.py
#def __setitem__(self, name, value, change_userdefine=False):

import re
value= "306000, 322500, 322700, 322900, 323100, 323300, 323500, 323700, 323900, 305800, 13000, 13065, 13069, 13100, 13163, 13167, 13200, 25200, 25300, 25000, 42780, 90200, 91200, 90400, 91400, 61100, 61130, 61200, 61230, 13400, 82200, 292200, 292600, 315000, 315200, 262000, 263000"

value = filter(None, re.split(r'(?:(?<!\\)\s)|,', value, re.VERBOSE))
print "value=", value
------------------------


[1] https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/4444.html