### PR TITLE
updated Reweighting Cards for aQGC_VVjj_hadronic (2017)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WMhadWMhadJJ_EWK_LO_NPle1/aQGC_WMhadWMhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WMhadWMhadJJ_EWK_LO_NPle1/aQGC_WMhadWMhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WMhadZhadJJ_EWK_LO_NPle1/aQGC_WMhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WMhadZhadJJ_EWK_LO_NPle1/aQGC_WMhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadWMhadJJ_EWK_LO_NPle1/aQGC_WPhadWMhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadWMhadJJ_EWK_LO_NPle1/aQGC_WPhadWMhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadWPhadJJ_EWK_LO_NPle1/aQGC_WPhadWPhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadWPhadJJ_EWK_LO_NPle1/aQGC_WPhadWPhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadZhadJJ_EWK_LO_NPle1/aQGC_WPhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_WPhadZhadJJ_EWK_LO_NPle1/aQGC_WPhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_ZhadZhadJJ_EWK_LO_NPle1/aQGC_ZhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/aQGC_VVjj_hadronic/aQGC_ZhadZhadJJ_EWK_LO_NPle1/aQGC_ZhadZhadJJ_EWK_LO_NPle1_reweight_card.dat
@@ -2,4248 +2,8884 @@ change helicity False
 change rwgt_dir rwgt
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m900p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -900.000000e-12
+        set anoinputs 1 -118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m880p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -880.000000e-12
+        set anoinputs 1 -115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m860p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -860.000000e-12
+        set anoinputs 1 -112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m840p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -840.000000e-12
+        set anoinputs 1 -109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -820.000000e-12
+        set anoinputs 1 -106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -800.000000e-12
+        set anoinputs 1 -103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -780.000000e-12
+        set anoinputs 1 -100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -760.000000e-12
+        set anoinputs 1 -97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -740.000000e-12
+        set anoinputs 1 -95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -720.000000e-12
+        set anoinputs 1 -92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -700.000000e-12
+        set anoinputs 1 -89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -680.000000e-12
+        set anoinputs 1 -86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -660.000000e-12
+        set anoinputs 1 -83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -640.000000e-12
+        set anoinputs 1 -80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -620.000000e-12
+        set anoinputs 1 -77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -600.000000e-12
+        set anoinputs 1 -74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -580.000000e-12
+        set anoinputs 1 -72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -560.000000e-12
+        set anoinputs 1 -69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -540.000000e-12
+        set anoinputs 1 -66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -520.000000e-12
+        set anoinputs 1 -63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -500.000000e-12
+        set anoinputs 1 -60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -480.000000e-12
+        set anoinputs 1 -57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -460.000000e-12
+        set anoinputs 1 -54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -440.000000e-12
+        set anoinputs 1 -51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -420.000000e-12
+        set anoinputs 1 -48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -400.000000e-12
+        set anoinputs 1 -46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -380.000000e-12
+        set anoinputs 1 -43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -360.000000e-12
+        set anoinputs 1 -40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -340.000000e-12
+        set anoinputs 1 -37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -320.000000e-12
+        set anoinputs 1 -34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -300.000000e-12
+        set anoinputs 1 -31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -280.000000e-12
+        set anoinputs 1 -28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -260.000000e-12
+        set anoinputs 1 -25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -240.000000e-12
+        set anoinputs 1 -23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -220.000000e-12
+        set anoinputs 1 -20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -200.000000e-12
+        set anoinputs 1 -17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -180.000000e-12
+        set anoinputs 1 -14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -160.000000e-12
+        set anoinputs 1 -11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -140.000000e-12
+        set anoinputs 1 -8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -120.000000e-12
+        set anoinputs 1 -5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_m2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 -100.000000e-12
+        set anoinputs 1 -2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -80.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -60.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -40.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 1 -20.000000e-12
-
-
-#************	FS0	***************************
-launch --rwgt_name=FS0_0p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 1 0.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_20p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_2p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 20.000000e-12
+        set anoinputs 1 2.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_40p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_5p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 40.000000e-12
+        set anoinputs 1 5.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_60p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_8p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 60.000000e-12
+        set anoinputs 1 8.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_80p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_11p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 80.000000e-12
+        set anoinputs 1 11.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_100p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 100.000000e-12
+        set anoinputs 1 14.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_120p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_17p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 120.000000e-12
+        set anoinputs 1 17.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_140p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_20p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 140.000000e-12
+        set anoinputs 1 20.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_160p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_23p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 160.000000e-12
+        set anoinputs 1 23.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_180p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_25p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 180.000000e-12
+        set anoinputs 1 25.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_200p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_28p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 200.000000e-12
+        set anoinputs 1 28.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_220p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 220.000000e-12
+        set anoinputs 1 31.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_240p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_34p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 240.000000e-12
+        set anoinputs 1 34.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_260p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_37p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 260.000000e-12
+        set anoinputs 1 37.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_280p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_40p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 280.000000e-12
+        set anoinputs 1 40.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_300p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_43p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 300.000000e-12
+        set anoinputs 1 43.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_320p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_46p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 320.000000e-12
+        set anoinputs 1 46.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_340p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_48p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 340.000000e-12
+        set anoinputs 1 48.960000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_360p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_51p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 360.000000e-12
+        set anoinputs 1 51.840000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_380p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_54p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 380.000000e-12
+        set anoinputs 1 54.720000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_400p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_57p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 400.000000e-12
+        set anoinputs 1 57.600000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_420p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_60p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 420.000000e-12
+        set anoinputs 1 60.480000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_440p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_63p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 440.000000e-12
+        set anoinputs 1 63.360000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_460p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_66p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 460.000000e-12
+        set anoinputs 1 66.240000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_480p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_69p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 480.000000e-12
+        set anoinputs 1 69.120000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_500p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_72p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 500.000000e-12
+        set anoinputs 1 72.000000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_520p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_74p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 520.000000e-12
+        set anoinputs 1 74.880000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_540p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_77p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 540.000000e-12
+        set anoinputs 1 77.760000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_560p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_80p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 560.000000e-12
+        set anoinputs 1 80.640000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_580p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_83p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 580.000000e-12
+        set anoinputs 1 83.520000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_600p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_86p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 600.000000e-12
+        set anoinputs 1 86.400000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_620p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_89p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 620.000000e-12
+        set anoinputs 1 89.280000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_640p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_92p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 640.000000e-12
+        set anoinputs 1 92.160000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_660p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_95p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 660.000000e-12
+        set anoinputs 1 95.040000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_680p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_97p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 680.000000e-12
+        set anoinputs 1 97.920000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_700p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_100p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 700.000000e-12
+        set anoinputs 1 100.800000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_720p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_103p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 720.000000e-12
+        set anoinputs 1 103.680000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_740p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_106p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 740.000000e-12
+        set anoinputs 1 106.560000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_760p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_109p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 760.000000e-12
+        set anoinputs 1 109.440000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_780p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_112p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 780.000000e-12
+        set anoinputs 1 112.320000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_800p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_115p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 800.000000e-12
+        set anoinputs 1 115.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_820p0
+#******************** FS0 ********************
+launch --rwgt_name=FS0_118p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 820.000000e-12
+        set anoinputs 1 118.080000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_840p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 840.000000e-12
+        set anoinputs 2 -79.130000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_860p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 860.000000e-12
+        set anoinputs 2 -77.200000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_880p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 880.000000e-12
+        set anoinputs 2 -75.270000e-12
 
 
-#************	FS0	***************************
-launch --rwgt_name=FS0_900p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 1 900.000000e-12
+        set anoinputs 2 -73.340000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -330.000000e-12
+        set anoinputs 2 -71.410000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -320.000000e-12
+        set anoinputs 2 -69.480000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -310.000000e-12
+        set anoinputs 2 -67.550000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -300.000000e-12
+        set anoinputs 2 -65.620000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -290.000000e-12
+        set anoinputs 2 -63.690000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -280.000000e-12
+        set anoinputs 2 -61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -270.000000e-12
+        set anoinputs 2 -59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -260.000000e-12
+        set anoinputs 2 -57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -250.000000e-12
+        set anoinputs 2 -55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -240.000000e-12
+        set anoinputs 2 -54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -230.000000e-12
+        set anoinputs 2 -52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -220.000000e-12
+        set anoinputs 2 -50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -210.000000e-12
+        set anoinputs 2 -48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -200.000000e-12
+        set anoinputs 2 -46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -190.000000e-12
+        set anoinputs 2 -44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -180.000000e-12
+        set anoinputs 2 -42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -170.000000e-12
+        set anoinputs 2 -40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -160.000000e-12
+        set anoinputs 2 -38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -150.000000e-12
+        set anoinputs 2 -36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -140.000000e-12
+        set anoinputs 2 -34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -130.000000e-12
+        set anoinputs 2 -32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -120.000000e-12
+        set anoinputs 2 -30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -110.000000e-12
+        set anoinputs 2 -28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -100.000000e-12
+        set anoinputs 2 -27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -90.000000e-12
+        set anoinputs 2 -25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -80.000000e-12
+        set anoinputs 2 -23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -70.000000e-12
+        set anoinputs 2 -21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -60.000000e-12
+        set anoinputs 2 -19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -50.000000e-12
+        set anoinputs 2 -17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -40.000000e-12
+        set anoinputs 2 -15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -30.000000e-12
+        set anoinputs 2 -13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -20.000000e-12
+        set anoinputs 2 -11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_m10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 -10.000000e-12
+        set anoinputs 2 -9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_0p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m7p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -7.720000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m5p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -5.790000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m3p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -3.860000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_m1p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 2 -1.930000e-12
+
+
+#******************** FS1 ********************
+launch --rwgt_name=FS1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 2 0.000000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_10p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_1p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 10.000000e-12
+        set anoinputs 2 1.930000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_20p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_3p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 20.000000e-12
+        set anoinputs 2 3.860000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_30p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_5p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 30.000000e-12
+        set anoinputs 2 5.790000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_7p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 40.000000e-12
+        set anoinputs 2 7.720000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_50p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_9p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 50.000000e-12
+        set anoinputs 2 9.650000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_60p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_11p58
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 60.000000e-12
+        set anoinputs 2 11.580000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_70p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_13p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 70.000000e-12
+        set anoinputs 2 13.510000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_80p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_15p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 80.000000e-12
+        set anoinputs 2 15.440000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_90p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_17p37
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 90.000000e-12
+        set anoinputs 2 17.370000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_100p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_19p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 100.000000e-12
+        set anoinputs 2 19.300000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_110p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_21p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 110.000000e-12
+        set anoinputs 2 21.230000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_120p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_23p16
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 120.000000e-12
+        set anoinputs 2 23.160000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_130p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_25p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 130.000000e-12
+        set anoinputs 2 25.090000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_140p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_27p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 140.000000e-12
+        set anoinputs 2 27.020000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_150p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_28p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 150.000000e-12
+        set anoinputs 2 28.950000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_160p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_30p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 160.000000e-12
+        set anoinputs 2 30.880000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_170p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_32p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 170.000000e-12
+        set anoinputs 2 32.810000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_180p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_34p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 180.000000e-12
+        set anoinputs 2 34.740000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_190p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_36p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 190.000000e-12
+        set anoinputs 2 36.670000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_200p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_38p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 200.000000e-12
+        set anoinputs 2 38.600000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_210p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_40p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 210.000000e-12
+        set anoinputs 2 40.530000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_220p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_42p46
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 220.000000e-12
+        set anoinputs 2 42.460000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_230p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_44p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 230.000000e-12
+        set anoinputs 2 44.390000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_240p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_46p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 240.000000e-12
+        set anoinputs 2 46.320000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_250p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_48p25
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 250.000000e-12
+        set anoinputs 2 48.250000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_260p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_50p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 260.000000e-12
+        set anoinputs 2 50.180000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_270p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_52p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 270.000000e-12
+        set anoinputs 2 52.110000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_280p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_54p04
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 280.000000e-12
+        set anoinputs 2 54.040000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_290p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_55p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 290.000000e-12
+        set anoinputs 2 55.970000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_300p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_57p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 300.000000e-12
+        set anoinputs 2 57.900000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_310p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_59p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 310.000000e-12
+        set anoinputs 2 59.830000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_320p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_61p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 320.000000e-12
+        set anoinputs 2 61.760000e-12
 
 
-#************	FS1	***************************
-launch --rwgt_name=FS1_330p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_63p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 2 330.000000e-12
+        set anoinputs 2 63.690000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m42p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_65p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -42.000000e-12
+        set anoinputs 2 65.620000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m41p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_67p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -41.000000e-12
+        set anoinputs 2 67.550000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m40p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_69p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -40.000000e-12
+        set anoinputs 2 69.480000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m39p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_71p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -39.000000e-12
+        set anoinputs 2 71.410000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m38p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_73p34
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -38.000000e-12
+        set anoinputs 2 73.340000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m37p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_75p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -37.000000e-12
+        set anoinputs 2 75.270000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m36p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_77p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -36.000000e-12
+        set anoinputs 2 77.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m35p0
+#******************** FS1 ********************
+launch --rwgt_name=FS1_79p13
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -35.000000e-12
+        set anoinputs 2 79.130000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m34p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 -34.000000e-12
+        set anoinputs 3 -2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m19p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -19.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m18p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -18.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m17p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -17.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m16p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -16.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m15p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -15.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m14p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -14.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m13p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -13.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m12p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -12.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m11p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -11.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m10p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -10.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m9p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -9.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m8p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -8.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m7p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -7.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m6p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -6.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m5p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -5.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m4p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -4.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m3p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 -3.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_m2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_m1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 -1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_0p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_m0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 -0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 0.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_1p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_0p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 0.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 1.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_2p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.050000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.100000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.150000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.200000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.250000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.300000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.350000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.400000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.450000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.500000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.550000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.600000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.650000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.700000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.750000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.800000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.850000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.900000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 3 1.950000e-12
+
+
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p00
         set anoinputs 11 0.000000e+00
         set anoinputs 3 2.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_3p0
