### PR TITLE
add 100 NNPDF LO variations

### DIFF
--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -194,9 +194,9 @@ if [ $is5FlavorScheme -eq 1 ]; then
   NNPDF30_nlo_nf_5_pdfas.LHgrid
   NNPDF30_nnlo_nf_5_pdfas.LHgrid 1
   NNPDF31_lo_as_0118.LHgrid 1
-  NNPDF31_lo_as_0130.LHgrid 1
+  NNPDF31_lo_as_0130.LHgrid
   NNPDF30_lo_as_0118.LHgrid 1
-  NNPDF30_lo_as_0130.LHgrid 1
+  NNPDF30_lo_as_0130.LHgrid
  " >> syscalc_card.dat
 
 else
@@ -224,9 +224,10 @@ else
   PDF4LHC15_nlo_nf4_30.LHgrid
   NNPDF31_nnlo_as_0118_nf_4.LHgrid
   NNPDF31_nlo_as_0118_nf_4.LHgrid
+  NNPDF31_lo_as_0130.LHgrid
   NNPDF30_nlo_as_0118_nf_4.LHgrid
   NNPDF30_lo_as_0118_nf_4.LHgrid 1
-  NNPDF30_lo_as_0130_nf_4.LHgrid 1
+  NNPDF30_lo_as_0130_nf_4.LHgrid
   NNPDF30_nlo_nf_4_pdfas.LHgrid
   NNPDF30_nnlo_nf_4_pdfas.LHgrid 1
   " >> syscalc_card.dat


### PR DESCRIPTION
For Exotica/B2G MC production, we would like to use NNPDF 3.1 LO as the default PDF. In addition, we also would like to keep NNPDF 3.0 LO for comparison with previous 2015/2016 analyses. However, the 100 variation of these PDF sets are not saved by default. Therefore, runcmsgrid_LO.sh is modified.