### PR TITLE
Compilation of VH_ew

### DIFF
--- a/bin/Powheg/patches/hwew.patch
+++ b/bin/Powheg/patches/hwew.patch
@@ -1,0 +1,207 @@
+--- scalupveto_HW.f	2018-02-22 16:32:52.000000001 +0100
++++ scalupveto_HW.f.new	2018-02-22 16:34:17.000000001 +0100
+@@ -784,3 +784,100 @@
+       endif
+              
+       end
++
++      subroutine sortbypt(n,iarr)
++      implicit none
++      integer n,iarr(n)
++      include 'hepevt.h'
++      integer j,k
++      real * 8 tmp,pt(nmxhep)
++      logical touched
++      do j=1,n
++         pt(j)=sqrt(phep(1,iarr(j))**2+phep(2,iarr(j))**2)
++      enddo
++c bubble sort
++      touched=.true.
++      do while(touched)
++         touched=.false.
++         do j=1,n-1
++            if(pt(j).lt.pt(j+1)) then
++               k=iarr(j)
++               iarr(j)=iarr(j+1)
++               iarr(j+1)=k
++               tmp=pt(j)
++               pt(j)=pt(j+1)
++               pt(j+1)=tmp
++               touched=.true.
++            endif
++         enddo
++      enddo
++      end
++
++      function islept(j)
++      implicit none
++      logical islept
++      integer j
++      if(abs(j).ge.11.and.abs(j).le.15) then
++         islept = .true.
++      else
++         islept = .false.
++      endif
++      end
++
++      function get_ptrel(pin,pjet)
++      implicit none
++      real * 8 get_ptrel,pin(0:3),pjet(0:3)
++      real * 8 pin2,pjet2,cth2,scalprod
++      pin2  = pin(1)**2 + pin(2)**2 + pin(3)**2
++      pjet2 = pjet(1)**2 + pjet(2)**2 + pjet(3)**2
++      scalprod = pin(1)*pjet(1) + pin(2)*pjet(2) + pin(3)*pjet(3)
++      cth2 = scalprod**2/pin2/pjet2
++      get_ptrel = sqrt(pin2*abs(1d0 - cth2))
++      end
++
++      subroutine pwhgfinalopshist
++      end
++
++
++c     Scan the hep common block to find "nmax" final-state particles with idhep = id
++c     Return the pt-ordered position of the found particles in idarr(1:nidarr)
++c     If the found particles are less than nidarr, nidarr is set to the actual number of
++c     found particles
++      subroutine find_particles(id,nmax,idarr)
++      implicit none
++      include 'hepevt.h'
++      integer id,nmax
++      integer idarr(nmax)
++      integer ihep,imax 
++      imax = 0
++      do ihep=1,nhep
++         if (idhep(ihep).eq.id .and.isthep(ihep).eq.1) then
++cc     for HERWIG and PY6 the status of final state particles is 1
++c     $        (WHCPRG.ne.'PY8   '.and. isthep(ihep).eq.1) .or.         
++c     $        (WHCPRG.eq.'PY8   '.and. isthep(ihep).gt.0) )) then
++c     found
++            imax = imax+1
++            idarr(imax)=ihep
++         endif
++      if (imax.eq.nmax) goto 111
++      enddo
++      
++ 111  continue
++      call sortbypt(imax,idarr(1:imax))
++      nmax = imax
++      end
++
++
++
++c     relative pt of 1 with respect to 2 for FSR
++      function ptrelFSR(p1,p2)
++      implicit none
++      real * 8 ptrelFSR
++      real*8 p1(1:4),p2(1:4)
++      real * 8 costh,mod1,mod2
++      mod1 = sqrt(p1(1)**2+p1(2)**2+p1(3)**2)
++      mod2 = sqrt(p2(1)**2+p2(2)**2+p2(3)**2)
++      costh = (p1(1)*p2(1) + p1(2)*p2(2) + p1(3)*p2(3))/(mod1*mod2)
++
++      ptrelFSR = mod1 * sqrt(2*(1d0 - costh))
++      end
+--- pwhg_analysis-HWnJ_res.f	2018-02-22 16:32:40.000000001 +0100
++++ pwhg_analysis-HWnJ_res.f.new	2018-02-22 16:34:25.000000001 +0100
+@@ -1253,100 +1253,5 @@
+       end
+ 
+ 
+-      subroutine sortbypt(n,iarr)
+-      implicit none
+-      integer n,iarr(n)
+-      include 'hepevt.h'
+-      integer j,k
+-      real * 8 tmp,pt(nmxhep)
+-      logical touched
+-      do j=1,n
+-         pt(j)=sqrt(phep(1,iarr(j))**2+phep(2,iarr(j))**2)
+-      enddo
+-c bubble sort
+-      touched=.true.
+-      do while(touched)
+-         touched=.false.
+-         do j=1,n-1
+-            if(pt(j).lt.pt(j+1)) then
+-               k=iarr(j)
+-               iarr(j)=iarr(j+1)
+-               iarr(j+1)=k
+-               tmp=pt(j)
+-               pt(j)=pt(j+1)
+-               pt(j+1)=tmp
+-               touched=.true.
+-            endif
+-         enddo
+-      enddo
+-      end
+-
+-      function islept(j)
+-      implicit none
+-      logical islept
+-      integer j
+-      if(abs(j).ge.11.and.abs(j).le.15) then
+-         islept = .true.
+-      else
+-         islept = .false.
+-      endif
+-      end
+-
+-      function get_ptrel(pin,pjet)
+-      implicit none
+-      real * 8 get_ptrel,pin(0:3),pjet(0:3)
+-      real * 8 pin2,pjet2,cth2,scalprod
+-      pin2  = pin(1)**2 + pin(2)**2 + pin(3)**2
+-      pjet2 = pjet(1)**2 + pjet(2)**2 + pjet(3)**2
+-      scalprod = pin(1)*pjet(1) + pin(2)*pjet(2) + pin(3)*pjet(3)
+-      cth2 = scalprod**2/pin2/pjet2
+-      get_ptrel = sqrt(pin2*abs(1d0 - cth2))
+-      end
+-
+-      subroutine pwhgfinalopshist
+-      end
+-
+-
+-c     Scan the hep common block to find "nmax" final-state particles with idhep = id
+-c     Return the pt-ordered position of the found particles in idarr(1:nidarr)
+-c     If the found particles are less than nidarr, nidarr is set to the actual number of
+-c     found particles
+-      subroutine find_particles(id,nmax,idarr)
+-      implicit none
+-      include 'hepevt.h'
+-      integer id,nmax
+-      integer idarr(nmax)
+-      integer ihep,imax 
+-      imax = 0
+-      do ihep=1,nhep
+-         if (idhep(ihep).eq.id .and.isthep(ihep).eq.1) then
+-cc     for HERWIG and PY6 the status of final state particles is 1
+-c     $        (WHCPRG.ne.'PY8   '.and. isthep(ihep).eq.1) .or.         
+-c     $        (WHCPRG.eq.'PY8   '.and. isthep(ihep).gt.0) )) then
+-c     found
+-            imax = imax+1
+-            idarr(imax)=ihep
+-         endif
+-      if (imax.eq.nmax) goto 111
+-      enddo
+-      
+- 111  continue
+-      call sortbypt(imax,idarr(1:imax))
+-      nmax = imax
+-      end
+-
+-
+-
+-c     relative pt of 1 with respect to 2 for FSR
+-      function ptrelFSR(p1,p2)
+-      implicit none
+-      real * 8 ptrelFSR
+-      real*8 p1(1:4),p2(1:4)
+-      real * 8 costh,mod1,mod2
+-      mod1 = sqrt(p1(1)**2+p1(2)**2+p1(3)**2)
+-      mod2 = sqrt(p2(1)**2+p2(2)**2+p2(3)**2)
+-      costh = (p1(1)*p2(1) + p1(2)*p2(2) + p1(3)*p2(3))/(mod1*mod2)
+-
+-      ptrelFSR = mod1 * sqrt(2*(1d0 - costh))
+-      end
++    
+ 

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -364,8 +364,8 @@ fi
 ### retrieve the powheg source tar ball
 export POWHEGSRC=powhegboxV2_rev3453_date20171005.tar.gz
 
