### PR TITLE
Updating boosted Z and inclusive (m>50GeV) DYJets cards for 2017 (MadGraph5_aMCatNLO)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-incl/DYJets_HT-incl_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-incl/DYJets_HT-incl_proc_card.dat
@@ -25,10 +25,8 @@
 ##************************************************************
 import model sm-ckm_no_b_mass
 # Define multiparticle labels
-define p u c s d b u~ c~ s~ d~ b~ g
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
-define j  = p
 # Specify process(es) to run
 generate p p > l+ l- / h @0
 add process p p > l+ l- j / h @1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-incl/DYJets_HT-incl_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_HT_LO_MLM/DYJets_HT_mll50/DYJets_HT-incl/DYJets_HT-incl_proc_card.dat
@@ -1,29 +1,29 @@
 #************************************************************
-#*                        MadGraph 5                        *
-#*                                                          *
-#*                *                       *                 *
-#*                  *        * *        *                   *
-#*                    * * * * 5 * * * *                     *
-#*                  *        * *        *                   *
-#*                *                       *                 *
-#*                                                          *
-#*                                                          *
-#*         VERSION 1.5.11                2013-06-21         *
-#*                                                          *
-#*    The MadGraph Development Team - Please visit us at    *
-#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
-#*                                                          *
-#************************************************************
-#*                                                          *
-#*               Command File for MadGraph 5                *
-#*                                                          *
-#*     run as ./bin/mg5  filename                           *
-#*                                                          *
-#************************************************************
-
+##*                                                          *
+##*                     W E L C O M E to                     *
+##*              M A D G R A P H 5 _ a M C @ N L O           *
+##*                                                          *
+##*                                                          *
+##*                 *                       *                *
+##*                   *        * *        *                  *
+##*                     * * * * 5 * * * *                    *
+##*                   *        * *        *                  *
+##*                 *                       *                *
+##*                                                          *
+##*         VERSION 2.4.2                 2016-06-10         *
+##*                                                          *
+##*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+##*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+##*                            and                           *
+##*            http://amcatnlo.web.cern.ch/amcatnlo/         *
+##*                                                          *
+##*               Type 'help' for in-line help.              *
+##*           Type 'tutorial' to learn how MG5 works         *
+##*    Type 'tutorial aMCatNLO' to learn how aMC@NLO works   *
+##*    Type 'tutorial MadLoop' to learn how MadLoop works    *
+##*                                                          *
+##************************************************************
 import model sm-ckm_no_b_mass
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
 # Define multiparticle labels
 define p u c s d b u~ c~ s~ d~ b~ g
 define l+ = e+ mu+ ta+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_Zpt-150toInf_5f_LO_MLM/DYJets_Zpt-150toInf_5f_LO_MLM_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_Zpt-150toInf_5f_LO_MLM/DYJets_Zpt-150toInf_5f_LO_MLM_proc_card.dat
@@ -1,29 +1,29 @@
 #************************************************************
-#*                        MadGraph 5                        *
 #*                                                          *
-#*                *                       *                 *
-#*                  *        * *        *                   *
-#*                    * * * * 5 * * * *                     *
-#*                  *        * *        *                   *
-#*                *                       *                 *
+#*                     W E L C O M E to                     *
+#*              M A D G R A P H 5 _ a M C @ N L O           *
 #*                                                          *
 #*                                                          *
-#*         VERSION 1.5.11                2013-06-21         *
+#*                 *                       *                *
+#*                   *        * *        *                  *
+#*                     * * * * 5 * * * *                    *
+#*                   *        * *        *                  *
+#*                 *                       *                *
 #*                                                          *
-#*    The MadGraph Development Team - Please visit us at    *
+#*         VERSION 2.4.2                 2016-06-10         *
+#*                                                          *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
 #*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                            and                           *
+#*            http://amcatnlo.web.cern.ch/amcatnlo/         *
+#*                                                          *
+#*               Type 'help' for in-line help.              *
+#*           Type 'tutorial' to learn how MG5 works         *
+#*    Type 'tutorial aMCatNLO' to learn how aMC@NLO works   *
+#*    Type 'tutorial MadLoop' to learn how MadLoop works    *
 #*                                                          *
 #************************************************************
-#*                                                          *
-#*               Command File for MadGraph 5                *
-#*                                                          *
-#*     run as ./bin/mg5  filename                           *
-#*                                                          *
-#************************************************************
-
 import model sm-ckm_no_b_mass
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
 # Define multiparticle labels
 define p u c s d b u~ c~ s~ d~ b~ g
 define l+ = e+ mu+ ta+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_Zpt-150toInf_5f_LO_MLM/DYJets_Zpt-150toInf_5f_LO_MLM_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJets_Zpt-150toInf_5f_LO_MLM/DYJets_Zpt-150toInf_5f_LO_MLM_proc_card.dat
@@ -25,10 +25,8 @@
 #************************************************************
 import model sm-ckm_no_b_mass
 # Define multiparticle labels
-define p u c s d b u~ c~ s~ d~ b~ g
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
-define j  = p
 # Specify process(es) to run
 generate p p > l+ l- / h @0
 add process p p > l+ l- j / h @1


### PR DESCRIPTION
Banner updated and neutrino defintions removed. However I didn't remove the proton and jet definitions because the parsing code complains without them.