### PR TITLE
reduce the mll cut in the ZGamma sample from 30 to 4 GeV

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_5f_NLO_FXFX/ZATo2LA01j_5f_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_5f_NLO_FXFX/ZATo2LA01j_5f_NLO_FXFX_run_card.dat
@@ -141,7 +141,7 @@
    0  = drll    ! Min distance between opposite sign lepton pairs
    0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
    0  = mll     ! Min inv. mass of all opposite sign lepton pairs
-  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+   4  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_proc_card.dat
@@ -8,4 +8,4 @@ define lep = e+ mu+ ta+ e- mu- ta-
 generate p p > lep lep a [QCD] @0
 add process p p > lep lep j a [QCD] @1
 
-output ZATo2LA01j_5f_NLO_FXFX -nojpeg
+output ZATo2LA01j_mll4_5f_NLO_FXFX -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_proc_card.dat
@@ -1,0 +1,11 @@
+import model loop_sm-no_b_mass
+
+define p = p b b~
+define j = j b b~
+
+define lep = e+ mu+ ta+ e- mu- ta-
+
+generate p p > lep lep a [QCD] @0
+add process p p > lep lep j a [QCD] @1
+
+output ZATo2LA01j_5f_NLO_FXFX -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_5f_NLO_FXFX/ZATo2LA01j_mll4_5f_NLO_FXFX_run_card.dat
@@ -141,7 +141,7 @@
    0  = drll    ! Min distance between opposite sign lepton pairs
    0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
    0  = mll     ! Min inv. mass of all opposite sign lepton pairs
-  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+   4  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *


### PR DESCRIPTION
In order to estimate the background in the WGamma analysis, we need to reduce the mll_sf cut from 30 to 4 in the ZGamma sample, such that events where an FSR photon takes most of the pt of its mother lepton are included. I have checked that this increases the cross-section of the sample from 75.13 to 76.98 pb, before the matching efficiency.