### PR TITLE
diphoton card modification

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/diphotonJets_5f_NLO_FXFX_Mgg80ToInf/diphotonJets_5f_NLO_FXFX_Mgg80ToInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/diphotonJets_5f_NLO_FXFX_Mgg80ToInf/diphotonJets_5f_NLO_FXFX_Mgg80ToInf_run_card.dat
@@ -93,9 +93,9 @@ F = fixed_QES_scale ! if .true. use fixed Ellis-Sexton scale
 2.0 = rw_Rscale_up ! upper bound for ren scale variations
 0.5 = rw_Fscale_down ! lower bound for fact scale variations
 2.0 = rw_Fscale_up ! upper bound for fact scale variations
-.true. = reweight_PDF ! reweight to get PDF uncertainty
-292201 = PDF_set_min ! First of the error PDF sets
-292302 = PDF_set_max ! Last of the error PDF sets
+#.true. = reweight_PDF ! reweight to get PDF uncertainty
+#292201 = PDF_set_min ! First of the error PDF sets
+#292302 = PDF_set_max ! Last of the error PDF sets
 #***********************************************************************
 # Merging - WARNING! Applies merging only at the hard-event level. *
 # After showering an MLM-type merging should be applied as well. *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/diphotonJets_5f_NLO_FXFX_Mgg80ToInf/diphotonJets_5f_NLO_FXFX_Mgg80ToInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/diphotonJets_5f_NLO_FXFX_Mgg80ToInf/diphotonJets_5f_NLO_FXFX_Mgg80ToInf_run_card.dat
@@ -93,9 +93,6 @@ F = fixed_QES_scale ! if .true. use fixed Ellis-Sexton scale
 2.0 = rw_Rscale_up ! upper bound for ren scale variations
 0.5 = rw_Fscale_down ! lower bound for fact scale variations
 2.0 = rw_Fscale_up ! upper bound for fact scale variations
-#.true. = reweight_PDF ! reweight to get PDF uncertainty
-#292201 = PDF_set_min ! First of the error PDF sets
-#292302 = PDF_set_max ! Last of the error PDF sets
 #***********************************************************************
 # Merging - WARNING! Applies merging only at the hard-event level. *
 # After showering an MLM-type merging should be applied as well. *


### PR DESCRIPTION
Diphoton card fix by removing .true. = reweight_PDF.
It was discussed in [here](https://github.com/cms-sw/genproductions/issues/1640)