### PR TITLE
Cards for monophoton DMsimp samples

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_customizecards.dat
@@ -1,0 +1,17 @@
+set param_card mass  55 1000
+set param_card mass  52 1
+set param_card dminputs 2 1
+set param_card dminputs 3 0
+set param_card dminputs 4 0.25
+set param_card dminputs 5 0.25
+set param_card dminputs 6 0.25
+set param_card dminputs 7 0.25
+set param_card dminputs 8 0.25
+set param_card dminputs 9 0.25
+set param_card dminputs 10 0
+set param_card dminputs 11 0
+set param_card dminputs 12 0
+set param_card dminputs 13 0
+set param_card dminputs 14 0
+set param_card dminputs 15 0
+set param_card decay 55 auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_extramodels.dat
@@ -1,0 +1,1 @@
+DMsimp_s_spin1.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_proc_card.dat
@@ -1,0 +1,5 @@
+import DMsimp_s_spin1
+# Define multiparticle labels
+generate       p p  > xd xd~ a   [QCD]
+add process    p p  > xd xd~ a j [QCD]
+output Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1	= run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500	= nevents ! Number of unweighted events requested 
+  -1.0	= req_acc ! Required accuracy (-1=auto determined from nevents)
+  -1	= nevt_job ! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+  average	= event_norm ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+  0.01	= req_acc_fo ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+  5000	= npoints_fo_grid ! number of points to setup grids
+  4	= niters_fo_grid ! number of iter. to setup grids
+  10000	= npoints_fo ! number of points to compute Xsec
+  6	= niters_fo ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+  1	= lpp1 ! beam 1 type (0 = no PDF)
+  1	= lpp2 ! beam 2 type (0 = no PDF)
+  6500.0	= ebeam1 ! beam 1 energy in GeV
+  6500.0	= ebeam2 ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+  lhapdf	= pdlabel ! PDF set
+$DEFAULT_PDF_SETS = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8	= parton_shower 
+  1.0	= shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.118	= mur_ref_fixed ! fixed ren reference scale 
+  91.118	= muf_ref_fixed ! fixed fact reference scale
+  -1	= dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+  1.0	= mur_over_ref ! ratio of current muR over reference muR
+  1.0	= muf_over_ref ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+  1.0, 2.0, 0.5	= rw_rscale ! muR factors to be included by reweighting
+  1.0, 2.0, 0.5	= rw_fscale ! muF factors to be included by reweighting
+  True	= reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+$DEFAULT_PDF_MEMBERS = reweight_pdf ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+  True	= store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+  3	= ickkw 
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+  15.0	= bwcutoff 
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0	= jetalgo ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7	= jetradius ! The radius parameter for the jet algorithm
+  10.0	= ptj ! Min jet transverse momentum
+  -1.0	= etaj ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0	= ptl ! Min lepton transverse momentum
+  -1.0	= etal ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0	= drll ! Min distance between opposite sign lepton pairs
+  0.0	= drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0	= mll ! Min inv. mass of all opposite sign lepton pairs
+  30.0	= mll_sf ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 130.0	= ptgmin ! Min photon transverse momentum
+  -1.0	= etagamma ! Max photon abs(pseudo-rap)
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+  0	= iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/customizecards.dat
@@ -1,0 +1,17 @@
+set param_card mass  55 _MMED_
+set param_card mass  52 _MDM_
+set param_card dminputs 2 _gDMV_
+set param_card dminputs 3 _gDMA_
+set param_card dminputs 4 _gVq_
+set param_card dminputs 5 _gVq_
+set param_card dminputs 6 _gVq_
+set param_card dminputs 7 _gVq_
+set param_card dminputs 8 _gVq_
+set param_card dminputs 9 _gVq_
+set param_card dminputs 10 _gAq_
+set param_card dminputs 11 _gAq_
+set param_card dminputs 12 _gAq_
+set param_card dminputs 13 _gAq_
+set param_card dminputs 14 _gAq_
+set param_card dminputs 15 _gAq_
+set param_card decay 55 auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/extramodels.dat
@@ -1,0 +1,1 @@
+DMsimp_s_spin1.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/make_cards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/make_cards.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#################################################
+### Script to generate cards directories for  ###
+### monophoton DMsimp samples (pta > 130 GeV) ###
+#################################################
+
+CARDDIR=$(cd $(dirname $0); pwd)
+
+for MMED in 50 100 500 1000 1500 2000
+do
+  for MDM in 1 10 50 150 500
+  do
+    [ $MDM -eq $(($MMED/2)) ] && MDM=$(($MDM-10))
+    [ $MDM -gt $(($MMED/2)) ] && break
+
+    CARDLABEL=Mphi-${MMED}_Mchi-${MDM}_gSM-0p25_gDM-1p0_pta130
+
+    ## Vector
+    CARDNAME=Vector_MonoPhoton_NLO_${CARDLABEL}    
+    DIR=$CARDDIR/Vector_${CARDLABEL}
+
+    mkdir -p $DIR
+
+    cp $CARDDIR/extramodels.dat $DIR/${CARDNAME}_extramodels.dat
+    cp $CARDDIR/run_card.dat $DIR/${CARDNAME}_run_card.dat
+    sed -e "s/_MMED_/$MMED/" -e "s/_MDM_/$MDM/" -e "s/_gDMV_/1/" -e "s/_gVq_/0.25/" -e "s/_gDMA_/0/" -e "s/_gAq_/0/" $CARDDIR/customizecards.dat > $DIR/${CARDNAME}_customizecards.dat
+    sed "s/_NAME_/$CARDNAME/" $CARDDIR/proc_card.dat > $DIR/${CARDNAME}_proc_card.dat
+
+    ## Axial
+    CARDNAME=Axial_MonoPhoton_NLO_${CARDLABEL}    
+    DIR=$CARDDIR/Axial_${CARDLABEL}
+
+    mkdir -p $DIR
+
+    cp $CARDDIR/extramodels.dat $DIR/${CARDNAME}_extramodels.dat
+    cp $CARDDIR/run_card.dat $DIR/${CARDNAME}_run_card.dat
+    sed -e "s/_MMED_/$MMED/" -e "s/_MDM_/$MDM/" -e "s/_gDMV_/0/" -e "s/_gVq_/0/" -e "s/_gDMA_/1/" -e "s/_gAq_/0.25/" $CARDDIR/customizecards.dat > $DIR/${CARDNAME}_customizecards.dat
+    sed "s/_NAME_/$CARDNAME/" $CARDDIR/proc_card.dat > $DIR/${CARDNAME}_proc_card.dat
+
+  done
+done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/proc_card.dat
@@ -1,0 +1,5 @@
+import DMsimp_s_spin1
+# Define multiparticle labels
+generate       p p  > xd xd~ a   [QCD]
+add process    p p  > xd xd~ a j [QCD]
+output _NAME_

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MonoPhoton_DMsimp/run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1	= run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500	= nevents ! Number of unweighted events requested 
+  -1.0	= req_acc ! Required accuracy (-1=auto determined from nevents)
+  -1	= nevt_job ! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+  average	= event_norm ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+  0.01	= req_acc_fo ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+  5000	= npoints_fo_grid ! number of points to setup grids
+  4	= niters_fo_grid ! number of iter. to setup grids
+  10000	= npoints_fo ! number of points to compute Xsec
+  6	= niters_fo ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+  1	= lpp1 ! beam 1 type (0 = no PDF)
+  1	= lpp2 ! beam 2 type (0 = no PDF)
+  6500.0	= ebeam1 ! beam 1 energy in GeV
+  6500.0	= ebeam2 ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+  lhapdf	= pdlabel ! PDF set
+$DEFAULT_PDF_SETS = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8	= parton_shower 
+  1.0	= shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.118	= mur_ref_fixed ! fixed ren reference scale 
+  91.118	= muf_ref_fixed ! fixed fact reference scale
+  -1	= dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+  1.0	= mur_over_ref ! ratio of current muR over reference muR
+  1.0	= muf_over_ref ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+  1.0, 2.0, 0.5	= rw_rscale ! muR factors to be included by reweighting
+  1.0, 2.0, 0.5	= rw_fscale ! muF factors to be included by reweighting
+  True	= reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+$DEFAULT_PDF_MEMBERS = reweight_pdf ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+  True	= store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+  3	= ickkw 
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+  15.0	= bwcutoff 
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0	= jetalgo ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7	= jetradius ! The radius parameter for the jet algorithm
+  10.0	= ptj ! Min jet transverse momentum
+  -1.0	= etaj ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0	= ptl ! Min lepton transverse momentum
+  -1.0	= etal ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0	= drll ! Min distance between opposite sign lepton pairs
+  0.0	= drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0	= mll ! Min inv. mass of all opposite sign lepton pairs
+  30.0	= mll_sf ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 130.0	= ptgmin ! Min photon transverse momentum
+  -1.0	= etagamma ! Max photon abs(pseudo-rap)
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+  0	= iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_customizecards.dat
@@ -1,0 +1,17 @@
+set param_card mass  55 1000
+set param_card mass  52 1
+set param_card dminputs 2 1
+set param_card dminputs 3 0
+set param_card dminputs 4 0.25
+set param_card dminputs 5 0.25
+set param_card dminputs 6 0.25
+set param_card dminputs 7 0.25
+set param_card dminputs 8 0.25
+set param_card dminputs 9 0.25
+set param_card dminputs 10 0
+set param_card dminputs 11 0
+set param_card dminputs 12 0
+set param_card dminputs 13 0
+set param_card dminputs 14 0
+set param_card dminputs 15 0
+set param_card decay 55 auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_extramodels.dat
@@ -1,0 +1,1 @@
+DMsimp_s_spin1.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_proc_card.dat
@@ -1,0 +1,5 @@
+import DMsimp_s_spin1
+# Define multiparticle labels
+generate       p p  > xd xd~ a   [QCD]
+add process    p p  > xd xd~ a j [QCD]
+output Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/Vector_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130/Vector_MonoPhoton_NLO_Mphi-1000_Mchi-1_gSM-0p25_gDM-1p0_pta130_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1	= run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500	= nevents ! Number of unweighted events requested 
+  -1.0	= req_acc ! Required accuracy (-1=auto determined from nevents)
+  -1	= nevt_job ! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+  average	= event_norm ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+  0.01	= req_acc_fo ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+  5000	= npoints_fo_grid ! number of points to setup grids
+  4	= niters_fo_grid ! number of iter. to setup grids
+  10000	= npoints_fo ! number of points to compute Xsec
+  6	= niters_fo ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+  1	= lpp1 ! beam 1 type (0 = no PDF)
+  1	= lpp2 ! beam 2 type (0 = no PDF)
+  6500.0	= ebeam1 ! beam 1 energy in GeV
+  6500.0	= ebeam2 ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+  lhapdf	= pdlabel ! PDF set
+  292200        = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8	= parton_shower 
+  1.0	= shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.118	= mur_ref_fixed ! fixed ren reference scale 
+  91.118	= muf_ref_fixed ! fixed fact reference scale
+  -1	= dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+  1.0	= mur_over_ref ! ratio of current muR over reference muR
+  1.0	= muf_over_ref ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+  1.0, 2.0, 0.5	= rw_rscale ! muR factors to be included by reweighting
+  1.0, 2.0, 0.5	= rw_fscale ! muF factors to be included by reweighting
+  True	= reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+  .true. = reweight_PDF ! reweight to get PDF uncertainty
+  292201 = PDF_set_min ! First of the error PDF sets
+  292302 = PDF_set_max ! Last of the error PDF sets
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+  True	= store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+  3	= ickkw 
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+  15.0	= bwcutoff 
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0	= jetalgo ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7	= jetradius ! The radius parameter for the jet algorithm
+  10.0	= ptj ! Min jet transverse momentum
+  -1.0	= etaj ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0	= ptl ! Min lepton transverse momentum
+  -1.0	= etal ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0	= drll ! Min distance between opposite sign lepton pairs
+  0.0	= drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0	= mll ! Min inv. mass of all opposite sign lepton pairs
+  30.0	= mll_sf ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 130.0	= ptgmin ! Min photon transverse momentum
+  -1.0	= etagamma ! Max photon abs(pseudo-rap)
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+  0	= iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/customizecards.dat
@@ -1,0 +1,17 @@
+set param_card mass  55 _MMED_
+set param_card mass  52 _MDM_
+set param_card dminputs 2 _gDMV_
+set param_card dminputs 3 _gDMA_
+set param_card dminputs 4 _gVq_
+set param_card dminputs 5 _gVq_
+set param_card dminputs 6 _gVq_
+set param_card dminputs 7 _gVq_
+set param_card dminputs 8 _gVq_
+set param_card dminputs 9 _gVq_
+set param_card dminputs 10 _gAq_
+set param_card dminputs 11 _gAq_
+set param_card dminputs 12 _gAq_
+set param_card dminputs 13 _gAq_
+set param_card dminputs 14 _gAq_
+set param_card dminputs 15 _gAq_
+set param_card decay 55 auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/extramodels.dat
@@ -1,0 +1,1 @@
+DMsimp_s_spin1.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/make_cards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/make_cards.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#################################################
+### Script to generate cards directories for  ###
+### monophoton DMsimp samples (pta > 130 GeV) ###
+#################################################
+
+CARDDIR=$(cd $(dirname $0); pwd)
+
+for MMED in 50 100 500 1000 1500 2000
+do
+  for MDM in 1 10 50 150 500
+  do
+    [ $MDM -eq $(($MMED/2)) ] && MDM=$(($MDM-10))
+    [ $MDM -gt $(($MMED/2)) ] && break
+
+    CARDLABEL=Mphi-${MMED}_Mchi-${MDM}_gSM-0p25_gDM-1p0_pta130
+
+    ## Vector
+    CARDNAME=Vector_MonoPhoton_NLO_${CARDLABEL}    
+    DIR=$CARDDIR/Vector_${CARDLABEL}
+
+    mkdir -p $DIR
+
+    cp $CARDDIR/extramodels.dat $DIR/${CARDNAME}_extramodels.dat
+    cp $CARDDIR/run_card.dat $DIR/${CARDNAME}_run_card.dat
+    sed -e "s/_MMED_/$MMED/" -e "s/_MDM_/$MDM/" -e "s/_gDMV_/1/" -e "s/_gVq_/0.25/" -e "s/_gDMA_/0/" -e "s/_gAq_/0/" $CARDDIR/customizecards.dat > $DIR/${CARDNAME}_customizecards.dat
+    sed "s/_NAME_/$CARDNAME/" $CARDDIR/proc_card.dat > $DIR/${CARDNAME}_proc_card.dat
+
+    ## Axial
+    CARDNAME=Axial_MonoPhoton_NLO_${CARDLABEL}    
+    DIR=$CARDDIR/Axial_${CARDLABEL}
+
+    mkdir -p $DIR
+
+    cp $CARDDIR/extramodels.dat $DIR/${CARDNAME}_extramodels.dat
+    cp $CARDDIR/run_card.dat $DIR/${CARDNAME}_run_card.dat
+    sed -e "s/_MMED_/$MMED/" -e "s/_MDM_/$MDM/" -e "s/_gDMV_/0/" -e "s/_gVq_/0/" -e "s/_gDMA_/1/" -e "s/_gAq_/0.25/" $CARDDIR/customizecards.dat > $DIR/${CARDNAME}_customizecards.dat
+    sed "s/_NAME_/$CARDNAME/" $CARDDIR/proc_card.dat > $DIR/${CARDNAME}_proc_card.dat
+
+  done
+done

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/proc_card.dat
@@ -1,0 +1,5 @@
+import DMsimp_s_spin1
+# Define multiparticle labels
+generate       p p  > xd xd~ a   [QCD]
+add process    p p  > xd xd~ a j [QCD]
+output _NAME_

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/MonoPhoton_DMsimp/run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1	= run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500	= nevents ! Number of unweighted events requested 
+  -1.0	= req_acc ! Required accuracy (-1=auto determined from nevents)
+  -1	= nevt_job ! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+  average	= event_norm ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+  0.01	= req_acc_fo ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+  5000	= npoints_fo_grid ! number of points to setup grids
+  4	= niters_fo_grid ! number of iter. to setup grids
+  10000	= npoints_fo ! number of points to compute Xsec
+  6	= niters_fo ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+  1	= lpp1 ! beam 1 type (0 = no PDF)
+  1	= lpp2 ! beam 2 type (0 = no PDF)
+  6500.0	= ebeam1 ! beam 1 energy in GeV
+  6500.0	= ebeam2 ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+  lhapdf	= pdlabel ! PDF set
+  292200        = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8	= parton_shower 
+  1.0	= shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.118	= mur_ref_fixed ! fixed ren reference scale 
+  91.118	= muf_ref_fixed ! fixed fact reference scale
+  -1	= dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+  1.0	= mur_over_ref ! ratio of current muR over reference muR
+  1.0	= muf_over_ref ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+  1.0, 2.0, 0.5	= rw_rscale ! muR factors to be included by reweighting
+  1.0, 2.0, 0.5	= rw_fscale ! muF factors to be included by reweighting
+  True	= reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+  .true. = reweight_PDF ! reweight to get PDF uncertainty
+  292201 = PDF_set_min ! First of the error PDF sets
+  292302 = PDF_set_max ! Last of the error PDF sets
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+  True	= store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+  3	= ickkw 
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+  15.0	= bwcutoff 
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0	= jetalgo ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7	= jetradius ! The radius parameter for the jet algorithm
+  10.0	= ptj ! Min jet transverse momentum
+  -1.0	= etaj ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0	= ptl ! Min lepton transverse momentum
+  -1.0	= etal ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0	= drll ! Min distance between opposite sign lepton pairs
+  0.0	= drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0	= mll ! Min inv. mass of all opposite sign lepton pairs
+  30.0	= mll_sf ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 130.0	= ptgmin ! Min photon transverse momentum
+  -1.0	= etagamma ! Max photon abs(pseudo-rap)
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+  0	= iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_1j_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_FXFX_5f_1j_max1j_LHE_pythia8_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 20.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nPartonsNow = 1',
+            'TimeShower:nPartonsInBorn = 1', #number of coloured particles (before resonance decays) in highest multiplicity born matrix element
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+        )
+    )

--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_1j_max1j_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_1j_max1j_LHE_pythia8_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 20.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nPartonsNow = 1',
+            'TimeShower:nPartonsInBorn = 1', #number of coloured particles (before resonance decays) in highest multiplicity born matrix element
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+        )
+    )


### PR DESCRIPTION
We would like to remake the DMsimp (NLO QCD) monophoton samples because the existing version has a cut on the mediator pT, which makes the photon pT not necessarily high and thus makes our acceptance low (primary discriminating variable in the analysis is photon pT).

Production request is here:
https://docs.google.com/spreadsheets/d/1SHuXn9vgIq1jOr9ixVhqcWXC7a8ZNxCQvj1n9iXlkDI/edit?usp=sharing

The PR contains a directory MG5/cards/production/2017/MonoPhoton_DMsimp which has the card templates and a script to generate the cards, along with one example subdirectory. Also, I am PRing a generic hadronizer fragment for +1jet FxFx (xqcut 10 GeV) which for some reason does not exist in the current master.