### PR TITLE
backwards compatibility

### DIFF
--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -53,6 +53,10 @@ if args.decay_card is not None:
             command += line.rstrip("\n").replace("ReadCSmax", "")+" "  #remove CSmax so the same card can be used for generating ggH or decaying
     command += " ReadLHE=undecayed.lhe Seed=${rnum}"
 command += ' DataFile=Out'
+########################
+#backwards compatibility
+command = command.replace("Seed=SEED", "")
+########################
 print command
 #Note the same seed is used twice.  This sounds bad but the JHUGen processes are completely independent and use the seed in different ways.
 

--- a/bin/Powheg/runcmsgrid_powhegjhugen.sh
+++ b/bin/Powheg/runcmsgrid_powhegjhugen.sh
@@ -165,6 +165,10 @@ cp ${file}_final.lhe ${WORKDIR}/${file}_tmp.lhe
 cd ${WORKDIR}
 partialcommand=`cat JHUGen.input`
 jhugencommand="./JHUGen $partialcommand ReadLHE=${file}_tmp.lhe DataFile=${file}_final Seed=${seed}"
+########################
+#backwards compatibility
+jhugencommand=$(echo $jhugencommand | sed "s/Seed=SEED//g")
+########################
 echo ${jhugencommand}
 ${jhugencommand}
 


### PR DESCRIPTION
to work for older JHUGen cards that specify Seed=SEED (now it's just done in the script)

as requested here https://github.com/cms-sw/genproductions/pull/1399#issuecomment-335595532