+#******************** FM0 ********************
+launch --rwgt_name=FM0_2p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 3.000000e-12
+        set anoinputs 3 2.050000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_4p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 4.000000e-12
+        set anoinputs 4 -24.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 5.000000e-12
+        set anoinputs 4 -24.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_6p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 6.000000e-12
+        set anoinputs 4 -23.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_7p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 7.000000e-12
+        set anoinputs 4 -22.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_8p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 8.000000e-12
+        set anoinputs 4 -22.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_9p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 9.000000e-12
+        set anoinputs 4 -21.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 10.000000e-12
+        set anoinputs 4 -21.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_11p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 11.000000e-12
+        set anoinputs 4 -20.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_12p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 12.000000e-12
+        set anoinputs 4 -19.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_13p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 13.000000e-12
+        set anoinputs 4 -19.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_14p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 14.000000e-12
+        set anoinputs 4 -18.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 15.000000e-12
+        set anoinputs 4 -18.000000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_16p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 16.000000e-12
+        set anoinputs 4 -17.400000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_17p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 17.000000e-12
+        set anoinputs 4 -16.800000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_18p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 18.000000e-12
+        set anoinputs 4 -16.200000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_19p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 3 19.000000e-12
+        set anoinputs 4 -15.600000e-12
 
 
-#************	FM0	***************************
-launch --rwgt_name=FM0_20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 20.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_21p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 21.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_22p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 22.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_23p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 23.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_24p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 24.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 25.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_26p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 26.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_27p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 27.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_28p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 28.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_29p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 29.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 30.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_31p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 31.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_32p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 32.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_33p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 33.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_34p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 34.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 35.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_36p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 36.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_37p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 37.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_38p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 38.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_39p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 39.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 40.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_41p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 41.000000e-12
-
-
-#************	FM0	***************************
-launch --rwgt_name=FM0_42p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 3 42.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -165.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -160.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -155.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -150.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -145.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -140.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -135.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -130.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -125.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -120.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -115.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -110.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m105p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -105.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m100p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -100.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m95p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -95.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m90p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -90.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m85p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -85.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m80p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -80.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m75p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -75.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m70p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -70.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m65p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -65.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m60p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -60.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m55p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -55.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m50p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -50.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m45p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -45.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m40p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -40.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m35p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -35.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m30p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -30.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m25p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -25.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m20p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 4 -20.000000e-12
-
-
-#************	FM1	***************************
-launch --rwgt_name=FM1_m15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 -15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m14p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -10.000000e-12
+        set anoinputs 4 -14.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_m5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 -5.000000e-12
+        set anoinputs 4 -13.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_0p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -1.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 -0.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 0.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_5p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 5.000000e-12
+        set anoinputs 4 0.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_10p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 10.000000e-12
+        set anoinputs 4 1.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_15p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 1.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 2.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 3.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 4.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 5.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 6.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 7.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 8.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 9.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 10.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 11.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.000000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 12.600000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.200000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_13p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 13.800000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_14p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 4 14.400000e-12
+
+
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p00
         set anoinputs 11 0.000000e+00
         set anoinputs 4 15.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_20p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_15p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 20.000000e-12
