### PR TITLE
update JHUGen version

### DIFF
--- a/bin/JHUGen/patches/install.sh
+++ b/bin/JHUGen/patches/install.sh
@@ -11,7 +11,7 @@ if [ $linkMELA != true ] && [ $linkMELA != false ]; then
     echo "Argument to $0 has to be true to link MELA or false to not link it"
 fi
 
-jhugenversion=v7.0.11
+jhugenversion=v7.1.0
 
 wget --no-check-certificate http://spin.pha.jhu.edu/Generator/JHUGenerator.${jhugenversion}.tar.gz -O JHUGenerator.${jhugenversion}.tar.gz
 tar xzvf JHUGenerator.${jhugenversion}.tar.gz

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -286,7 +286,7 @@ def runGetSource(parstage, xgrid, folderName, powInputName, process, noPdfCheck,
 '''
 # Release to be used to define the environment and the compiler needed
 export RELEASE=${CMSSW_VERSION}
-export jhugenversion="v7.0.11"
+export jhugenversion="v7.1.0"
 
 cd $WORKDIR
 pwd


### PR DESCRIPTION
This version expands the Z' implementation, which is going to be used for upcoming low mass resonance X->upsilon upsilon and X->upsilon gamma* requests.  There are no changes that would be relevant for ongoing productions.