### PR TITLE
Critical fixes for HNNLO and MadLibs

### DIFF
--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -424,9 +424,9 @@ if [ "$process" = "bbH" ]; then
    sed -i -e "s#O2#O0#g" Makefile
 fi
 
-## Not needed anymore
-# sed -i -e 's#$(PDFPACK#lhefread.o pwhg_io_interface.o rwl_weightlists.o rwl_setup_param_weights.o \\ \
-#	$(PDFPACK#' Makefile
+# Remove strange options in fortran (fixed line length, multiCPU compilation)
+sed -i -e "s#132#none#g" Makefile
+sed -i -e "s#make -j FC#make FC#g" Makefile
 
 # hardcode svn info
 sed -i -e 's#^pwhg_main:#$(shell ../svnversion/svnversion.sh>/dev/null) \
@@ -596,8 +596,8 @@ if [ "$process" = "HJ" ]; then
   cp ../POWHEG-BOX/HJ/NNLOPS-mass-effects/HNNLO-makefile ./makefile 
   cp -r ../POWHEG-BOX/HJ/NNLOPS-mass-effects/HNNLO-patches ./
   cd src/Need/
-  cat pdfset_lhapdf.f | sed -e "s#30#40#g" | sed -e "s#20#25#g" > pdfset_lhapdf.f.new
-  mv pdfset_lhapdf.f.new pdfset_lhapdf.f
+  cat pdfset_lhapdf.f | sed -e "s#30#40#g" | sed -e "s#20#25#g" | sed -e "s#InitPDFset#InitPDFsetByName#g" > pdfset_lhapdf.f.new
+  mv pdfset_lhapdf.f.new pdfset_lhapdf.f  
   cd -
   cat makefile | sed -e "s#LHAPDFLIB=.\+#LHAPDFLIB=$(scram tool info lhapdf | grep LIBDIR | cut -d "=" -f2)#g" > makefile
   make || fail_exit "Failed to compile HNNLO"


### PR DESCRIPTION
Two fixes:
- Call PDF initialization by name in HNNLO as suggested by @agrohsje --> affects HJ+NNLOPS
- Remove weird fortran options (fixed line length causes problems in gfortran6.3 on lxplus)  --> affects trijet and possibly others

@gourangakole @pgunnell 

@bendavid please let us know if HNNLO fix is somehow clashing with your dev version
