### PR TITLE
Gridpack generation support for T2_BE_IIHE's cream02 cluster

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -228,12 +228,10 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
       echo "set run_mode  1" >> mgconfigscript
       if [ "$queue" == "condor" ]; then
         echo "set cluster_type condor" >> mgconfigscript
-        #*FIXME* broken in mg_amc 2.4.0
-#        echo "set cluster_queue None" >> mgconfigscript
+      elif [ "$queue" == "cream02" ]; then
+        echo "set cluster_type pbs" >> mgconfigscript
       else
         echo "set cluster_type lsf" >> mgconfigscript
-        #*FIXME* broken in mg_amc 2.4.0
-#         echo "set cluster_queue $queue" >> mgconfigscript
       fi 
       if [ $iscmsconnect -gt 0 ]; then
 	  n_retries=10
@@ -356,6 +354,10 @@ if [ ! -d ${AFS_GEN_FOLDER}/${name}_gridpack ]; then
   #*FIXME* workaround for broken set cluster_queue handling
   if [ "$queue" == "condor" ]; then
     echo "cluster_queue = None" >> ./$MGBASEDIRORIG/input/mg5_configuration.txt
+  elif [ "$queue" == "cream02" ]; then
+    echo "cluster_queue = localgrid@cream02" >> ./$MGBASEDIRORIG/input/mg5_configuration.txt
+    mkdir -p /user/$USER/temp
+    echo "cluster_temp_path = /user/$USER/temp" >> ./$MGBASEDIRORIG/input/mg5_configuration.txt
   else
     echo "cluster_queue = $queue" >> ./$MGBASEDIRORIG/input/mg5_configuration.txt
   fi

--- a/bin/MadGraph5_aMCatNLO/patches/0017-fix-pbs-cluster.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0017-fix-pbs-cluster.patch
@@ -5,6 +5,17 @@ diff --git a/madgraph/various/cluster.py b/madgraph/various/cluster.py
 -    maximum_submited_jobs = 2500
 +    maximum_submited_jobs = 1000
 @@ -1244,2 +1244,3 @@
-+        text += "source $VO_CMS_SW_DIR/cmsset_default.sh;eval `scram runtime -sh`;"
++        text += "source /cvmfs/cms.cern.ch/cmsset_default.sh;eval `scram runtime -sh`;"
          if not os.path.isabs(prog):
              text += "./%s" % prog
+@@ -1281,6 +1282,9 @@
+-        for line in status.stdout:
++        for line in (status.stdout + status.stderr):
+             line = line.strip()
+             if 'cannot connect to server' in line or 'cannot read reply' in line:
+                 raise ClusterManagmentError, 'server disconnected'
+             if 'Unknown' in line:
+                 return 'F'
++            elif 'Invalid credential' in line:       # sometimes qstat simply fails, wait a bit and try again
++                time.sleep(10)
++                return self.control_one_job(id)

--- a/bin/MadGraph5_aMCatNLO/patches/0017-fix-pbs-cluster.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0017-fix-pbs-cluster.patch
@@ -1,10 +1,10 @@
 diff --git a/madgraph/various/cluster.py b/madgraph/various/cluster.py
 --- a/madgraph/various/cluster.py
 +++ b/madgraph/various/cluster.py
-@@ -1220,1 +1220,1 @@
+@@ -1216,1 +1216,1 @@
 -    maximum_submited_jobs = 2500
 +    maximum_submited_jobs = 1000
-@@ -1248,2 +1248,3 @@
+@@ -1244,2 +1244,3 @@
 +        text += "source $VO_CMS_SW_DIR/cmsset_default.sh;eval `scram runtime -sh`;"
          if not os.path.isabs(prog):
              text += "./%s" % prog

--- a/bin/MadGraph5_aMCatNLO/patches/1006-fix-pbs-cluster.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/1006-fix-pbs-cluster.patch
@@ -1,0 +1,10 @@
+diff --git a/madgraph/various/cluster.py b/madgraph/various/cluster.py
+--- a/madgraph/various/cluster.py
++++ b/madgraph/various/cluster.py
+@@ -1220,1 +1220,1 @@
+-    maximum_submited_jobs = 2500
++    maximum_submited_jobs = 1000
+@@ -1248,2 +1248,3 @@
++        text += "source $VO_CMS_SW_DIR/cmsset_default.sh;eval `scram runtime -sh`;"
+         if not os.path.isabs(prog):
+             text += "./%s" % prog


### PR DESCRIPTION
With these changes you can run the gridpack_generation.sh script also on the T2_BE_IIHE's cream02 cluster. This is also very useful for the Belgian users, so I make the pull request in order to share it. As it simply adds "cream02" for the queue option, it will not affect other users.

The patch in madgraph/various/cluster.py makes an essential change to the PBSCluster class: it sources the CMSSW environment such that the needed fortran libraries are available.