### PR TITLE
Fix incorrect settings of decay widths for AtoZh samples 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M220/AtoZh_M220_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.985184057
 set param_card loop 11 -0.17150036
 set param_card loop 12 306.64018
 set param_card loop 13 189.507941
-set param_card decay 35 1.13202522e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 2.06849263e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 8.12273125e-01 # Charged Higgs decays
+set param_card decay 35 1.13202522e-01 
+set param_card decay 36 2.06849263e-02 
+set param_card decay 37 8.12273125e-01 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M240/AtoZh_M240_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.989599273
 set param_card loop 11 -0.143851587
 set param_card loop 12 357.604027
 set param_card loop 13 227.888918
-set param_card decay 35 5.41283368e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 2.93389584e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 1.17688231e+00 # Charged Higgs decays
+set param_card decay 35 5.41283368e-01 
+set param_card decay 36 2.93389584e-02 
+set param_card decay 37 1.17688231e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M260/AtoZh_M260_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.992524279
 set param_card loop 11 -0.122047348
 set param_card loop 12 413.283731
 set param_card loop 13 270.566373
-set param_card decay 35 7.86882681e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 3.81945409e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 1.54967073e+00 # Charged Higgs decays
+set param_card decay 35 7.86882681e-01 
+set param_card decay 36 3.81945409e-02 
+set param_card decay 37 1.54967073e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M280/AtoZh_M280_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.994455568
 set param_card loop 11 -0.105157613
 set param_card loop 12 472.568557
 set param_card loop 13 315.320184
-set param_card decay 35 8.81377996e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 4.60685849e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 1.91418825e+00 # Charged Higgs decays
+set param_card decay 35 8.81377996e-01 
+set param_card decay 36 4.60685849e-02 
+set param_card decay 37 1.91418825e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M300/AtoZh_M300_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.995830271
 set param_card loop 11 -0.0912253841
 set param_card loop 12 536.150197
 set param_card loop 13 363.780317
-set param_card decay 35 9.13678508e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 5.33353819e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 2.27291084e+00 # Charged Higgs decays
+set param_card decay 35 9.13678508e-01 
+set param_card decay 36 5.33353819e-02 
+set param_card decay 37 2.27291084e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M320/AtoZh_M320_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.996773483
 set param_card loop 11 -0.0802659529
 set param_card loop 12 604.437874
 set param_card loop 13 415.29556
-set param_card decay 35 9.28837910e-01 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 6.35568561e-02 # h3 decays, CP-odd Higgs
-set param_card decay 37 2.62332713e+00 # Charged Higgs decays
+set param_card decay 35 9.28837910e-01 
+set param_card decay 36 6.35568561e-02 
+set param_card decay 37 2.62332713e+00

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M340/AtoZh_M340_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.997526291
 set param_card loop 11 -0.070294371
 set param_card loop 12 677.875358
 set param_card loop 13 472.415122
-set param_card decay 35 1.00582435e+00 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 1.09329924e-01 # h3 decays, CP-odd Higgs
-set param_card decay 37 2.97106493e+00 # Charged Higgs decays
+set param_card decay 35 1.00582435e+00 
+set param_card decay 36 1.09329924e-01 
+set param_card decay 37 2.97106493e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M350/AtoZh_M350_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.997799488
 set param_card loop 11 -0.0663037141
 set param_card loop 12 715.259224
 set param_card loop 13 500.95855
-set param_card decay 35 1.19850489e+00 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 1.68629367e+00 # h3 decays, CP-odd Higgs
-set param_card decay 37 3.13607304e+00 # Charged Higgs decays
+set param_card decay 35 1.19850489e+00 
+set param_card decay 36 1.68629367e+00 
+set param_card decay 37 3.13607304e+00 

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/AtoZh_mhmodp_MG5_aMCNLO/AtoZh_M400/AtoZh_M400_customizecards.dat
@@ -117,6 +117,6 @@ set param_card loop 10 0.998732586
 set param_card loop 11 -0.0503311168
 set param_card loop 12 916.226138
 set param_card loop 13 655.056549
-set param_card decay 35 2.33323671e+00 # h2 decays, heaviest CP-even Higgs
-set param_card decay 36 3.82011292e+00 # h3 decays, CP-odd Higgs
-set param_card decay 37 3.92439730e+00 # Charged Higgs decays
+set param_card decay 35 2.33323671e+00 
+set param_card decay 36 3.82011292e+00 
+set param_card decay 37 3.92439730e+00 


### PR DESCRIPTION
The solution is to remove the invalid comments in customizecards