### PR TITLE
modification in the decay filter HHTo2C2L2Nu and renamed into HHTo2C2…

### DIFF
--- a/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2C2WTo2C2L2Nu_madgraph_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2C2WTo2C2L2Nu_madgraph_pythia8_cff.py
@@ -26,23 +26,20 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,
         processParameters = cms.vstring(
-            '23:mMin = 0.05',
-            '23:onMode = off',
-            '23:onIfAny = 11 12 13 14 15 16', # only leptonic Z decays
+            '15:onMode = on',
             '24:mMin = 0.05',
             '24:onMode = off',
             '24:onIfAny = 11 13 15', # only leptonic W decays
             '25:m0 = 125.0',
             '25:onMode = off',
             '25:onIfMatch = 4 -4',
-            '25:onIfMatch = 23 23',
             '25:onIfMatch = 24 -24',
             'ResonanceDecayFilter:filter = on',
             'ResonanceDecayFilter:exclusive = on', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
             'ResonanceDecayFilter:eMuAsEquivalent = off', #on: treat electrons and muons as equivalent
             'ResonanceDecayFilter:eMuTauAsEquivalent = on', #on: treat electrons, muons , and taus as equivalent
             'ResonanceDecayFilter:allNuAsEquivalent = on', #on: treat all three neutrino flavours as equivalent
-            'ResonanceDecayFilter:mothers = 25,23,24', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
+            'ResonanceDecayFilter:mothers = 25,24', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
             'ResonanceDecayFilter:daughters = 4,4,11,11,12,12',
           ),
         parameterSets = cms.vstring('pythia8CommonSettings',


### PR DESCRIPTION
modification to the file ResonanceDecayFilter_example_HHTo2C2L2Nu_madgraph_pythia8_cff.py in order to allow only HH(H->CC, H->WW) and not also H->ZZ taken into account in another filter. The file has been subsequently renamed into ResonanceDecayFilter_example_HHTo2C2WTo2C2L2Nu_madgraph_pythia8_cff.py