### PR TITLE
[mg26x] Add patch to prevent madspin crash.

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0015-fix-madspin-br-crash.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0015-fix-madspin-br-crash.patch
@@ -1,0 +1,14 @@
+=== modified file 'MadSpin/interface_madspin.py'
+--- ./MadSpin/interface_madspin.py	2018-01-11 10:40:04 +0000
++++ ./MadSpin/interface_madspin.py	2018-02-21 17:03:42 +0000
+@@ -641,7 +641,8 @@
+             for decay in generate_all.all_ME.values():
+                 decay['path'] = decay['path'].replace(generate_all.path_me, self.options['ms_dir'])
+                 for decay2 in decay['decays']:
+-                    decay2['path'] = decay2['path'].replace(generate_all.path_me, self.options['ms_dir'])
++                    if decay2['path']:
++                        decay2['path'] = decay2['path'].replace(generate_all.path_me, self.options['ms_dir'])
+             generate_all.path_me = self.options['ms_dir'] # directory can have been move
+             generate_all.ms_dir = generate_all.path_me
+         
+


### PR DESCRIPTION
This patch will be part of MG2.6.2:
https://bazaar.launchpad.net/~mg5core1/mg5amcnlo/2.6.2/revision/305

It solves the problem discussed here:
https://github.com/cms-sw/genproductions/issues/1670