### PR TITLE
Set TMPDIR to condor scratch area when not defined

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0018-propagate-madevent-exitcode-properly.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0018-propagate-madevent-exitcode-properly.patch
@@ -1,26 +1,59 @@
 diff --git a/Template/LO/SubProcesses/refine.sh b/Template/LO/SubProcesses/refine.sh
-index 577461f..52006bc 100644
+index 577461f..eec44ea 100644
 --- a/Template/LO/SubProcesses/refine.sh
 +++ b/Template/LO/SubProcesses/refine.sh
-@@ -78,3 +78,4 @@ j=%(directory)s
+@@ -12,6 +12,10 @@ if [ $SRT_LD_LIBRARY_PATH_SCRAMRT ]; then
+   fi
+ fi
+ 
++# If TMPDIR is unset, set it to the condor scratch area if present
++# and fallback to /tmp
++export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
++
+ if [[ -e MadLoop5_resources.tar.gz && ! -e MadLoop5_resources ]]; then
+ tar -xzf MadLoop5_resources.tar.gz
+ fi
+@@ -78,3 +82,4 @@ j=%(directory)s
       fi
       cd ../
  
 +exit $status_code
 diff --git a/Template/LO/SubProcesses/refine_splitted.sh b/Template/LO/SubProcesses/refine_splitted.sh
-index d7d5df6..fef13e5 100644
+index d7d5df6..6f65eb0 100644
 --- a/Template/LO/SubProcesses/refine_splitted.sh
 +++ b/Template/LO/SubProcesses/refine_splitted.sh
-@@ -85,3 +85,4 @@ if [[ $status_code -ne 0 ]]; then
+@@ -12,6 +12,10 @@ if [ $SRT_LD_LIBRARY_PATH_SCRAMRT ]; then
+   fi
+ fi
+ 
++# If TMPDIR is unset, set it to the condor scratch area if present
++# and fallback to /tmp
++export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
++
+ if [[ -e MadLoop5_resources.tar.gz && ! -e MadLoop5_resources ]]; then
+ tar -xzf MadLoop5_resources.tar.gz
+ fi
+@@ -85,3 +89,4 @@ if [[ $status_code -ne 0 ]]; then
  fi
  
  cd ../
 +exit $status_code
 diff --git a/Template/LO/SubProcesses/survey.sh b/Template/LO/SubProcesses/survey.sh
-index c9ef2c5..37472be 100755
+index c9ef2c5..1333846 100755
 --- a/Template/LO/SubProcesses/survey.sh
 +++ b/Template/LO/SubProcesses/survey.sh
-@@ -80,6 +80,8 @@ for i in $@ ; do
+@@ -12,6 +12,10 @@ if [ $SRT_LD_LIBRARY_PATH_SCRAMRT ]; then
+   fi
+ fi
+ 
++# If TMPDIR is unset, set it to the condor scratch area if present
++# and fallback to /tmp
++export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
++
+ if [[ -e MadLoop5_resources.tar.gz && ! -e MadLoop5_resources ]]; then
+ tar -xzf MadLoop5_resources.tar.gz;
+ fi
+@@ -80,6 +84,8 @@ for i in $@ ; do
  	 rm results.dat
  	 echo "ERROR DETECTED"
  	 echo "end code not correct $status_code" > results.dat
@@ -29,10 +62,40 @@ index c9ef2c5..37472be 100755
       fi
       cd ../;
  
-@@ -87,6 +89,3 @@ for i in $@ ; do
+@@ -87,6 +93,3 @@ for i in $@ ; do
  done;
  
  # Cleaning 
 -
 -
 -
+diff --git a/Template/NLO/SubProcesses/ajob_template b/Template/NLO/SubProcesses/ajob_template
+index db5444b..dd3e508 100755
+--- a/Template/NLO/SubProcesses/ajob_template
++++ b/Template/NLO/SubProcesses/ajob_template
+@@ -19,6 +19,10 @@ if [ $SRT_LD_LIBRARY_PATH_SCRAMRT ]; then
+   fi
+ fi
+ 
++# If TMPDIR is unset, set it to the condor scratch area if present
++# and fallback to /tmp
++export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
++
+ tarCounter=0
+ while [[ (-f MadLoop5_resources.tar.gz) && (! -f MadLoop5_resources/HelConfigs.dat) && ($tarCounter < 10) ]]; do
+     if [[ $tarCounter > 0 ]]; then
+diff --git a/Template/NLO/SubProcesses/reweight_xsec_events.local b/Template/NLO/SubProcesses/reweight_xsec_events.local
+index a38c4e8..c8c856b 100644
+--- a/Template/NLO/SubProcesses/reweight_xsec_events.local
++++ b/Template/NLO/SubProcesses/reweight_xsec_events.local
+@@ -15,6 +15,10 @@ if [ $SRT_LD_LIBRARY_PATH_SCRAMRT ]; then
+   fi
+ fi
+ 
++# If TMPDIR is unset, set it to the condor scratch area if present
++# and fallback to /tmp
++export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
++
+ if [[ -e ./reweight_xsec_events ]]
+ then
+     (echo $event_file; echo $save_wgts) | ./reweight_xsec_events > reweight_xsec_events.output


### PR DESCRIPTION
Update patch 0018 to make sure TMPDIR does exist in the environment.

Most cluster configurations define TMPDIR as the batch manager scratch area in the worker node environment. When this doesn't happen, it falls back to `/tmp`. This patch set TMPDIR to the condor scratch area if:
- TMPDIR is not set in the environment (LSF jobs and local condor jobs should have this set already, but not necessarily on all sites in the global pool)
- _CONDOR_SCRATCH_DIR does exist (this should be the case for all condor jobs, local or grid)

otherwise, it falls back to `/tmp`, which is the default.

This is also related to #1534