### PR TITLE
adding explicit reference to the top cut

### DIFF
--- a/bin/Phantom/cards/examples/phantomProduction_example.cfg
+++ b/bin/Phantom/cards/examples/phantomProduction_example.cfg
@@ -195,3 +195,11 @@ ghhfactor = -1.d0
 # in this last case SM gamh is multiplied
 # by ghhfactor**2 
 gamhh_ns = -41.62d0
+
+# cut on the invariant mass of all triplets of
+# particles who could form a top
+# to avoid top contributions
+# The corresponding deltacuttop fixes the
+# interval excluded : topmas +- deltatacuttop
+i_deltacuttop = 1
+deltacuttop = 10.d0


### PR DESCRIPTION
Since in the default config file of Phantom, which gets parsed by our script, a cut around the top mass may be active, vetoing events with intermediate top quarks decaying into Wb, I am putting it explicitly here as well.