### PR TITLE
Updates to nmssmCascadeWithHiggsCards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
@@ -68,7 +68,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy2000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
@@ -68,7 +68,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy2600 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
@@ -68,7 +68,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy1200 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy1200/mH70_mSusy1200_run_card.dat
@@ -67,7 +67,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy2000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2000/mH70_mSusy2000_run_card.dat
@@ -67,7 +67,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_proc_card.dat
@@ -1,9 +1,9 @@
 import model nmssm
 define squark = ul ur dl dr cl cr sl sr ul~ ur~ dl~ dr~ cl~ cr~ sl~ sr~
-generate p p > squark squark
-add process p p > squark go
-add process p p > go go
-add process p p > squark squark j $ go
-add process p p > squark go j $ go
-add process p p > go go j
+generate p p > squark squark @ 0
+add process p p > squark go @ 1
+add process p p > go go @ 2
+add process p p > squark squark j $ go @ 3
+add process p p > squark go j $ go @ 4
+add process p p > go go j @ 5
 output mH70_mSusy2600 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/nmssmCascadeWithHiggs/mH70_mSusy2600/mH70_mSusy2600_run_card.dat
@@ -67,7 +67,7 @@
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
- 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
  1 = highestmult      ! for ickkw=2, highest mult group
  1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1.0 = alpsfact         ! scale factor for QCD emission vx


### PR DESCRIPTION
The matching parameter ickkw is set to 1 instead of 0 in all run_cards (2016 and 2017)
The processes in all proc_cards are now labelled with @n notation (2016 and 2017)