+        set anoinputs 4 15.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_25p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 25.000000e-12
+        set anoinputs 4 16.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_30p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_16p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 30.000000e-12
+        set anoinputs 4 16.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_35p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_17p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 35.000000e-12
+        set anoinputs 4 17.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_40p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 40.000000e-12
+        set anoinputs 4 18.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_45p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_18p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 45.000000e-12
+        set anoinputs 4 18.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_50p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 50.000000e-12
+        set anoinputs 4 19.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_55p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 55.000000e-12
+        set anoinputs 4 19.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_60p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_20p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 60.000000e-12
+        set anoinputs 4 20.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_65p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 65.000000e-12
+        set anoinputs 4 21.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_70p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_21p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 70.000000e-12
+        set anoinputs 4 21.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_75p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 75.000000e-12
+        set anoinputs 4 22.200000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_80p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_22p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 80.000000e-12
+        set anoinputs 4 22.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_85p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_23p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 85.000000e-12
+        set anoinputs 4 23.400000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_90p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 90.000000e-12
+        set anoinputs 4 24.000000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_95p0
+#******************** FM1 ********************
+launch --rwgt_name=FM1_24p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 95.000000e-12
+        set anoinputs 4 24.600000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_100p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 100.000000e-12
+        set anoinputs 5 -2.870000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_105p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 105.000000e-12
+        set anoinputs 5 -2.800000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_110p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 110.000000e-12
+        set anoinputs 5 -2.730000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_115p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 115.000000e-12
+        set anoinputs 5 -2.660000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_120p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 120.000000e-12
+        set anoinputs 5 -2.590000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_125p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 125.000000e-12
+        set anoinputs 5 -2.520000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_130p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 130.000000e-12
+        set anoinputs 5 -2.450000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_135p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 135.000000e-12
+        set anoinputs 5 -2.380000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_140p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 140.000000e-12
+        set anoinputs 5 -2.310000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_145p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 145.000000e-12
+        set anoinputs 5 -2.240000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_150p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 150.000000e-12
+        set anoinputs 5 -2.170000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_155p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 155.000000e-12
+        set anoinputs 5 -2.100000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_160p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 160.000000e-12
+        set anoinputs 5 -2.030000e-12
 
 
-#************	FM1	***************************
-launch --rwgt_name=FM1_165p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 4 165.000000e-12
+        set anoinputs 5 -1.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m84p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -84.000000e-12
+        set anoinputs 5 -1.890000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m82p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -82.000000e-12
+        set anoinputs 5 -1.820000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m80p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -80.000000e-12
+        set anoinputs 5 -1.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m78p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -78.000000e-12
+        set anoinputs 5 -1.680000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m76p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -76.000000e-12
+        set anoinputs 5 -1.610000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m74p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -74.000000e-12
+        set anoinputs 5 -1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m72p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -72.000000e-12
+        set anoinputs 5 -1.470000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m70p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -70.000000e-12
+        set anoinputs 5 -1.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m68p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -68.000000e-12
+        set anoinputs 5 -1.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m66p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -66.000000e-12
+        set anoinputs 5 -1.260000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m64p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -64.000000e-12
+        set anoinputs 5 -1.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m62p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -62.000000e-12
+        set anoinputs 5 -1.120000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m60p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -60.000000e-12
+        set anoinputs 5 -1.050000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m58p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -58.000000e-12
+        set anoinputs 5 -0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m56p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -56.000000e-12
+        set anoinputs 5 -0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m54p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -54.000000e-12
+        set anoinputs 5 -0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m52p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -52.000000e-12
+        set anoinputs 5 -0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m50p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -50.000000e-12
+        set anoinputs 5 -0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m48p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -48.000000e-12
+        set anoinputs 5 -0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m46p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -46.000000e-12
+        set anoinputs 5 -0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m44p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -44.000000e-12
+        set anoinputs 5 -0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m42p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -42.000000e-12
+        set anoinputs 5 -0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m40p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -40.000000e-12
+        set anoinputs 5 -0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m38p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -38.000000e-12
+        set anoinputs 5 -0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m36p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -36.000000e-12
+        set anoinputs 5 -0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m34p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -34.000000e-12
+        set anoinputs 5 -0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m32p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -32.000000e-12
+        set anoinputs 5 -0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m30p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -30.000000e-12
+        set anoinputs 5 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m28p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -28.000000e-12
+        set anoinputs 5 0.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m26p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -26.000000e-12
+        set anoinputs 5 0.140000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m24p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -24.000000e-12
+        set anoinputs 5 0.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m22p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -22.000000e-12
+        set anoinputs 5 0.280000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m20p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -20.000000e-12
+        set anoinputs 5 0.350000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m18p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -18.000000e-12
+        set anoinputs 5 0.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m16p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -16.000000e-12
+        set anoinputs 5 0.490000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m14p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -14.000000e-12
+        set anoinputs 5 0.560000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m12p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -12.000000e-12
+        set anoinputs 5 0.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m10p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -10.000000e-12
+        set anoinputs 5 0.700000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m8p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -8.000000e-12
+        set anoinputs 5 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m6p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -6.000000e-12
+        set anoinputs 5 0.840000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m4p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -4.000000e-12
+        set anoinputs 5 0.910000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_m2p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 -2.000000e-12
+        set anoinputs 5 0.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_0p0
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.050000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.120000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.190000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.260000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.330000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.400000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.470000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.540000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.610000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.680000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.750000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.820000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.890000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_1p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 1.960000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.030000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.100000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.170000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.240000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.310000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.380000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.450000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.520000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.590000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.660000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.730000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.800000e-12
+
+
+#******************** FM2 ********************
+launch --rwgt_name=FM2_2p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 5 2.870000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.830000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_m0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 -0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.000000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_0p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 0.630000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.260000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_1p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 1.890000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_2p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 2.520000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.150000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_3p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 3.780000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_4p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 4.410000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.040000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_5p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 5.670000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.300000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_6p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 6.930000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_7p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 7.560000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.190000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_8p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 8.820000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_9p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 9.450000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.080000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_10p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 10.710000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.340000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_11p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 11.970000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_12p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 12.600000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.230000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_13p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 13.860000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_14p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 14.490000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.120000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_15p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 15.750000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_16p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 16.380000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p01
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.010000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_17p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 17.640000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.270000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_18p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 18.900000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_19p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 19.530000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.160000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_20p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 20.790000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_21p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 21.420000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.050000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_22p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 22.680000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.310000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_23p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 23.940000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_24p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 24.570000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.200000e-12
+
+
+#******************** FM3 ********************
+launch --rwgt_name=FM3_25p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 6 25.830000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.970000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_m0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 -0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.000000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.170000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.340000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.510000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.680000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_0p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 0.850000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.020000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.190000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.360000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.530000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.700000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 1.870000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.040000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.210000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.380000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.550000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.720000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_2p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 2.890000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.060000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.230000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.400000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.570000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.740000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_3p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 3.910000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.080000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.250000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.420000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p59
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.590000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.760000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 4.930000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.100000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.270000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.440000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.610000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.780000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_5p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 5.950000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.120000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.290000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.460000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.630000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.800000e-12
+
+
+#******************** FM4 ********************
+launch --rwgt_name=FM4_6p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 7 6.970000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -34.030000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_m0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 -0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.000000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_0p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 0.830000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_1p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 1.660000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_2p49
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 2.490000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_3p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 3.320000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.150000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_4p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 4.980000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_5p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 5.810000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_6p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 6.640000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_7p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 7.470000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_8p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 8.300000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.130000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_9p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 9.960000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_10p79
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 10.790000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_11p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 11.620000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_12p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 12.450000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_13p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 13.280000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.110000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_14p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 14.940000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_15p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 15.770000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_16p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 16.600000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_17p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 17.430000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_18p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 18.260000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.090000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_19p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 19.920000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_20p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 20.750000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_21p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 21.580000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_22p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 22.410000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_23p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 23.240000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.070000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_24p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 24.900000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_25p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 25.730000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_26p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 26.560000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_27p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 27.390000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_28p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 28.220000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.050000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_29p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 29.880000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_30p71
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 30.710000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_31p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 31.540000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_32p37
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 32.370000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_33p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 33.200000e-12
+
+
+#******************** FM5 ********************
+launch --rwgt_name=FM5_34p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 8 34.030000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.510000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.400000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.290000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.180000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m4p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -4.070000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.960000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p85
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.850000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.740000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p63
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.630000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.520000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.410000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.300000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.190000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m3p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -3.080000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p97
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.970000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.860000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p75
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.750000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.640000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p53
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.530000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.420000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.310000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.200000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m2p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -2.090000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.980000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.870000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.760000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.650000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.540000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.430000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.320000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.210000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m1p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -1.100000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.990000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.880000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.770000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.660000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.550000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.440000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.330000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.220000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_m0p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 9 -0.110000e-12
+
+
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 9 0.000000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_2p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 2.000000e-12
+        set anoinputs 9 0.110000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_4p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p22
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 4.000000e-12
+        set anoinputs 9 0.220000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_6p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 6.000000e-12
+        set anoinputs 9 0.330000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_8p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p44
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 8.000000e-12
+        set anoinputs 9 0.440000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_10p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p55
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 10.000000e-12
+        set anoinputs 9 0.550000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_12p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 12.000000e-12
+        set anoinputs 9 0.660000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_14p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 14.000000e-12
+        set anoinputs 9 0.770000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_16p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 16.000000e-12
+        set anoinputs 9 0.880000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_18p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 18.000000e-12
+        set anoinputs 9 0.990000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_20p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 20.000000e-12
+        set anoinputs 9 1.100000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_22p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 22.000000e-12
+        set anoinputs 9 1.210000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_24p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p32
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 24.000000e-12
+        set anoinputs 9 1.320000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_26p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p43
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 26.000000e-12
+        set anoinputs 9 1.430000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_28p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 28.000000e-12
+        set anoinputs 9 1.540000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_30p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 30.000000e-12
+        set anoinputs 9 1.650000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_32p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 32.000000e-12
+        set anoinputs 9 1.760000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_34p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 34.000000e-12
+        set anoinputs 9 1.870000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_36p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 36.000000e-12
+        set anoinputs 9 1.980000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_38p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 38.000000e-12
+        set anoinputs 9 2.090000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_40p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 40.000000e-12
+        set anoinputs 9 2.200000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_42p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 42.000000e-12
+        set anoinputs 9 2.310000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_44p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 44.000000e-12
+        set anoinputs 9 2.420000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_46p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p53
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 46.000000e-12
+        set anoinputs 9 2.530000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_48p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 48.000000e-12
+        set anoinputs 9 2.640000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_50p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 50.000000e-12
+        set anoinputs 9 2.750000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_52p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 52.000000e-12
+        set anoinputs 9 2.860000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_54p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 54.000000e-12
+        set anoinputs 9 2.970000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_56p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 56.000000e-12
+        set anoinputs 9 3.080000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_58p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 58.000000e-12
+        set anoinputs 9 3.190000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_60p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 60.000000e-12
+        set anoinputs 9 3.300000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_62p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p41
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 62.000000e-12
+        set anoinputs 9 3.410000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_64p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 64.000000e-12
+        set anoinputs 9 3.520000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_66p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 66.000000e-12
+        set anoinputs 9 3.630000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_68p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 68.000000e-12
+        set anoinputs 9 3.740000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_70p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 70.000000e-12
+        set anoinputs 9 3.850000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_72p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 72.000000e-12
+        set anoinputs 9 3.960000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_74p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 74.000000e-12
+        set anoinputs 9 4.070000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_76p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 76.000000e-12
+        set anoinputs 9 4.180000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_78p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p29
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 78.000000e-12
+        set anoinputs 9 4.290000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_80p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 80.000000e-12
+        set anoinputs 9 4.400000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_82p0
+#******************** FM6 ********************
+launch --rwgt_name=FM6_4p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 82.000000e-12
+        set anoinputs 9 4.510000e-12
 
 
-#************	FM6	***************************
-launch --rwgt_name=FM6_84p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 9 84.000000e-12
+        set anoinputs 10 -40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m300p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -300.000000e-12
+        set anoinputs 10 -39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m295p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -295.000000e-12
+        set anoinputs 10 -38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m290p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -290.000000e-12
+        set anoinputs 10 -37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m285p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -285.000000e-12
+        set anoinputs 10 -36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m280p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -280.000000e-12
+        set anoinputs 10 -35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m275p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -275.000000e-12
+        set anoinputs 10 -34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m270p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -270.000000e-12
+        set anoinputs 10 -33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m265p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -265.000000e-12
+        set anoinputs 10 -32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m260p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -260.000000e-12
+        set anoinputs 10 -31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m255p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -255.000000e-12
+        set anoinputs 10 -30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m250p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -250.000000e-12
+        set anoinputs 10 -29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m245p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -245.000000e-12
+        set anoinputs 10 -28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m240p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -240.000000e-12
+        set anoinputs 10 -27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m235p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -235.000000e-12
+        set anoinputs 10 -26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m230p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -230.000000e-12
+        set anoinputs 10 -25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m225p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -225.000000e-12
+        set anoinputs 10 -24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m220p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -220.000000e-12
+        set anoinputs 10 -23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m215p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -215.000000e-12
+        set anoinputs 10 -22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m210p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -210.000000e-12
+        set anoinputs 10 -21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m205p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -205.000000e-12
+        set anoinputs 10 -20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m200p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -200.000000e-12
+        set anoinputs 10 -19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m195p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -195.000000e-12
+        set anoinputs 10 -18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m190p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -190.000000e-12
+        set anoinputs 10 -17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m185p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -185.000000e-12
+        set anoinputs 10 -16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m180p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -180.000000e-12
+        set anoinputs 10 -15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m175p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -175.000000e-12
+        set anoinputs 10 -14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m170p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -170.000000e-12
+        set anoinputs 10 -13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m165p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -165.000000e-12
+        set anoinputs 10 -12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m160p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -160.000000e-12
+        set anoinputs 10 -11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m155p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -155.000000e-12
+        set anoinputs 10 -10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m150p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -150.000000e-12
+        set anoinputs 10 -9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m145p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -145.000000e-12
+        set anoinputs 10 -8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m140p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -140.000000e-12
+        set anoinputs 10 -7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m135p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -135.000000e-12
+        set anoinputs 10 -6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m130p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -130.000000e-12
+        set anoinputs 10 -5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m125p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -125.000000e-12
+        set anoinputs 10 -4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m120p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -120.000000e-12
+        set anoinputs 10 -3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m115p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -115.000000e-12
+        set anoinputs 10 -2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m110p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -110.000000e-12
+        set anoinputs 10 -1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -105.000000e-12
+        set anoinputs 10 -0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_m0p00
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -100.000000e-12
+        set anoinputs 10 -0.000000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -95.000000e-12
+        set anoinputs 10 0.990000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_1p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -90.000000e-12
+        set anoinputs 10 1.980000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_2p97
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -85.000000e-12
+        set anoinputs 10 2.970000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_3p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -80.000000e-12
+        set anoinputs 10 3.960000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_4p95
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -75.000000e-12
+        set anoinputs 10 4.950000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_5p94
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -70.000000e-12
+        set anoinputs 10 5.940000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_6p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -65.000000e-12
+        set anoinputs 10 6.930000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_7p92
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -60.000000e-12
+        set anoinputs 10 7.920000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_8p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -55.000000e-12
+        set anoinputs 10 8.910000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_9p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -50.000000e-12
+        set anoinputs 10 9.900000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_10p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -45.000000e-12
+        set anoinputs 10 10.890000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_11p88
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -40.000000e-12
+        set anoinputs 10 11.880000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_12p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -35.000000e-12
+        set anoinputs 10 12.870000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_13p86
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -30.000000e-12
+        set anoinputs 10 13.860000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_14p85
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -25.000000e-12
+        set anoinputs 10 14.850000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_15p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -20.000000e-12
+        set anoinputs 10 15.840000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_16p83
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -15.000000e-12
+        set anoinputs 10 16.830000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_17p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -10.000000e-12
+        set anoinputs 10 17.820000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_m5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_18p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 -5.000000e-12
+        set anoinputs 10 18.810000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_0p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_19p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 0.000000e-12
+        set anoinputs 10 19.800000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_5p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_20p79
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 5.000000e-12
+        set anoinputs 10 20.790000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_10p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_21p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 10.000000e-12
+        set anoinputs 10 21.780000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_15p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_22p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 15.000000e-12
+        set anoinputs 10 22.770000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_20p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_23p76
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 20.000000e-12
+        set anoinputs 10 23.760000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_25p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_24p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 25.000000e-12
+        set anoinputs 10 24.750000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_30p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_25p74
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 30.000000e-12
+        set anoinputs 10 25.740000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_35p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_26p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 35.000000e-12
+        set anoinputs 10 26.730000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_40p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_27p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 40.000000e-12
+        set anoinputs 10 27.720000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_45p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_28p71
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 45.000000e-12
+        set anoinputs 10 28.710000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_50p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_29p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 50.000000e-12
+        set anoinputs 10 29.700000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_55p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_30p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 55.000000e-12
+        set anoinputs 10 30.690000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_60p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_31p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 60.000000e-12
+        set anoinputs 10 31.680000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_65p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_32p67
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 65.000000e-12
+        set anoinputs 10 32.670000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_70p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_33p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 70.000000e-12
+        set anoinputs 10 33.660000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_75p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_34p65
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 75.000000e-12
+        set anoinputs 10 34.650000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_80p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_35p64
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 80.000000e-12
+        set anoinputs 10 35.640000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_85p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_36p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 85.000000e-12
+        set anoinputs 10 36.630000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_90p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_37p62
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 90.000000e-12
+        set anoinputs 10 37.620000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_95p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_38p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 95.000000e-12
+        set anoinputs 10 38.610000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_100p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_39p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 100.000000e-12
+        set anoinputs 10 39.600000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_105p0
+#******************** FM7 ********************
+launch --rwgt_name=FM7_40p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 10 105.000000e-12
+        set anoinputs 10 40.590000e-12
 
 
-#************	FM7	***************************
-launch --rwgt_name=FM7_110p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 110.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_115p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 115.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_120p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 120.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_125p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 125.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_130p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 130.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_135p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 135.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_140p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 140.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_145p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 145.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_150p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 150.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_155p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 155.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_160p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 160.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_165p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 165.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_170p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 170.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_175p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 175.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_180p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 180.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_185p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 185.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_190p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 190.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_195p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 195.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_200p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 200.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_205p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 205.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_210p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 210.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_215p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 215.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_220p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 220.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_225p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 225.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_230p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 230.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_235p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 235.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_240p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 240.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_245p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 245.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_250p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 250.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_255p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 255.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_260p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 260.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_265p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 265.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_270p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 270.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_275p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 275.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_280p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 280.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_285p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 285.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_290p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 290.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_295p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 295.000000e-12
-
-
-#************	FM7	***************************
-launch --rwgt_name=FM7_300p0
-        set anoinputs 11 0.000000e+00
-        set anoinputs 10 300.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p8
-        set anoinputs 11 -6.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p6
-        set anoinputs 11 -6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p4
-        set anoinputs 11 -6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p2
-        set anoinputs 11 -6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m6p0
-        set anoinputs 11 -6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p8
-        set anoinputs 11 -5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p6
-        set anoinputs 11 -5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p4
-        set anoinputs 11 -5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p2
-        set anoinputs 11 -5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m5p0
-        set anoinputs 11 -5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p8
-        set anoinputs 11 -4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p6
-        set anoinputs 11 -4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p4
-        set anoinputs 11 -4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p2
-        set anoinputs 11 -4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m4p0
-        set anoinputs 11 -4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p8
-        set anoinputs 11 -3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p6
-        set anoinputs 11 -3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p4
-        set anoinputs 11 -3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p2
-        set anoinputs 11 -3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m3p0
-        set anoinputs 11 -3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p8
-        set anoinputs 11 -2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p6
-        set anoinputs 11 -2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p4
-        set anoinputs 11 -2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p2
-        set anoinputs 11 -2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m2p0
-        set anoinputs 11 -2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p8
-        set anoinputs 11 -1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p6
-        set anoinputs 11 -1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p4
-        set anoinputs 11 -1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p2
-        set anoinputs 11 -1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_m1p0
-        set anoinputs 11 -1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p82
+        set anoinputs 11 -0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p80
         set anoinputs 11 -0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p78
