### PR TITLE
Remove settings only valid in mg26x

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP/ALP_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP/ALP_run_card.dat
@@ -63,8 +63,6 @@
   -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
   3.0 = lhe_version       ! Change the way clustering information pass to shower.        
   True = clusinfo         ! include clustering tag in output
-  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
-
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
@@ -83,18 +81,6 @@
 #  1: importance sampling over helicities
 #*********************************************************************
    0  = nhel          ! using helicities importance sampling or not.
-#*********************************************************************
-# Generation bias, check the wiki page below for more information:   *
-#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
-#*********************************************************************
- None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
- {} = bias_parameters ! Specifies the parameters of the module.
-#
-#*******************************                                                 
-# Parton level cuts definition *
-#*******************************                                     
-#                                                                    
-#
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
@@ -251,9 +237,7 @@
 # CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
 #***********************************************************************
  -1.0  =  ktdurham        
- 0.4   =  dparameter
- -1.0  =  ptlund
- 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
+ 0.4   =  dparameter 
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MSSMD/MSSMD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/MSSMD/MSSMD_run_card.dat
@@ -63,8 +63,6 @@
   -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
   3.0 = lhe_version       ! Change the way clustering information pass to shower.        
   True = clusinfo         ! include clustering tag in output
-  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
-
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
@@ -83,18 +81,6 @@
 #  1: importance sampling over helicities
 #*********************************************************************
    0  = nhel          ! using helicities importance sampling or not.
-#*********************************************************************
-# Generation bias, check the wiki page below for more information:   *
-#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
-#*********************************************************************
- None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
- {} = bias_parameters ! Specifies the parameters of the module.
-#
-#*******************************                                                 
-# Parton level cuts definition *
-#*******************************                                     
-#                                                                    
-#
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
@@ -251,9 +237,7 @@
 # CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
 #***********************************************************************
  -1.0  =  ktdurham        
- 0.4   =  dparameter
- -1.0  =  ptlund
- 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
+ 0.4   =  dparameter  
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *


### PR DESCRIPTION
Hi @qliphy,

The PR is to make sure the run card work in the master branch by removing settings only valid in mg26x.

Thanks,
Wei