### PR TITLE
Add another hold code to the list for release/resubmission.

### DIFF
--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
@@ -119,9 +119,10 @@ proxy-watcher -start
 #26:119 : CVMFS failed
 #30:256: Job put on hold by remote host
 #13: condor_starter or shadow failed to send job
+#12:28 : (errno 28) No space left on device
 
 if [ -z "$CONDOR_RELEASE_HOLDCODES" ]; then
-  export CONDOR_RELEASE_HOLDCODES="26:119,13,30:256"
+  export CONDOR_RELEASE_HOLDCODES="26:119,13,30:256,12:28"
 fi
 if [ -z "$CONDOR_RELEASE_HOLDCODES_SHADOW_LIM" ]; then
   export CONDOR_RELEASE_HOLDCODES_SHADOW_LIM="10"


### PR DESCRIPTION
This should release and resubmit a job when a message like below is shown:

```
ClusterId 1054284 with HoldReason: Error from
glidein_27986_94860774@se1wn29.pi.infn.it: STARTER at 10.1.5.29 failed
to write to file
/home/grid/cmsplt17/home_cream_421610391/CREAM421610391/glide_9cqwfs/execute/dir_5025/madevent:
(errno 28) No space left on device
```