### PR TITLE
modified cards for 2017 production of Zprime VBF WW 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow.sh
@@ -3,7 +3,7 @@
 masses=(600 800 1000 1200 1400 1600 1800 2000 2500 3000 3500 4000 4500)
 sample=Zprime_VBF_WW_inclu_narrow_M
 
-postfix=(_run_card.dat _customizecards.dat _proc_card.dat)
+postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)
 
 echo ${masses[*]}
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M/Zprime_VBF_WW_inclu_narrow_M_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M/Zprime_VBF_WW_inclu_narrow_M_extramodels.dat
@@ -1,0 +1,2 @@
+#from https://github.com/syuvivida/DibosonBSMSignal_13TeV/tree/master/Models/Vector_Triplet_free_Width_UFO_VBF
+Vector_Triplet_free_Width_UFO_VBF.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M/Zprime_VBF_WW_inclu_narrow_M_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow_M/Zprime_VBF_WW_inclu_narrow_M_run_card.dat
@@ -68,7 +68,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf 
  1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
  1        = alpsfact         ! scale factor for QCD emission vx
  F        = chcluster        ! cluster only according to channel diag
- F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
  5        = asrwgtflavor     ! highest quark flavor for a_s reweight
  T        = clusinfo         ! include clustering tag in output
  3.0      = lhe_version       ! Change the way clustering information pass to shower.        


### PR DESCRIPTION
In the previous version of the cards the extramodel one was not present and I think it is needed to avoid crashes during the gridpack production.
Also I've  set pdfwgt to True in the run card.