### PR TITLE
increment JHUGen and add more decays

### DIFF
--- a/bin/JHUGen/cards/decay/WW2l2nu_notaus.input
+++ b/bin/JHUGen/cards/decay/WW2l2nu_notaus.input
@@ -1,0 +1,1 @@
+DecayMode1=4 DecayMode2=4

--- a/bin/JHUGen/cards/decay/WW2l2nu_notaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/WW2l2nu_notaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=4 DecayMode2=4 ReweightDecay WidthSchemeIn=3 ReadPmHstar PmHstarFile=PMWWdistribution.out

--- a/bin/JHUGen/cards/decay/WW2l2nu_withtaus.input
+++ b/bin/JHUGen/cards/decay/WW2l2nu_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10

--- a/bin/JHUGen/cards/decay/WW2l2nu_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/WW2l2nu_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10 ReweightDecay WidthSchemeIn=3 ReadPmHstar PmHstarFile=PMWWdistribution.out

--- a/bin/JHUGen/cards/decay/WW4q.input
+++ b/bin/JHUGen/cards/decay/WW4q.input
@@ -1,0 +1,1 @@
+DecayMode1=5 DecayMode2=5

--- a/bin/JHUGen/cards/decay/WW4q_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/WW4q_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=5 DecayMode2=5 ReweightDecay WidthSchemeIn=3 ReadPmHstar PmHstarFile=PMWWdistribution.out

--- a/bin/JHUGen/cards/decay/WWlnuqq_notaus.input
+++ b/bin/JHUGen/cards/decay/WWlnuqq_notaus.input
@@ -1,0 +1,1 @@
+DecayMode1=4 DecayMode2=5

--- a/bin/JHUGen/cards/decay/WWlnuqq_notaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/WWlnuqq_notaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=4 DecayMode2=5 ReweightDecay WidthSchemeIn=3 ReadPmHstar PmHstarFile=PMWWdistribution.out

--- a/bin/JHUGen/cards/decay/WWlnuqq_withtaus.input
+++ b/bin/JHUGen/cards/decay/WWlnuqq_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=5

--- a/bin/JHUGen/cards/decay/WWlnuqq_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/WWlnuqq_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=5 ReweightDecay WidthSchemeIn=3 ReadPmHstar PmHstarFile=PMWWdistribution.out

--- a/bin/JHUGen/patches/install.sh
+++ b/bin/JHUGen/patches/install.sh
@@ -11,16 +11,18 @@ if [ $linkMELA != true ] && [ $linkMELA != false ]; then
     echo "Argument to $0 has to be true to link MELA or false to not link it"
 fi
 
-wget --no-check-certificate http://cms-project-generators.web.cern.ch/cms-project-generators/slc6_amd64_gcc481/JHUGenerator.v7.0.9.tar.gz -O JHUGenerator.v7.0.9.tar.gz
-tar xzvf JHUGenerator.v7.0.9.tar.gz
+jhugenversion=v7.0.11
+
+wget --no-check-certificate http://spin.pha.jhu.edu/Generator/JHUGenerator.${jhugenversion}.tar.gz -O JHUGenerator.${jhugenversion}.tar.gz
+tar xzvf JHUGenerator.${jhugenversion}.tar.gz
 rm -rf AnalyticMELA
 rm -f manJHUGenerator*.pdf
 cd JHUGenerator
 sed -i "s/UseLHAPDF=No/UseLHAPDF=Yes/" makefile
 if ! $linkMELA; then
     sed -i "s/linkMELA = Yes/linkMELA = No/" makefile
-    rm -rf ../JHUGenMELAv2
+    rm -rf ../JHUGenMELA
 fi
 make
-rm ../JHUGenerator.v7.0.9.tar.gz
+rm ../JHUGenerator.${jhugenversion}.tar.gz
 

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -286,7 +286,7 @@ def runGetSource(parstage, xgrid, folderName, powInputName, process, noPdfCheck,
 '''
 # Release to be used to define the environment and the compiler needed
 export RELEASE=${CMSSW_VERSION}
-export jhugenversion="v7.0.9"
+export jhugenversion="v7.0.11"
 
 cd $WORKDIR
 pwd
@@ -506,7 +506,7 @@ rm -f Makefile.interm tmpfile
 echo "LIBS+=-lz -lstdc++" >> Makefile
 if [ $jhugen = 1 ]; then
   if [ ! -f JHUGenerator.${jhugenversion}.tar.gz ]; then
-    wget --no-verbose --no-check-certificate http://cms-project-generators.web.cern.ch/cms-project-generators/slc6_amd64_gcc481/JHUGenerator.${jhugenversion}.tar.gz || fail_exit "Failed to get JHUGen tar ball "
+    wget --no-verbose --no-check-certificate http://spin.pha.jhu.edu/Generator/JHUGenerator.${jhugenversion}.tar.gz || fail_exit "Failed to get JHUGen tar ball "
   fi
 
   tar zxf JHUGenerator.${jhugenversion}.tar.gz


### PR DESCRIPTION
The new JHUGen version is identical for physics but fixes a miscommunication between POWHEG, JHUGen, and Pythia for the handling of event weights when the ReweightDecay option is used for POWHEG ggH samples.