### PR TITLE
extramodel card for the different masses was not being created by the script

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-0/Radion_VBF_WW_inclu/Radion_VBF_WW_inclu_narrow.sh
@@ -11,8 +11,7 @@ for mass in ${masses[*]}; do
     echo generating cards for M = $mass GeV
     
     mkdir ${sample}${mass}
-           
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do           
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-0/Radion_VBF_ZZ_inclu/Radion_VBF_ZZ_inclu_narrow.sh
@@ -11,8 +11,7 @@ for mass in ${masses[*]}; do
     echo generating cards for M = $mass GeV
     
     mkdir ${sample}${mass}
-           
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do           
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Wprime_VBF_WZ_inclu/Wprime_VBF_WZ_inclu_narrow.sh
@@ -12,7 +12,7 @@ for mass in ${masses[*]}; do
     
     mkdir ${sample}${mass}
            
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_VBF_WW_inclu/Zprime_VBF_WW_inclu_narrow.sh
@@ -12,7 +12,7 @@ for mass in ${masses[*]}; do
     
     mkdir ${sample}${mass}
            
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_WW_inclu/BulkGraviton_VBF_WW_inclu_narrow.sh
@@ -12,7 +12,7 @@ for mass in ${masses[*]}; do
     
     mkdir ${sample}${mass}
            
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-2/BulkGraviton_VBF_ZZ_inclu/BulkGraviton_VBF_ZZ_inclu_narrow.sh
@@ -12,7 +12,7 @@ for mass in ${masses[*]}; do
     
     mkdir ${sample}${mass}
            
-    for i in {0..2}; do
+    for ((i=0;i<${#postfix[@]};i+=1)); do
 	sed "s/<MASS>/${mass}/g" ${sample}/${sample}${postfix[$i]} > ${sample}$mass/${sample}$mass${postfix[$i]}
     done    
 done


### PR DESCRIPTION
This was because a loop was going from 0 to 2 instead of going from 0 to postfix dimension, that is now been fixed for:
Radion_VBF_WW
Radion_VBF_ZZ
Wprime_VBF_WZ
Zprime_VBF_WW
BulkGraviton_VBF_WW
BulkGraviton_VBF_ZZ