+        set anoinputs 11 -0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p76
+        set anoinputs 11 -0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p74
+        set anoinputs 11 -0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p72
+        set anoinputs 11 -0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p70
+        set anoinputs 11 -0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p68
+        set anoinputs 11 -0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p66
+        set anoinputs 11 -0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p64
+        set anoinputs 11 -0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p62
+        set anoinputs 11 -0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p60
         set anoinputs 11 -0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p58
+        set anoinputs 11 -0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p56
+        set anoinputs 11 -0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p54
+        set anoinputs 11 -0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p52
+        set anoinputs 11 -0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p50
+        set anoinputs 11 -0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p48
+        set anoinputs 11 -0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p46
+        set anoinputs 11 -0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p44
+        set anoinputs 11 -0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p42
+        set anoinputs 11 -0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p40
         set anoinputs 11 -0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_m0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p38
+        set anoinputs 11 -0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p36
+        set anoinputs 11 -0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p34
+        set anoinputs 11 -0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p32
+        set anoinputs 11 -0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p30
+        set anoinputs 11 -0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p28
+        set anoinputs 11 -0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p26
+        set anoinputs 11 -0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p24
+        set anoinputs 11 -0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p22
+        set anoinputs 11 -0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p20
         set anoinputs 11 -0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p0
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p18
+        set anoinputs 11 -0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p16
+        set anoinputs 11 -0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p14
+        set anoinputs 11 -0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p12
+        set anoinputs 11 -0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p10
+        set anoinputs 11 -0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p08
+        set anoinputs 11 -0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p06
+        set anoinputs 11 -0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p04
+        set anoinputs 11 -0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_m0p02
+        set anoinputs 11 -0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p00
         set anoinputs 11 0.000000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p2
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p02
+        set anoinputs 11 0.020000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p04
+        set anoinputs 11 0.040000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p06
+        set anoinputs 11 0.060000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p08
+        set anoinputs 11 0.080000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p10
+        set anoinputs 11 0.100000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p12
+        set anoinputs 11 0.120000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p14
+        set anoinputs 11 0.140000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p16
+        set anoinputs 11 0.160000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p18
+        set anoinputs 11 0.180000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p20
         set anoinputs 11 0.200000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p4
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p22
+        set anoinputs 11 0.220000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p24
+        set anoinputs 11 0.240000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p26
+        set anoinputs 11 0.260000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p28
+        set anoinputs 11 0.280000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p30
+        set anoinputs 11 0.300000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p32
+        set anoinputs 11 0.320000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p34
+        set anoinputs 11 0.340000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p36
+        set anoinputs 11 0.360000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p38
+        set anoinputs 11 0.380000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p40
         set anoinputs 11 0.400000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p6
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p42
+        set anoinputs 11 0.420000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p44
+        set anoinputs 11 0.440000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p46
+        set anoinputs 11 0.460000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p48
+        set anoinputs 11 0.480000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p50
+        set anoinputs 11 0.500000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p52
+        set anoinputs 11 0.520000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p54
+        set anoinputs 11 0.540000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p56
+        set anoinputs 11 0.560000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p58
+        set anoinputs 11 0.580000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p60
         set anoinputs 11 0.600000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_0p8
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p62
+        set anoinputs 11 0.620000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p64
+        set anoinputs 11 0.640000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p66
+        set anoinputs 11 0.660000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p68
+        set anoinputs 11 0.680000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p70
+        set anoinputs 11 0.700000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p72
+        set anoinputs 11 0.720000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p74
+        set anoinputs 11 0.740000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p76
+        set anoinputs 11 0.760000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p78
+        set anoinputs 11 0.780000e-12
+
+
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p80
         set anoinputs 11 0.800000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p0
