### PR TITLE
Update default CMS Connect MaxWallTime values

### DIFF
--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
@@ -130,7 +130,7 @@ fi
 # Set a list of maxwalltime in minutes
 # Pilots maximum life is 48h or 2880 minutes
 if [ -z "$CONDOR_SET_MAXWALLTIMES" ]; then
-  export CONDOR_SET_MAXWALLTIMES="500,960,2160,2820"
+  export CONDOR_SET_MAXWALLTIMES="500,960,2160,2820,4200"
 fi
 
 ##########################


### PR DESCRIPTION
Change default maxwalltime values, to request up to 70 hours of MaxWallTime if needed.