### PR TITLE
Fix systematics issue for LO MG without madspin

### DIFF
--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -72,9 +72,11 @@ fi
 cd $LHEWORKDIR
 
 runlabel=GridRun_${rnum}
+event_file=events.lhe.gz
 if [ "$domadspin" -gt "0" ] ; then 
-    mv process/events_decayed.lhe.gz process/madevent/Events/${runlabel}/events.lhe.gz
+    event_file=events_decayed.lhe.gz
 fi
+mv process/$event_file process/madevent/Events/${runlabel}/events.lhe.gz
 
 # Add scale and PDF weights using systematics module
 #


### PR DESCRIPTION
wrong event file was being used when generation was done without
madspin. Correct file with unweighted events should now be used.