-if [ "$process" = "b_bbar_4l" ]; then 
-  export POWHEGSRC=powhegboxRES_rev3468_date20171122.tar.gz 
+if [ "$process" = "b_bbar_4l" ] || [ "$process" = "HWJ_ew" ] || [ "$process" = "HW_ew" ] || [ "$process" = "HZJ_ew" ] || [ "$process" = "HZ_ew" ]; then 
+  export POWHEGSRC=powhegboxRES_rev3478_date20180122.tar.gz 
 fi
 
 echo 'D/L POWHEG source...'
@@ -423,11 +423,6 @@ sed -i -e "s#PDF[ \t]*=[ \t]*native#PDF=lhapdf#g" Makefile
 # Use gfortran, not other compilers which are not free/licensed
 sed -i -e "s#COMPILER[ \t]*=[ \t]*ifort#COMPILER=gfortran#g" Makefile
 
-# Use option O0 for bbH (O2 too long)
-if [ "$process" = "bbH" ]; then
-   sed -i -e "s#O2#O0#g" Makefile
-fi
-
 # Remove strange options in fortran (fixed line length, multiCPU compilation)
 sed -i -e "s#132#none#g" Makefile
 sed -i -e "s#make -j FC#make FC#g" Makefile
@@ -440,7 +435,7 @@ pwhg_main:#g' Makefile
 echo "pwhg_main.o: svn.version" >> Makefile
 echo "lhefwrite.o: svn.version" >> Makefile
 
