### PR TITLE
fix when we get NaN in MCFM

### DIFF
--- a/bin/MCFM/adjlheevent.py
+++ b/bin/MCFM/adjlheevent.py
@@ -46,10 +46,12 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("requestednumofevents", type=int)
 parser.add_argument("foundnumofevents", type=int)
+parser.add_argument("seed", type=int)
 parser.add_argument("lhefiles", nargs="+")
 args = parser.parse_args()
 requestednumofevents = args.requestednumofevents
 foundnumofevents = args.foundnumofevents
+random.seed(args.seed)
 lhefiles = args.lhefiles
 lheeventstr=getlheeventstring()
 lheheadfoot=getlheheadfoot()

--- a/bin/MCFM/runcmsgrid_template.sh
+++ b/bin/MCFM/runcmsgrid_template.sh
@@ -97,7 +97,7 @@ while [ ${produced_lhe} -lt ${nevt} ]; do
 done
 
 cd $LHEWORKDIR
-python adjlheevent.py ${nevt} ${produced_lhe} cmsgrid_*.lhe
+python adjlheevent.py ${nevt} ${produced_lhe} ${rnum} cmsgrid_*.lhe
 
 ls -l
 echo


### PR DESCRIPTION
Sometimes events with 4 lepton interference have NaN somewhere in the phase space.  When the event generation finds this NaN, MCFM crashes because there's an assertion in LHAPDF that q^2 > 0, and NaN is not > 0.

This is a patch to run MCFM multiple times and merge the LHE file together, dropping the events that are only partially written with no </event>.  Because MCFM doesn't always produce the exact number of events requested, the script selects random ones to drop.  (This was done already, but now it looks through multiple files.)

The implementation is mostly copied from the Madgraph one, with some adaptations.  I've run some local tests and it works well.