### PR TITLE
Update gridpack_generation.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -102,8 +102,7 @@ RUNHOME=`pwd`
 LOGFILE=${RUNHOME}/${name}.log
 LOGFILE_NAME=${LOGFILE/.log/}
 if [ "${name}" != "interactive" ]; then
-  exec > >(tee ${LOGFILE})
-  exec 2>&1
+  exec &> ${LOGFILE}
 fi
 
 echo "Starting job on " `date` #Only to display the starting of production date


### PR DESCRIPTION
Tier Sites with singularity don't like process substitution <() format, so replacing it with an alternative.

Should solve #1420, but it is still untested.