-# Find proper histo booking routine (two of them exist)
+# Find proper histo booking routine (many of them exist)
 BOOK_HISTO="pwhg_bookhist-multi.o"
 if [ `echo ${POWHEGSRC} | cut -d "_" -f 1` = "powhegboxV1" ]; then
    BOOK_HISTO="pwhg_bookhist.o"
@@ -467,6 +462,9 @@ fi
 if [ "$process" = "Wgamma" ] || [ "$process" = "W_ew-BMNNP" ]; then
     patch -l -p0 -i ${WORKDIR}/patches/pwhg_analysis_driver.patch 
 fi
+if [ "$process" = "HW_ew" ]; then
+    patch -l -p0 -i ${WORKDIR}/patches/hwew.patch 
+fi
 #if [ "$process" = "ttb_NLO_dec" ]; then
 #    patch -l -p0 -i ${WORKDIR}/patches/pwhg_analysis_driver_offshellmap.patch
 #fi
@@ -481,23 +479,44 @@ sed -i -e "s#LHAPDF_CONFIG[ \t]*=[ \t]*#\#LHAPDF_CONFIG=#g" Makefile
 sed -i -e "s#pwhg_bookhist.o# #g" Makefile
 sed -i -e "s#pwhg_bookhist-new.o# #g" Makefile
 sed -i -e "s#pwhg_bookhist-multi.o# #g" Makefile
+
+# Use option O0 for bbH (O2 too long)
+if [ "$process" = "bbH" ]; then
+   sed -i -e "s#O2#O0#g" Makefile
+fi
+
+# fix fortran options and missing libraries in VH_ew
+if [ "$process" = "HW_ew" ] || [ "$process" = "HZ_ew" ] || [ "$process" = "HZJ_ew" ] || [ "$process" = "HWJ_ew" ] ; then
+   sed -i -e "s#OL_process_src#OL_process_src f90_flags=-ffree-line-length-none#g" Makefile
+fi
+if [ "$process" = "HWJ_ew" ] || [ "$process" = "HZJ_ew" ] ; then
+   sed -i -e "s#boostrot.o#boostrot.o boostrot4.o#g" Makefile
+fi
+
+# 
 if [ "$process" = "ttJ" ]; then
   sed -i -e "s#_PATH) -L#_PATH) #g" Makefile
   sed -i -e "s# -lvirtual#/libvirtual.so.1.0.0#g" Makefile
 fi
+
+# Use option O0 for ttH (O2 too long)
 if [ "$process" = "ttH" ]; then
   sed -i 's/O2/O0/g' Makefile
   sed -i 's/4.5d0/4.75d0/g' init_couplings.f
 fi
+
 if [ "$process" = "gg_H_MSSM" ]; then 
   sed -i 's/leq/le/g' nloreal.F
   cp -p ../gg_H_quark-mass-effects/SLHA.h .
   cp -p ../gg_H_quark-mass-effects/SLHADefs.h .
-fi  
+fi
   
 echo "ANALYSIS=none " >> tmpfile
+
 if [ "$process" = "Wgamma" ]; then
   echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-dummy.o uti.o " >> tmpfile
+#elif [ "$process" = "HW_ew" ] || [ "$process" = "HWJ_ew" ]; then 
+#  echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-HWnJ_res.o pwhg_analysis_paper-HWnJ_res.o observables.o multi_plot.o " >> tmpfile
 else
   echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-dummy.o " >> tmpfile
 fi
@@ -508,6 +527,8 @@ rm -f Makefile.interm tmpfile
 
 # Add libraries
 echo "LIBS+=-lz -lstdc++" >> Makefile
+
+# Add extra packages
 if [ $jhugen = 1 ]; then
   if [ ! -f JHUGenerator.${jhugenversion}.tar.gz ]; then
     wget --no-verbose --no-check-certificate http://spin.pha.jhu.edu/Generator/JHUGenerator.${jhugenversion}.tar.gz || fail_exit "Failed to get JHUGen tar ball "


### PR DESCRIPTION
Minimal changes to make VH work:

- use of no fixed line length in f90
- patch HW_ew to have basic routines outside analysis package
- add missing libraries

IMPORTANT: These are only changes to make VH(J)_ew compile. Producing events seems complicated (need to produce gridpack with one option, run with another option and save results as weights). 

It appears similar to NNLOPS procedure: scripts/weight files can be adapted to deal with this procedure but we have to see with Oleari if potential pitfalls are there, similar to the NNLOPS case (e.g. meaningless weights if too few events per job are run).    