### PR TITLE
add script to generate other mass points

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/SingleLQ3ToTauB_5f_madgraph_LO/clone.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/SingleLQ3ToTauB_5f_madgraph_LO/clone.sh
@@ -1,0 +1,69 @@
+# s-channel
+# create Madgraph cards, based on M200 GeV one
+# 
+
+for mass in 300 400 500 600 700 800 900 1000 1200 1500 2000 
+do
+
+    echo "generating ... " ${mass}
+
+    cp -r SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M200 SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}
+
+    for card in extramodels param_card proc_card run_card
+    do
+	mv SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M200_${card}.dat SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}_${card}.dat
+    done
+
+
+    sed -i -e "s/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M200/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M"${mass}"/" SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}_proc_card.dat
+    sed -i -e "s/9000006 2.000000e+02 # mr23/9000006 "${mass}" # mr23/" SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_s-channel-M${mass}_param_card.dat
+
+done
+
+
+
+# t-channel
+# create Madgraph cards, based on M200 GeV one
+# 
+
+for mass in 300 400 500 600 700 800 900 1000 1200 1500 2000 
+do
+
+    echo "generating ... " ${mass}
+
+    cp -r SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M200 SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}
+
+    for card in extramodels param_card proc_card run_card
+    do
+	mv SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M200_${card}.dat SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}_${card}.dat
+    done
+
+
+    sed -i -e "s/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M200/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M"${mass}"/" SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}_proc_card.dat
+    sed -i -e "s/9000006 2.000000e+02 # mr23/9000006 "${mass}" # mr23/" SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_t-channel-M${mass}_param_card.dat
+
+done
+
+
+# pair prod.
+# create Madgraph cards, based on M200 GeV one
+# 
+
+for mass in 300 400 500 600 700 800 900 1000 1200 1500 2000 
+do
+
+    echo "generating ... " ${mass}
+
+    cp -r SingleLQ3ToTauB_5f_madgraph_LO_pair-M200 SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}
+
+    for card in extramodels param_card proc_card run_card
+    do
+	mv SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_pair-M200_${card}.dat SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}_${card}.dat
+    done
+
+
+    sed -i -e "s/SingleLQ3ToTauB_5f_madgraph_LO_pair-M200/SingleLQ3ToTauB_5f_madgraph_LO_pair-M"${mass}"/" SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}_proc_card.dat
+    sed -i -e "s/9000006 2.000000e+02 # mr23/9000006 "${mass}" # mr23/" SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}/SingleLQ3ToTauB_5f_madgraph_LO_pair-M${mass}_param_card.dat
+
+done
+


### PR DESCRIPTION
This is the script to clone Madgraph cards, used to generate other mass points (*), starting from 200 GeV one (whose cards already approved at https://github.com/cms-sw/genproductions/pull/1516)

There are three processes (s-, t- and pair production).

(*)
300, 400, 500, 600, 700, 800, 900, 1000, 1200, 1500, 2000 GeV