### PR TITLE
Updates for semi-invisible Higgs fragments

### DIFF
--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_HToGDarkG_M-125_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_HToGDarkG_M-125_LHE_pythia8_cff.py
@@ -1,31 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-try:
-    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
-except ImportError:
-    pythia8CP5SettingsBlock = cms.PSet(
-        pythia8CP5Settings = cms.vstring(
-        'Tune:pp 14',
-            'Tune:ee 7',
-            'MultipartonInteractions:ecmPow=0.03344',
-            'PDF:pSet=20',
-            'MultipartonInteractions:bProfile=2',
-            'MultipartonInteractions:pT0Ref=1.41',
-            'MultipartonInteractions:coreRadius=0.7634',
-            'MultipartonInteractions:coreFraction=0.63',
-            'ColourReconnection:range=5.176',
-            'SigmaTotal:zeroAXB=off',
-            'SpaceShower:alphaSorder=2',
-            'SpaceShower:alphaSvalue=0.118',
-            'SigmaProcess:alphaSvalue=0.118',
-            'SigmaProcess:alphaSorder=2',
-            'MultipartonInteractions:alphaSvalue=0.118',
-            'MultipartonInteractions:alphaSorder=2',
-            'TimeShower:alphaSorder=2',
-            'TimeShower:alphaSvalue=0.118',
-            )
-    )
-
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_HToGDarkG_M-125_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_1p_HToGDarkG_M-125_LHE_pythia8_cff.py
@@ -1,6 +1,31 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+try:
+    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+except ImportError:
+    pythia8CP5SettingsBlock = cms.PSet(
+        pythia8CP5Settings = cms.vstring(
+        'Tune:pp 14',
+            'Tune:ee 7',
+            'MultipartonInteractions:ecmPow=0.03344',
+            'PDF:pSet=20',
+            'MultipartonInteractions:bProfile=2',
+            'MultipartonInteractions:pT0Ref=1.41',
+            'MultipartonInteractions:coreRadius=0.7634',
+            'MultipartonInteractions:coreFraction=0.63',
+            'ColourReconnection:range=5.176',
+            'SigmaTotal:zeroAXB=off',
+            'SpaceShower:alphaSorder=2',
+            'SpaceShower:alphaSvalue=0.118',
+            'SigmaProcess:alphaSvalue=0.118',
+            'SigmaProcess:alphaSorder=2',
+            'MultipartonInteractions:alphaSvalue=0.118',
+            'MultipartonInteractions:alphaSorder=2',
+            'TimeShower:alphaSorder=2',
+            'TimeShower:alphaSvalue=0.118',
+            )
+    )
+
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -17,10 +42,10 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
             'POWHEG:nFinal = 1',   ## Number of final state particles
                                    ## (BEFORE THE DECAYS) in the LHE
                                    ## other than emitted extra parton
-            '3000022:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
-            '3000022:isVisible = 0',
+            '53:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
+            '53:isVisible = 0',
             '25:m0 = 125.0',
-            '25:oneChannel = 1 1 100 22 3000022'
+            '25:oneChannel = 1 1 100 22 53'
           ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_LHE_pythia8_cff.py
@@ -1,31 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-try:
-    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
-except ImportError:
-    pythia8CP5SettingsBlock = cms.PSet(
-        pythia8CP5Settings = cms.vstring(
-        'Tune:pp 14',
-            'Tune:ee 7',
-            'MultipartonInteractions:ecmPow=0.03344',
-            'PDF:pSet=20',
-            'MultipartonInteractions:bProfile=2',
-            'MultipartonInteractions:pT0Ref=1.41',
-            'MultipartonInteractions:coreRadius=0.7634',
-            'MultipartonInteractions:coreFraction=0.63',
-            'ColourReconnection:range=5.176',
-            'SigmaTotal:zeroAXB=off',
-            'SpaceShower:alphaSorder=2',
-            'SpaceShower:alphaSvalue=0.118',
-            'SigmaProcess:alphaSvalue=0.118',
-            'SigmaProcess:alphaSorder=2',
-            'MultipartonInteractions:alphaSvalue=0.118',
-            'MultipartonInteractions:alphaSorder=2',
-            'TimeShower:alphaSorder=2',
-            'TimeShower:alphaSvalue=0.118',
-            )
-    )
-
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_LHE_pythia8_cff.py
@@ -1,6 +1,31 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+try:
+    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+except ImportError:
+    pythia8CP5SettingsBlock = cms.PSet(
+        pythia8CP5Settings = cms.vstring(
+        'Tune:pp 14',
+            'Tune:ee 7',
+            'MultipartonInteractions:ecmPow=0.03344',
+            'PDF:pSet=20',
+            'MultipartonInteractions:bProfile=2',
+            'MultipartonInteractions:pT0Ref=1.41',
+            'MultipartonInteractions:coreRadius=0.7634',
+            'MultipartonInteractions:coreFraction=0.63',
+            'ColourReconnection:range=5.176',
+            'SigmaTotal:zeroAXB=off',
+            'SpaceShower:alphaSorder=2',
+            'SpaceShower:alphaSvalue=0.118',
+            'SigmaProcess:alphaSvalue=0.118',
+            'SigmaProcess:alphaSorder=2',
+            'MultipartonInteractions:alphaSvalue=0.118',
+            'MultipartonInteractions:alphaSorder=2',
+            'TimeShower:alphaSorder=2',
+            'TimeShower:alphaSvalue=0.118',
+            )
+    )
+
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -17,10 +42,10 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
             'POWHEG:nFinal = 3',   ## Number of final state particles
                                    ## (BEFORE THE DECAYS) in the LHE
                                    ## other than emitted extra parton
