### PR TITLE
VBF Haa for 2016 with 4FS PDF and no gen cut for leptons

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M20_Tomumubb/vbfh01_M125_Toa01a01_M20_Tomumubb_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M20_Tomumubb/vbfh01_M125_Toa01a01_M20_Tomumubb_run_card.dat
@@ -49,7 +49,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
  'lhapdf'    = pdlabel     ! PDF set
-  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
@@ -107,7 +107,7 @@
  20  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
- 10  = ptl       ! minimum pt for the charged leptons 
+  0  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states
@@ -133,7 +133,7 @@
    5  = etaj    ! max rap for the jets 
   -1  = etab    ! max rap for the b
  2.5  = etaa    ! max rap for the photons 
- 2.5  = etal    ! max rap for the charged leptons 
+  -1  = etal    ! max rap for the charged leptons 
  0.6  = etaonium ! max rap for the quarkonium states
    0  = etajmin ! min rap for the jets
    0  = etabmin ! min rap for the b
@@ -144,7 +144,7 @@
 #*********************************************************************
  0.4 = drjj    ! min distance between jets 
  0   = drbb    ! min distance between b's 
- 0.4 = drll    ! min distance between leptons 
+ 0   = drll    ! min distance between leptons 
  0.4 = draa    ! min distance between gammas 
  0   = drbj    ! min distance between b and jet 
  0.4 = draj    ! min distance between gamma and jet 
@@ -265,7 +265,7 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   T = use_syst
+   T = use_syst       ! Enable systematics studies
 #
 #**************************************
 # Parameter of the systematics study

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M40_Tomumubb/vbfh01_M125_Toa01a01_M40_Tomumubb_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M40_Tomumubb/vbfh01_M125_Toa01a01_M40_Tomumubb_run_card.dat
@@ -49,7 +49,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
  'lhapdf'    = pdlabel     ! PDF set
-  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
@@ -107,7 +107,7 @@
  20  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
- 10  = ptl       ! minimum pt for the charged leptons 
+  0  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states
@@ -133,7 +133,7 @@
    5  = etaj    ! max rap for the jets 
   -1  = etab    ! max rap for the b
  2.5  = etaa    ! max rap for the photons 
- 2.5  = etal    ! max rap for the charged leptons 
+  -1  = etal    ! max rap for the charged leptons 
  0.6  = etaonium ! max rap for the quarkonium states
    0  = etajmin ! min rap for the jets
    0  = etabmin ! min rap for the b
@@ -144,7 +144,7 @@
 #*********************************************************************
  0.4 = drjj    ! min distance between jets 
  0   = drbb    ! min distance between b's 
- 0.4 = drll    ! min distance between leptons 
+ 0   = drll    ! min distance between leptons 
  0.4 = draa    ! min distance between gammas 
  0   = drbj    ! min distance between b and jet 
  0.4 = draj    ! min distance between gamma and jet 
@@ -265,7 +265,7 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   T = use_syst
+   T = use_syst       ! Enable systematics studies
 #
 #**************************************
 # Parameter of the systematics study

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M60_Tomumubb/vbfh01_M125_Toa01a01_M60_Tomumubb_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/higgs/vbfh01_M125_Toa01a01_M60_Tomumubb/vbfh01_M125_Toa01a01_M60_Tomumubb_run_card.dat
@@ -49,7 +49,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
  'lhapdf'    = pdlabel     ! PDF set
-  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+  263400    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
@@ -107,7 +107,7 @@
  20  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
- 10  = ptl       ! minimum pt for the charged leptons 
+  0  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states
@@ -133,7 +133,7 @@
    5  = etaj    ! max rap for the jets 
   -1  = etab    ! max rap for the b
  2.5  = etaa    ! max rap for the photons 
- 2.5  = etal    ! max rap for the charged leptons 
+  -1  = etal    ! max rap for the charged leptons 
  0.6  = etaonium ! max rap for the quarkonium states
    0  = etajmin ! min rap for the jets
    0  = etabmin ! min rap for the b
@@ -144,7 +144,7 @@
 #*********************************************************************
  0.4 = drjj    ! min distance between jets 
  0   = drbb    ! min distance between b's 
- 0.4 = drll    ! min distance between leptons 
+ 0   = drll    ! min distance between leptons 
  0.4 = draa    ! min distance between gammas 
  0   = drbj    ! min distance between b and jet 
  0.4 = draj    ! min distance between gamma and jet 
@@ -265,7 +265,7 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   T = use_syst
+   T = use_syst       ! Enable systematics studies
 #
 #**************************************
 # Parameter of the systematics study


### PR DESCRIPTION
These cards have been approved before. Now they are with changes on lepton cuts and PDF to be used in "2016" analysis