### PR TITLE
[python][ThirteenTeV][Higgs][HH] Adjusted decay fragments for HHTo2BLNu2J

### DIFF
--- a/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_madgraph_pythia8_CP5_cff.py
+++ b/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_madgraph_pythia8_CP5_cff.py
@@ -1,45 +1,44 @@
-import FWCore.ParameterSet.Config as cms
+# -*- coding: utf-8 -*-
 
-# link to cards:
-# https://github.com/OlivierBondu/genproductions/tree/ed5057598b9fbf246741829603162f1bc6700f7d/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-0/Radion_GF_HH
+
+import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
-generator = cms.EDFilter("Pythia8HadronizerFilter",
-                         maxEventsToPrint = cms.untracked.int32(1),
-                         pythiaPylistVerbosity = cms.untracked.int32(1),
-                         filterEfficiency = cms.untracked.double(1.0),
-                         pythiaHepMCVerbosity = cms.untracked.bool(False),
-                         comEnergy = cms.double(13000.),
-                         PythiaParameters = cms.PSet(
+
+generator = cms.EDFilter(
+    "Pythia8HadronizerFilter",
+    maxEventsToPrint=cms.untracked.int32(1),
+    pythiaPylistVerbosity=cms.untracked.int32(1),
+    filterEfficiency=cms.untracked.double(1.0),
+    pythiaHepMCVerbosity=cms.untracked.bool(False),
+    comEnergy=cms.double(13000.),
+    PythiaParameters=cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,
-        processParameters = cms.vstring(
-            '15:onMode = off',
-            '15:onIfAny = 11 13', # only leptonic tau decays
+        processParameters=cms.vstring(
             '24:mMin = 0.05',
-            '24:onMode = on', # all W decays
+            '24:onMode = on',
             '25:m0 = 125.0',
             '25:onMode = off',
             '25:onIfMatch = 5 -5',
             '25:onIfMatch = 24 -24',
             'ResonanceDecayFilter:filter = on',
-            'ResonanceDecayFilter:exclusive = on', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
-            'ResonanceDecayFilter:eMuAsEquivalent = off', #on: treat electrons and muons as equivalent
+            'ResonanceDecayFilter:exclusive = on', #on: require exactly the specified number of daughters
             'ResonanceDecayFilter:eMuTauAsEquivalent = on', #on: treat electrons, muons , and taus as equivalent
             'ResonanceDecayFilter:allNuAsEquivalent = on', #on: treat all three neutrino flavours as equivalent
-            'ResonanceDecayFilter:udscAsEquivalent   = off', #on: treat udsc quarks as equivalent
-            'ResonanceDecayFilter:udscbAsEquivalent  = on',  #on: treat udscb quarks as equivalent
-            'ResonanceDecayFilter:mothers = 25,24', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
-            'ResonanceDecayFilter:daughters = 5,5,24,24,11,12,1,1',
-          ),
-        parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP5Settings',
-                                    'processParameters'
-                                    )
-        )
-                         )
-
+            'ResonanceDecayFilter:udscAsEquivalent = on', #on: treat udsc quarks as equivalent
+            'ResonanceDecayFilter:mothers = 24,25',
+            'ResonanceDecayFilter:daughters = 5,5,1,1,11,12',
+        ),
+        parameterSets=cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'processParameters',
+        ),
+    ),
+)
 
 ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_powheg_pythia8_CP5_cff.py
+++ b/python/ThirteenTeV/Higgs/HH/ResonanceDecayFilter_example_HHTo2BLNu2J_powheg_pythia8_CP5_cff.py
@@ -1,44 +1,47 @@
+# -*- coding: utf-8 -*-
+
+
 import FWCore.ParameterSet.Config as cms
+
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 
-generator = cms.EDFilter("Pythia8HadronizerFilter",
-                         maxEventsToPrint = cms.untracked.int32(1),
-                         pythiaPylistVerbosity = cms.untracked.int32(1),
-                         filterEfficiency = cms.untracked.double(1.0),
-                         pythiaHepMCVerbosity = cms.untracked.bool(False),
-                         comEnergy = cms.double(13000.),
-                         PythiaParameters = cms.PSet(
+
+generator = cms.EDFilter(
+    "Pythia8HadronizerFilter",
+    maxEventsToPrint=cms.untracked.int32(1),
+    pythiaPylistVerbosity=cms.untracked.int32(1),
+    filterEfficiency=cms.untracked.double(1.0),
+    pythiaHepMCVerbosity=cms.untracked.bool(False),
+    comEnergy=cms.double(13000.),
+    PythiaParameters=cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,
         pythia8PowhegEmissionVetoSettingsBlock,
-        processParameters = cms.vstring(
-            'POWHEG:nFinal = 2',  ## Number of final state particles
-            '15:onMode = off',
-            '15:onIfAny = 11 13', # only leptonic tau decays
+        processParameters=cms.vstring(
+            'POWHEG:nFinal = 2',   # Number of final state particles (BEFORE THE DECAYS) in the LHE other than emitted extra parton
             '24:mMin = 0.05',
-            '24:onMode = on', # all W decays
+            '24:onMode = on',
             '25:m0 = 125.0',
             '25:onMode = off',
             '25:onIfMatch = 5 -5',
             '25:onIfMatch = 24 -24',
             'ResonanceDecayFilter:filter = on',
-            'ResonanceDecayFilter:exclusive = on', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
-            'ResonanceDecayFilter:eMuAsEquivalent = off', #on: treat electrons and muons as equivalent
+            'ResonanceDecayFilter:exclusive = on', #on: require exactly the specified number of daughters
             'ResonanceDecayFilter:eMuTauAsEquivalent = on', #on: treat electrons, muons , and taus as equivalent
             'ResonanceDecayFilter:allNuAsEquivalent = on', #on: treat all three neutrino flavours as equivalent
-            'ResonanceDecayFilter:udscAsEquivalent   = off', #on: treat udsc quarks as equivalent
-            'ResonanceDecayFilter:udscbAsEquivalent  = on',  #on: treat udscb quarks as equivalent
-            'ResonanceDecayFilter:mothers = 25,24', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
-            'ResonanceDecayFilter:daughters = 5,5,24,24,11,12,1,1',
-          ),
-        parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP5Settings',
-                                    'pythia8PowhegEmissionVetoSettings',
-                                    'processParameters'
-                                    )
-        )
-                         )
+            'ResonanceDecayFilter:udscAsEquivalent = on', #on: treat udsc quarks as equivalent
+            'ResonanceDecayFilter:mothers = 24,25',
+            'ResonanceDecayFilter:daughters = 5,5,1,1,11,12',
+        ),
+        parameterSets=cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+        ),
+    ),
+)
 
 ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This is an adjustment of the decay fragments for the channel HHTo2BLNu2J (Semi-leptonic di-Higgs bbWW channel).
After haven spoken with Olivier, I adjusted both cards (madgraph and powheg).
The following explicit changes have been made:

- enabled all tau decays
- set the ResonanceDecayFilter:daughters to ‚5,5,1,1,11,12‘

CC: @OlivierBondu @l-cadamuro @acarvalh
tags: [python][ThirteenTeV][Higgs][HH]