-            '3000022:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
-            '3000022:isVisible = 0',
+            '53:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
+            '53:isVisible = 0',
             '25:m0 = 125.0',
-            '25:oneChannel = 1 1 100 22 3000022'
+            '25:oneChannel = 1 1 100 22 53'
           ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_ZToLL_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_ZToLL_LHE_pythia8_cff.py
@@ -1,31 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-try:
-    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
-except ImportError:
-    pythia8CP5SettingsBlock = cms.PSet(
-        pythia8CP5Settings = cms.vstring(
-        'Tune:pp 14',
-            'Tune:ee 7',
-            'MultipartonInteractions:ecmPow=0.03344',
-            'PDF:pSet=20',
-            'MultipartonInteractions:bProfile=2',
-            'MultipartonInteractions:pT0Ref=1.41',
-            'MultipartonInteractions:coreRadius=0.7634',
-            'MultipartonInteractions:coreFraction=0.63',
-            'ColourReconnection:range=5.176',
-            'SigmaTotal:zeroAXB=off',
-            'SpaceShower:alphaSorder=2',
-            'SpaceShower:alphaSvalue=0.118',
-            'SigmaProcess:alphaSvalue=0.118',
-            'SigmaProcess:alphaSorder=2',
-            'MultipartonInteractions:alphaSvalue=0.118',
-            'MultipartonInteractions:alphaSorder=2',
-            'TimeShower:alphaSorder=2',
-            'TimeShower:alphaSvalue=0.118',
-            )
-    )
-
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",

--- a/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_ZToLL_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/Hadronizer_TuneCP5_13TeV_powhegEmissionVeto_3p_HToGDarkG_M-125_ZToLL_LHE_pythia8_cff.py
@@ -1,6 +1,31 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+try:
+    from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+except ImportError:
+    pythia8CP5SettingsBlock = cms.PSet(
+        pythia8CP5Settings = cms.vstring(
+        'Tune:pp 14',
+            'Tune:ee 7',
+            'MultipartonInteractions:ecmPow=0.03344',
+            'PDF:pSet=20',
+            'MultipartonInteractions:bProfile=2',
+            'MultipartonInteractions:pT0Ref=1.41',
+            'MultipartonInteractions:coreRadius=0.7634',
+            'MultipartonInteractions:coreFraction=0.63',
+            'ColourReconnection:range=5.176',
+            'SigmaTotal:zeroAXB=off',
+            'SpaceShower:alphaSorder=2',
+            'SpaceShower:alphaSvalue=0.118',
+            'SigmaProcess:alphaSvalue=0.118',
+            'SigmaProcess:alphaSorder=2',
+            'MultipartonInteractions:alphaSvalue=0.118',
+            'MultipartonInteractions:alphaSorder=2',
+            'TimeShower:alphaSorder=2',
+            'TimeShower:alphaSvalue=0.118',
+            )
+    )
+
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -17,10 +42,10 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                  'POWHEG:nFinal = 3', ## Number of final state particles
                                       ## (BEFORE THE DECAYS) in the LHE
                                       ## other than emitted extra parton
-                 '3000022:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
-                 '3000022:isVisible = 0',
+                 '53:all = DarkPhoton void 3 0 0 0. 0. 0. 0. 0.',
+                 '53:isVisible = 0',
                  '25:m0 = 125.0',
-                 '25:oneChannel = 1 1 100 22 3000022',
+                 '25:oneChannel = 1 1 100 22 53',
                  '23:onMode = off',
                  '23:onIfAny = 11 13 15',
                ),


### PR DESCRIPTION
- We want to run a Summer15GS + Summer16DR request with these fragments, but CP5 tune cannot be imported in 71X. Hard-coding the configuration for the time being. Will remove the hard-coded part once we finish the 2016 analysis.
- @smrenna suggested using PID 53 (instead of 300022 which I randomly picked) for the dark photon. This is the CMS convention for a non-interacting vector.