-        set anoinputs 11 1.000000e-12
+#******************** FT0 ********************
+launch --rwgt_name=FT0_0p82
+        set anoinputs 11 0.820000e-12
 
 
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p2
-        set anoinputs 11 1.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p4
-        set anoinputs 11 1.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p6
-        set anoinputs 11 1.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_1p8
-        set anoinputs 11 1.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p0
-        set anoinputs 11 2.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p2
-        set anoinputs 11 2.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p4
-        set anoinputs 11 2.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p6
-        set anoinputs 11 2.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_2p8
-        set anoinputs 11 2.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p0
-        set anoinputs 11 3.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p2
-        set anoinputs 11 3.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p4
-        set anoinputs 11 3.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p6
-        set anoinputs 11 3.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_3p8
-        set anoinputs 11 3.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p0
-        set anoinputs 11 4.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p2
-        set anoinputs 11 4.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p4
-        set anoinputs 11 4.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p6
-        set anoinputs 11 4.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_4p8
-        set anoinputs 11 4.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p0
-        set anoinputs 11 5.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p2
-        set anoinputs 11 5.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p4
-        set anoinputs 11 5.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p6
-        set anoinputs 11 5.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_5p8
-        set anoinputs 11 5.800000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p0
-        set anoinputs 11 6.000000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p2
-        set anoinputs 11 6.200000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p4
-        set anoinputs 11 6.400000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p6
-        set anoinputs 11 6.600000e-12
-
-
-#************	FT0	***************************
-launch --rwgt_name=FT0_6p8
-        set anoinputs 11 6.800000e-12
-
-
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p23
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.500000e-12
+        set anoinputs 12 -1.230000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p20
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -12.000000e-12
+        set anoinputs 12 -1.200000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.500000e-12
+        set anoinputs 12 -1.170000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -11.000000e-12
+        set anoinputs 12 -1.140000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p11
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.500000e-12
+        set anoinputs 12 -1.110000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p08
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -10.000000e-12
+        set anoinputs 12 -1.080000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.500000e-12
+        set anoinputs 12 -1.050000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m1p02
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -9.000000e-12
+        set anoinputs 12 -1.020000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p99
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.500000e-12
+        set anoinputs 12 -0.990000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -8.000000e-12
+        set anoinputs 12 -0.960000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p93
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.500000e-12
+        set anoinputs 12 -0.930000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p90
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -7.000000e-12
+        set anoinputs 12 -0.900000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.500000e-12
+        set anoinputs 12 -0.870000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -6.000000e-12
+        set anoinputs 12 -0.840000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p81
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.500000e-12
+        set anoinputs 12 -0.810000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p78
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -5.000000e-12
+        set anoinputs 12 -0.780000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.500000e-12
+        set anoinputs 12 -0.750000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -4.000000e-12
+        set anoinputs 12 -0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.500000e-12
+        set anoinputs 12 -0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -3.000000e-12
+        set anoinputs 12 -0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.500000e-12
+        set anoinputs 12 -0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -2.000000e-12
+        set anoinputs 12 -0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.500000e-12
+        set anoinputs 12 -0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -1.000000e-12
+        set anoinputs 12 -0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_m0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 -0.500000e-12
+        set anoinputs 12 -0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.480000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.450000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.420000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.390000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.360000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.330000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.300000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p27
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.270000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.240000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.210000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.180000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.150000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.120000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.090000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.060000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_m0p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 -0.030000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 12 0.000000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_0p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 0.500000e-12
+        set anoinputs 12 0.030000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p06
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.000000e-12
+        set anoinputs 12 0.060000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_1p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p09
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 1.500000e-12
+        set anoinputs 12 0.090000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.000000e-12
+        set anoinputs 12 0.120000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_2p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p15
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 2.500000e-12
+        set anoinputs 12 0.150000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p18
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.000000e-12
+        set anoinputs 12 0.180000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_3p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 3.500000e-12
+        set anoinputs 12 0.210000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.000000e-12
+        set anoinputs 12 0.240000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_4p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p27
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 4.500000e-12
+        set anoinputs 12 0.270000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p30
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.000000e-12
+        set anoinputs 12 0.300000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_5p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 5.500000e-12
+        set anoinputs 12 0.330000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p36
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.000000e-12
+        set anoinputs 12 0.360000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_6p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p39
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 6.500000e-12
+        set anoinputs 12 0.390000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.000000e-12
+        set anoinputs 12 0.420000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_7p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 7.500000e-12
+        set anoinputs 12 0.450000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p48
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.000000e-12
+        set anoinputs 12 0.480000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_8p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p51
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 8.500000e-12
+        set anoinputs 12 0.510000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.000000e-12
+        set anoinputs 12 0.540000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_9p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p57
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 9.500000e-12
+        set anoinputs 12 0.570000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p60
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.000000e-12
+        set anoinputs 12 0.600000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_10p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 10.500000e-12
+        set anoinputs 12 0.630000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.000000e-12
+        set anoinputs 12 0.660000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_11p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p69
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 11.500000e-12
+        set anoinputs 12 0.690000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p0
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p72
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.000000e-12
+        set anoinputs 12 0.720000e-12
 
 
-#************	FT1	***************************
-launch --rwgt_name=FT1_12p5
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 12 12.500000e-12
+        set anoinputs 12 0.750000e-12
 
 
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.780000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.810000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.840000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.870000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.900000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.930000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.960000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_0p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 0.990000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.020000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p05
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.050000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.080000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p11
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.110000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.140000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.170000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.200000e-12
+
+
+#******************** FT1 ********************
+launch --rwgt_name=FT1_1p23
+        set anoinputs 11 0.000000e+00
+        set anoinputs 12 1.230000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.500000e-12
+        set anoinputs 13 -2.870000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -20.000000e-12
+        set anoinputs 13 -2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.500000e-12
+        set anoinputs 13 -2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -19.000000e-12
+        set anoinputs 13 -2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.500000e-12
+        set anoinputs 13 -2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -18.000000e-12
+        set anoinputs 13 -2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.500000e-12
+        set anoinputs 13 -2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -17.000000e-12
+        set anoinputs 13 -2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.500000e-12
+        set anoinputs 13 -2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -16.000000e-12
+        set anoinputs 13 -2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.500000e-12
+        set anoinputs 13 -2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -15.000000e-12
+        set anoinputs 13 -2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.500000e-12
+        set anoinputs 13 -2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -14.000000e-12
+        set anoinputs 13 -1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.500000e-12
+        set anoinputs 13 -1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -13.000000e-12
+        set anoinputs 13 -1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.500000e-12
+        set anoinputs 13 -1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -12.000000e-12
+        set anoinputs 13 -1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.500000e-12
+        set anoinputs 13 -1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -11.000000e-12
+        set anoinputs 13 -1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.500000e-12
+        set anoinputs 13 -1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -10.000000e-12
+        set anoinputs 13 -1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.500000e-12
+        set anoinputs 13 -1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -9.000000e-12
+        set anoinputs 13 -1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.500000e-12
+        set anoinputs 13 -1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -8.000000e-12
+        set anoinputs 13 -1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.500000e-12
+        set anoinputs 13 -1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -7.000000e-12
+        set anoinputs 13 -0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.500000e-12
+        set anoinputs 13 -0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -6.000000e-12
+        set anoinputs 13 -0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.500000e-12
+        set anoinputs 13 -0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -5.000000e-12
+        set anoinputs 13 -0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.500000e-12
+        set anoinputs 13 -0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -4.000000e-12
+        set anoinputs 13 -0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.500000e-12
+        set anoinputs 13 -0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -3.000000e-12
+        set anoinputs 13 -0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.500000e-12
+        set anoinputs 13 -0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -2.000000e-12
+        set anoinputs 13 -0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.500000e-12
+        set anoinputs 13 -0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -1.000000e-12
+        set anoinputs 13 -0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_m0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_m0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 -0.500000e-12
+        set anoinputs 13 -0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p00
         set anoinputs 11 0.000000e+00
         set anoinputs 13 0.000000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_0p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p07
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 0.500000e-12
+        set anoinputs 13 0.070000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p14
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.000000e-12
+        set anoinputs 13 0.140000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_1p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p21
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 1.500000e-12
+        set anoinputs 13 0.210000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p28
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.000000e-12
+        set anoinputs 13 0.280000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_2p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p35
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 2.500000e-12
+        set anoinputs 13 0.350000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p42
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.000000e-12
+        set anoinputs 13 0.420000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_3p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p49
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 3.500000e-12
+        set anoinputs 13 0.490000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p56
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.000000e-12
+        set anoinputs 13 0.560000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_4p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p63
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 4.500000e-12
+        set anoinputs 13 0.630000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p70
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.000000e-12
+        set anoinputs 13 0.700000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_5p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p77
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 5.500000e-12
+        set anoinputs 13 0.770000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p84
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.000000e-12
+        set anoinputs 13 0.840000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_6p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p91
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 6.500000e-12
+        set anoinputs 13 0.910000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_0p98
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.000000e-12
+        set anoinputs 13 0.980000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_7p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p05
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 7.500000e-12
+        set anoinputs 13 1.050000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p12
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.000000e-12
+        set anoinputs 13 1.120000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_8p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p19
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 8.500000e-12
+        set anoinputs 13 1.190000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p26
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.000000e-12
+        set anoinputs 13 1.260000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_9p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p33
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 9.500000e-12
+        set anoinputs 13 1.330000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p40
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.000000e-12
+        set anoinputs 13 1.400000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_10p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p47
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 10.500000e-12
+        set anoinputs 13 1.470000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p54
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.000000e-12
+        set anoinputs 13 1.540000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_11p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p61
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 11.500000e-12
+        set anoinputs 13 1.610000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p68
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.000000e-12
+        set anoinputs 13 1.680000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_12p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p75
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 12.500000e-12
+        set anoinputs 13 1.750000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p82
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.000000e-12
+        set anoinputs 13 1.820000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_13p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p89
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 13.500000e-12
+        set anoinputs 13 1.890000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_1p96
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.000000e-12
+        set anoinputs 13 1.960000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_14p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p03
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 14.500000e-12
+        set anoinputs 13 2.030000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p10
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.000000e-12
+        set anoinputs 13 2.100000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_15p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p17
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 15.500000e-12
+        set anoinputs 13 2.170000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p24
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.000000e-12
+        set anoinputs 13 2.240000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_16p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p31
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 16.500000e-12
+        set anoinputs 13 2.310000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p38
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.000000e-12
+        set anoinputs 13 2.380000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_17p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p45
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 17.500000e-12
+        set anoinputs 13 2.450000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p52
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.000000e-12
+        set anoinputs 13 2.520000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_18p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p59
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 18.500000e-12
+        set anoinputs 13 2.590000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p66
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.000000e-12
+        set anoinputs 13 2.660000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_19p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p73
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 19.500000e-12
+        set anoinputs 13 2.730000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p0
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p80
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.000000e-12
+        set anoinputs 13 2.800000e-12
 
 
-#************	FT2	***************************
-launch --rwgt_name=FT2_20p5
+#******************** FT2 ********************
+launch --rwgt_name=FT2_2p87
         set anoinputs 11 0.000000e+00
