### PR TITLE
[mg24x] Increase number of events for combine_events.f

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0019-increase-max-events-for-combine-events.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0019-increase-max-events-for-combine-events.patch
@@ -1,0 +1,44 @@
+diff --git a/Template/NLO/Source/combine_events.f b/Template/NLO/Source/combine_events.f
+index 77856a8..4022048 100644
+--- a/Template/NLO/Source/combine_events.f
++++ b/Template/NLO/Source/combine_events.f
+@@ -10,7 +10,7 @@ c
+       integer    maxsubprocesses
+       parameter (maxsubprocesses=9999)
+       integer    cmax_events
+-      parameter (cmax_events=500000)
++      parameter (cmax_events=10000000)
+       integer    sfnum
+       parameter (sfnum=17)   !Unit number for scratch file
+       integer    maxexternal
+@@ -481,7 +481,7 @@ c
+       parameter (maxexternal=17)
+       include 'run_config.inc'
+       integer    max_read
+-      parameter (max_read = 2000000)
++      parameter (max_read = 10000000)
+ c
+ c     Arguments
+ c
+diff --git a/madgraph/iolibs/template_files/madevent_combine_events.f b/madgraph/iolibs/template_files/madevent_combine_events.f
+index e882c75..f1913b5 100644
+--- a/madgraph/iolibs/template_files/madevent_combine_events.f
++++ b/madgraph/iolibs/template_files/madevent_combine_events.f
+@@ -13,7 +13,7 @@ c
+       integer    maxsubprocesses
+       parameter (maxsubprocesses=9999)
+       integer    cmax_events
+-      parameter (cmax_events=5000000)
++      parameter (cmax_events=10000000)
+       integer    sfnum
+       parameter (sfnum=17)   !Unit number for scratch file
+       integer    maxexternal
+@@ -612,7 +612,7 @@ c
+       include 'run_config.inc'
+       include 'run.inc'
+       integer    max_read
+-      parameter (max_read = 5000000)
++      parameter (max_read = 10000000)
+ c
+ c     Arguments
+ c


### PR DESCRIPTION
Patch to solve the problem discussed [here](https://hypernews.cern.ch/HyperNews/CMS/get/generators/3814/1/1/1/1/1/1/1/1.html)

Successfully tested by me and @wverbeke 

@kdlong @agrohsje: Do we still care about patching master/24x or should I just port the patch to the 26x branch and leave master as it is?
