### PR TITLE
set the run card variable use_syst to True

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
@@ -269,4 +269,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
@@ -269,4 +269,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
@@ -269,4 +269,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
@@ -268,4 +268,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
@@ -268,4 +268,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
@@ -268,4 +268,4 @@
 #          meaningful ONLY if plotted taking matchscale              *
 #          reweighting into account!                                 *
 #*********************************************************************
-   False  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies


### PR DESCRIPTION
The variable use_syst found in these 6 run cards was set to false. Consequently gridpack generation did not work correctly.