-        set anoinputs 13 20.500000e-12
+        set anoinputs 13 2.870000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.460000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_m0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 -0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.000000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.060000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.120000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p18
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.180000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.240000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.300000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.360000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.420000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.480000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.540000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.600000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p66
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.660000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.720000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.780000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.840000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.900000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 0.960000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.020000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.080000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p14
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.140000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.200000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.260000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.320000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.380000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.440000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.500000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.560000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p62
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.620000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.680000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.740000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.800000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.860000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.920000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_1p98
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 1.980000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.040000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.100000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.160000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.220000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.280000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.340000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.400000e-12
+
+
+#******************** FT5 ********************
+launch --rwgt_name=FT5_2p46
+        set anoinputs 11 0.000000e+00
+        set anoinputs 16 2.460000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_m0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 -0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_0p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 0.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_1p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 1.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.560000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p72
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.720000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_2p88
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 2.880000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.040000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.200000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p36
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.360000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.520000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.680000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_3p84
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 3.840000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.000000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.160000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.320000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.480000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.640000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.800000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_4p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 4.960000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.120000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.280000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.440000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.600000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p76
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.760000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_5p92
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 5.920000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.080000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p24
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.240000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.400000e-12
+
+
+#******************** FT6 ********************
+launch --rwgt_name=FT6_6p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 17 6.560000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_m0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 -0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_0p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 0.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_1p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 1.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_2p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 2.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 3.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_4p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 4.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_5p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 5.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_6p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 6.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_7p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 7.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 8.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.300000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.600000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_9p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 9.900000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.200000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p50
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.500000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_10p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 10.800000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p10
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.100000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p40
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.400000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_11p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 11.700000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.000000e-12
+
+
+#******************** FT7 ********************
+launch --rwgt_name=FT7_12p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 18 12.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.330000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_m0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 -0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.000000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p13
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.130000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p26
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.260000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p39
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.390000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p52
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.520000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p65
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.650000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p78
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.780000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_0p91
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 0.910000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p04
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.040000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p17
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.170000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p30
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.300000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p43
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.430000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p56
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.560000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p69
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.690000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p82
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.820000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_1p95
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 1.950000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p08
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.080000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p21
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.210000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p34
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.340000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p47
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.470000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.600000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.730000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.860000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_2p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 2.990000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.120000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.250000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.380000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.510000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.640000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.770000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_3p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 3.900000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.030000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.160000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.290000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p42
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.420000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p55
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.550000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p68
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.680000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p81
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.810000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_4p94
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 4.940000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p07
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.070000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p20
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.200000e-12
+
+
+#******************** FT8 ********************
+launch --rwgt_name=FT8_5p33
+        set anoinputs 11 0.000000e+00
+        set anoinputs 19 5.330000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.890000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_m0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 -0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p00
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.000000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p29
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.290000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p58
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.580000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_0p87
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 0.870000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p16
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.160000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p45
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.450000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_1p74
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 1.740000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p03
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.030000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p32
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.320000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p61
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.610000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_2p90
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 2.900000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p19
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.190000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p48
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.480000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_3p77
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 3.770000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p06
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.060000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p35
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.350000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p64
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.640000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_4p93
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 4.930000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p22
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.220000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p51
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.510000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_5p80
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 5.800000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p09
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.090000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p38
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.380000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p67
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.670000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_6p96
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 6.960000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p25
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.250000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p54
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.540000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_7p83
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 7.830000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p12
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.120000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p41
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.410000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p70
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.700000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_8p99
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 8.990000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p28
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.280000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p57
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.570000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_9p86
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 9.860000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p15
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.150000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p44
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.440000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_10p73
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 10.730000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p02
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.020000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p31
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.310000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p60
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.600000e-12
+
+
+#******************** FT9 ********************
+launch --rwgt_name=FT9_11p89
+        set anoinputs 11 0.000000e+00
+        set anoinputs 20 11.890000e-12
+
+


### PR DESCRIPTION
This updates the ReweightingCards to scan the same Ranges as in the 2016 Cards ([see the respective PR](https://github.com/cms-sw/genproductions/pull/1513))