### PR TITLE
Add WWJ NNLOPS

### DIFF
--- a/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
+++ b/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
@@ -43,32 +43,12 @@ nnlops 1           ! (default 0) If 1, activate NNLOPS
 sudscalevar 1      ! (default 1) scale variation also in Sudakov form factors in minlo
 factsc2min 2       ! value the factorization scale is frozen (needed with minlo)
 
-# the following is for parallel runs (see manual in POWHEG-BOX-V2/Docs/)
-# manyseeds 1
-# parallelstage 1
-# xgriditeration 1
-
 # other settings (mostly for debugging purposes)
 #flg_debug 1        ! store extra event info for debugging
 #storemintupb 1    ! (default 0) if 1 save calls in a file
 
-#storeinfo_rwgt 1   ! store info to allow for reweighting
-
-#rwl_file '-'
-#<initrwgt>
-#<weightgroup name='First-Weights'>
-#<weight id='11'> renscfact=1.0 facscfact=1.0 </weight>
-#<weight id='12'> renscfact=1.0 facscfact=2.0 </weight>
-#<weight id='21'> renscfact=2.0 facscfact=1.0 </weight>
-#<weight id='22'> renscfact=2.0 facscfact=2.0 </weight>
-#<weight id='1H'> renscfact=1.0 facscfact=0.5 </weight>
-#<weight id='H1'> renscfact=0.5 facscfact=1.0 </weight>
-#<weight id='HH'> renscfact=0.5 facscfact=0.5 </weight>
-#</initrwgt>
-
 lhrwgt_id 'st4'
 lhrwgt_descr 'Initial st4 event generation'
-
 
 # other parameters
 #wmasslow 10d0

--- a/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
+++ b/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
@@ -1,0 +1,75 @@
+e+mu- 1
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+lhans1 260400     ! pdf set for hadron 1 ( *must be a 4f set* )
+lhans2 260400     ! pdf set for hadron 2 ( *must be a 4f set* )
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+iseed SEED
+
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1  50000  ! number of calls for initializing the integration grid
+itmx1    1      ! number of iterations for initializing the integration grid
+ncall2  100000  ! number of calls for computing the integral and finding upper bound
+itmx2    1      ! number of iterations for computing the integral and finding upper bound
+foldcsi   1     ! number of folds on csi integration
+foldy     1     ! number of folds on  y  integration
+foldphi   1     ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1      ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0    ! increase upper bound for radiation generation
+
+bornonly  0        ! (default 0) if 1 do Born only
+#testplots 1        ! (default 0, do not) do NLO and PWHG distributions
+
+bornktmin 0.26     ! Generation cut; minimmum kt in underlying born
+facscfact 1        ! default 1
+renscfact 1        ! default 1
+runningscales 0    ! 0 = fixed scale (leave this to 0 when MiNLO is used.
+                   ! All scale settings is taken care of internally)
+
+alphas_from_lhapdf 1 ! Strongly recommended to set this to 1 when using 4f PDFs and/or NNLO pdfs
+
+# MiNLO/NNLOPS flags
+minlo 1            ! (default 0) If 1, use MiNLO
+minlo_nnll 1       ! (default 0) 
+nnlops 1           ! (default 0) If 1, activate NNLOPS
+sudscalevar 1      ! (default 1) scale variation also in Sudakov form factors in minlo
+factsc2min 2       ! value the factorization scale is frozen (needed with minlo)
+
+# the following is for parallel runs (see manual in POWHEG-BOX-V2/Docs/)
+# manyseeds 1
+# parallelstage 1
+# xgriditeration 1
+
+# other settings (mostly for debugging purposes)
+#flg_debug 1        ! store extra event info for debugging
+#storemintupb 1    ! (default 0) if 1 save calls in a file
+
+#storeinfo_rwgt 1   ! store info to allow for reweighting
+
+#rwl_file '-'
+#<initrwgt>
+#<weightgroup name='First-Weights'>
+#<weight id='11'> renscfact=1.0 facscfact=1.0 </weight>
+#<weight id='12'> renscfact=1.0 facscfact=2.0 </weight>
+#<weight id='21'> renscfact=2.0 facscfact=1.0 </weight>
+#<weight id='22'> renscfact=2.0 facscfact=2.0 </weight>
+#<weight id='1H'> renscfact=1.0 facscfact=0.5 </weight>
+#<weight id='H1'> renscfact=0.5 facscfact=1.0 </weight>
+#<weight id='HH'> renscfact=0.5 facscfact=0.5 </weight>
+#</initrwgt>
+
+lhrwgt_id 'st4'
+lhrwgt_descr 'Initial st4 event generation'
+
+
+# other parameters
+#wmasslow 10d0
+#wmasshigh 500d0

--- a/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
+++ b/bin/Powheg/examples/V2/WWJ_NNLOPS_13TeV/WWJ_NNLOPS_13TeV.input
@@ -3,8 +3,8 @@ e+mu- 1
 numevts NEVENTS     ! number of events to be generated
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
-lhans1 260400     ! pdf set for hadron 1 ( *must be a 4f set* )
-lhans2 260400     ! pdf set for hadron 2 ( *must be a 4f set* )
+lhans1 320900     ! pdf set for hadron 1 ( *must be a 4f set* )
+lhans2 320900     ! pdf set for hadron 2 ( *must be a 4f set* )
 ebeam1 6500d0     ! energy of beam 1
 ebeam2 6500d0     ! energy of beam 2
 

--- a/bin/Powheg/patches/rwl_write_weights2_extra.f
+++ b/bin/Powheg/patches/rwl_write_weights2_extra.f
@@ -1,0 +1,1 @@
+      if (flg_nnlops) call rwl_write_weights2_extra(iun,jg)

--- a/bin/Powheg/patches/wwj-weights.patch
+++ b/bin/Powheg/patches/wwj-weights.patch
@@ -1,0 +1,284 @@
+--- ../my_WWJ/POWHEG-BOX/rwl_weightlists.f	2018-09-04 10:13:18.000000001 +0200
++++ POWHEG-BOX/rwl_weightlists.f	2018-09-19 15:51:43.000000001 +0200
+@@ -345,6 +345,10 @@
+      2                 //tmpstr//'</wgt>')
+                endif
+             enddo
++c     If flg_nnlops is set, weights are doubled to include the NNLO corrected ones.
++c     We include here a dummy file. NNLOPS generators can override it to call their own routines
++c     for writing the NNLOPS weights in the event.            
++            include 'rwl_write_weights2_extra.f'
+          enddo
+          call pwhg_io_write(iun,'</rwgt>')
+       else
+--- ../my_WWJ/POWHEG-BOX/WWJ/nnlopsreweight.f	2018-09-04 10:17:03.000000001 +0200
++++ POWHEG-BOX/WWJ/nnlopsreweight.f	2018-09-24 10:06:44.000000001 +0200
+@@ -5,14 +5,15 @@
+       include 'pwhg_rwl.h'
+       include 'wwproj_parameters.h'
+       real *8 nnlops_resc(rwl_num_weights)
+-      integer i 
++      logical computeweight(rwl_num_weights)
++      integer i,j
+       logical, save :: ini = .true. 
+-      character(1000) :: NNLO_phiB(rwl_num_weights),MINLO_phiB(rwl_num_weights)
+       integer :: nnum, nden, nlines  
+       real*8 tmp_hist3(2,nmh3d,maxbins3)
+       character*(200) indexnamesNNLO(nmh3d),indexnamesMiNLO(nmh3d)
+       character(100) :: filename 
+-      integer, parameter :: maxdist = 7 
++      integer, parameter :: maxdist = 7
++      character(1000) :: NNLO_phiB(maxdist),MINLO_phiB(maxdist)
+       real *8 Kfact_dyWW(28,maxdist,maxdist)
+       common/ckfactdyww/Kfact_dyWW
+       character(4) :: murstr,mufstr 
+@@ -20,14 +21,18 @@
+       logical rwl_keypresent
+ 
+ 
+-c      write(*,*) '-------> compute_nnlops_weights', rwl_num_weights  
++      write(*,*) '-------> compute_nnlops_weights', rwl_num_weights  
+       if (ini) then 
+ 
+-         if (maxdist < rwl_num_weights) then 
+-            write(*,*) 'maxdist:       ', maxdist 
+-            write(*,*) 'rwl_num_weights:', rwl_num_weights 
+-            stop 'Increase maxdist to rwl_num_weights '
+-         endif
++         do i = 1,rwl_num_weights 
++            computeweight(i) = .false.
++         enddo
++
++c         if (maxdist < rwl_num_weights) then 
++c            write(*,*) 'maxdist:       ', maxdist 
++c            write(*,*) 'rwl_num_weights:', rwl_num_weights 
++c            stop 'Increase maxdist to rwl_num_weights '
++c         endif
+          
+ 
+ c-----> load arrays for rebinning:
+@@ -48,28 +53,33 @@
+ C     open MINLO and NNLO FILES with distributions differential in phiB
+ C     and store NNLO, MINLO_A, MINLO_B results 
+ C     at the moment we have equal number of numerators and denominators 
+-         nNum = rwl_num_weights 
+-         nden = rwl_num_weights 
++         nNum = maxdist 
++         nDen = maxdist 
++         j = 1
+          
+          do i = 1,rwl_num_weights 
+-         if ( rwl_keypresent(i,'facscfact',muf) .and. 
+-     C           rwl_keypresent(i,'renscfact',mur)) then 
++            if ( rwl_keypresent(i,'facscfact',muf) .and. 
++     C           rwl_keypresent(i,'renscfact',mur)) then
++               if ((muf/mur .lt. 3.0) .and. (muf/mur .gt. 0.3)) then
+ C     set filenames 
+-            write(*,*) 'mur', mur
+-            write(*,*) 'muf', muf
+-            write(murstr,'(F4.2)') mur 
+-            write(mufstr,'(f4.2)') muf 
+-            write(*,*) 'murstr,mufstr',murstr,mufstr
+-            NNLO_phiB(i) =
+-     C           'WW_MATRIX/MATRIX-NNLO-mur'//trim(murstr)//'-muf'//trim(mufstr)//'.top' 
+-            MINLO_phiB(i)=
+-     C           'WW_MINLO/MINLO-mur'//trim(murstr)//'-muf'//trim(mufstr)//'.top' 
+-            write(*,*) 'NNLO_phiB(i)',trim(NNLO_phiB(i))
+-            write(*,*) 'MINLO_phiB(i)',trim(MINLO_phiB(i))
+-         else
+-            stop 'key does not contain factscfact or renscfact' 
+-         endif
+-         
++                  computeweight(i) = .true.
++                  write(*,*) 'mur', mur
++                  write(*,*) 'muf', muf
++                  write(murstr,'(F4.2)') mur 
++                  write(mufstr,'(f4.2)') muf 
++                  write(*,*) 'murstr,mufstr',murstr,mufstr
++                  NNLO_phiB(j) =
++     C                 'WW_MATRIX/MATRIX-NNLO-mur'//trim(murstr)//'-muf'//trim(mufstr)//'.top' 
++                  MINLO_phiB(j)=
++     C                 'WW_MINLO/MINLO-mur'//trim(murstr)//'-muf'//trim(mufstr)//'.top' 
++                  write(*,*) 'NNLO_phiB(i)',trim(NNLO_phiB(j))
++                  write(*,*) 'MINLO_phiB(i)',trim(MINLO_phiB(j))
++                  j = j+1
++c               else
++c               stop 'key does not contain factscfact or renscfact' 
++               endif
++            endif
++            
+ C     NNLO_phiB(i) =
+ C     C      'WW_MATRIX/MATRIX-NNLO-'//rwl_weights_array(i)%id//'.top' 
+ C            MINLO_phiB(i)=
+@@ -108,7 +118,7 @@
+          call search_for_index(indexnamesNNLO,indexnamesMiNLO) !-- values passed in common block
+          
+ c-----> compute overall K-factor and K-factor differential in dy_WW      
+-         call get_overall_kfactor(nNum,rwl_num_weights)
++         call get_overall_kfactor(nNum,nDen)
+ c-----> sets Kfact_dyWW      
+          call get_dyWW_kfactor(Kfact_dyWW) 
+ 
+@@ -126,10 +136,16 @@
+ 
+ 
+ c-----> event analysis:
+-      call compute_rescaling(nNum,rwl_num_weights) !--- we pass everything using common block ('reweighting_common.h')
++      call compute_rescaling(nNum,nDen) !--- we pass everything using common block ('reweighting_common.h')
+ c-----> finally set our rescaling 
++      j = 1
+       do i=1,rwl_num_weights
+-         nnlops_resc(i) = resc(i,i,1)
++         if (computeweight(i) .eqv. .true.) then
++            nnlops_resc(i) = resc(j,j,1)
++            j = j+1
++         else
++            nnlops_resc(i) = -9999999.
++         endif
+       enddo
+       
+ c      write(*,*) 'NNLO_resc', nnlops_resc
+@@ -150,7 +166,8 @@
+       include 'pwhg_bookhist-common.h'
+ c      include 'new-mergedata.h'
+ 
+-      character*(1000) filenames(rwl_num_weights)
++      integer, parameter :: maxdist = 7
++      character*(1000) filenames(maxdist)
+       character*7 string
+       integer not_numerical(4*nmh3d),tmp_not_numerical(4*nmh3d)
+       integer i,ifile,nfiles,nlines,tmpnlines
+@@ -546,7 +563,7 @@
+ 
+       integer i1,i2,ipoly,inum,iden,ibin,i
+       integer nNum,nDen
+-      real*8 numval(1:rwl_num_weights),denval(1:rwl_num_weights)
++      real*8 numval(1:nNum),denval(1:nDen)
+ 
+       overall_kfact=0d0
+       overall_kfactA=0d0
+@@ -599,13 +616,14 @@
+       include 'reweighting_common.h' 
+       include 'pwhg_rwl.h'
+       include 'wwproj_parameters.h'
+-      real *8  Kfact_dyWW(nbin_dyWW,rwl_num_weights,rwl_num_weights)
+-      real *8  sigMINLO_dyWW(nbin_dyWW,rwl_num_weights),sigNNLO_dyWW(nbin_dyWW,rwl_num_weights)
+-      real *8 sum_1D(rwl_num_weights)
++      integer, parameter :: maxdist = 7 
++      real *8  Kfact_dyWW(nbin_dyWW,maxdist,maxdist)
++      real *8  sigMINLO_dyWW(nbin_dyWW,maxdist),sigNNLO_dyWW(nbin_dyWW,maxdist)
++      real *8 sum_1D(maxdist)
+       integer nnum, nden, ibin, i,j,k   
+       
+-      nnum = rwl_num_weights
+-      nden = rwl_num_weights
++      nnum = maxdist
++      nden = maxdist
+       sigNNLO_dyWW = 0d0 
+       do j=1,nbin_dyWW
+          sum_1D = 0d0 
+@@ -679,7 +697,8 @@
+       real*8 xval,xerr
+       real*8 tmpval,tmperr
+ c-----> other variables
+-      real*8 num(rwl_num_weights,rwl_num_weights),den(rwl_num_weights)
++      integer, parameter :: maxdist = 7 
++      real*8 num(maxdist,maxdist),den(maxdist)
+       integer ibin,i,j,k,n
+       logical out_of_range
+ c----->
+@@ -687,21 +706,20 @@
+ c-----> CS functions, coefficients
+       integer iCSm,iCSp,iwgt,ii
+       real*8 funct(1:9,2) !>> CS functions [1603.01620, eq.(2.3)]
+-      real*8 AAval_NNLO(1:9, 1:9, rwl_num_weights)
+-      real*8 AAerr_NNLO(1:9, 1:9, rwl_num_weights)
+-      real*8 AAval_MiNLO_A(1:9, 1:9, rwl_num_weights)
+-      real*8 AAerr_MiNLO_A(1:9, 1:9, rwl_num_weights)
+-      real*8 AAval_MiNLO_B(1:9, 1:9, rwl_num_weights)
+-      real*8 AAerr_MiNLO_B(1:9, 1:9, rwl_num_weights)
++      real*8 AAval_NNLO(1:9, 1:9, maxdist)
++      real*8 AAerr_NNLO(1:9, 1:9, maxdist)
++      real*8 AAval_MiNLO_A(1:9, 1:9, maxdist)
++      real*8 AAerr_MiNLO_A(1:9, 1:9, maxdist)
++      real*8 AAval_MiNLO_B(1:9, 1:9, maxdist)
++      real*8 AAerr_MiNLO_B(1:9, 1:9, maxdist)
+       real*8 val1(1:9,1:9),err1(1:9,1:9)
+       real*8 vala(1:9,1:9),erra(1:9,1:9)
+       real*8 valb(1:9,1:9),errb(1:9,1:9)
+       real*8 get_rwgt,tot
+       real *8 pi 
+       parameter (pi=3.141592653589793238462643383279502884197D0) 
+-      real * 8 num_noCS, den_noCS,resc_noCS(rwl_num_weights,rwl_num_weights,nscen)
+-      real *8 Kfact_dyWW_lcl(rwl_num_weights,rwl_num_weights) 
+-      integer, parameter :: maxdist = 7 
++      real * 8 num_noCS, den_noCS,resc_noCS(maxdist,maxdist,nscen)
++      real *8 Kfact_dyWW_lcl(maxdist,maxdist) 
+       real *8 Kfact_dyWW(28,maxdist,maxdist)
+       common/ckfactdyww/Kfact_dyWW
+       real *8 num_CS,den_CS 
+--- ../my_WWJ/POWHEG-BOX/WWJ/rwl_procdep.f	2018-09-04 10:17:03.000000001 +0200
++++ POWHEG-BOX/WWJ/rwl_procdep.f	2018-09-24 12:19:33.000000001 +0200
+@@ -2,13 +2,19 @@
+       implicit none 
+       include 'pwhg_rwl.h'
+       integer kw,kg,iun
+-
++      real *8 mur,muf
++      logical rwl_keypresent
+ 
+       do kw = 1,rwl_num_weights
+          if(rwl_weights_array(kw)%group == kg) then
+-            call pwhg_io_write(iun,"<weight id='"//
+-     1           rwl_weights_array(kw)%id//'-NNLOPS'//"' >"//
+-     2           rwl_weights_array(kw)%desc//"</weight>")
++            if ( rwl_keypresent(kw,'facscfact',muf) .and. 
++     C           rwl_keypresent(kw,'renscfact',mur)) then 
++               if ((muf/mur .lt. 3.0) .and. (muf/mur .gt. 0.3)) then
++                  call pwhg_io_write(iun,"<weight id='"//
++     1                 rwl_weights_array(kw)%id//'-NNLOPS'//"' >"//
++     2                 rwl_weights_array(kw)%desc//"</weight>")
++               endif
++            endif
+          endif
+       enddo
+       
+@@ -28,10 +34,37 @@
+          weights_new = rwl_weights * nnlops_resc 
+       endif
+       do jw = 1, rwl_num_weights
+-         if(rwl_weights_array(jw)%group == jg) then
++         if((rwl_weights_array(jw)%group == jg) .and. 
++     1        (weights_new(jw) .gt. -999.)) .and. 
++     2        (weights_new(jw) .lt. 999.)) then
+             write(tmpstr,'(E11.5)') weights_new(jw)
+             call pwhg_io_write(iun,tmpstr)
+          endif
+       enddo
++           
++      end
+ 
++      subroutine rwl_write_weights2_extra(iun,jg)
++      implicit none 
++      include 'pwhg_rwl.h'
++      character(len=11) tmpstr
++      integer iun,jg,jw 
++      real *8 nnlops_resc(rwl_num_weights),weights_new(rwl_num_weights) 
++
++C     first compute all rescaling factors at once 
++      if(rwl_weights_array(1)%group == jg) then
++         call compute_nnlops_weights(nnlops_resc)
++         weights_new = rwl_weights * nnlops_resc 
++      endif
++      do jw = 1, rwl_num_weights
++         if((rwl_weights_array(jw)%group == jg) .and. 
++     1        (weights_new(jw) .gt. -999.) .and. 
++     2        (weights_new(jw) .lt. 999.)) then
++            write(tmpstr,'(E11.5)') weights_new(jw)
++            call pwhg_io_write(iun,"<wgt id='"
++     1           //rwl_weights_array(jw)%id//'-NNLOPS'//"'>"
++     2           //tmpstr//'</wgt>')
++         endif
++      enddo
++              
+       end

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -322,7 +322,7 @@ is5FlavorScheme=1
 defaultPDF=306000
 
 
-if [[ "$process" == "ST_tch_4f" ]] || [[ "$process" == "bbH" ]] || [[ "$process" == "Wbb_dec" ]] || [[ "$process" == "Wbbj" ]]; then
+if [[ "$process" == "ST_tch_4f" ]] || [[ "$process" == "bbH" ]] || [[ "$process" == "Wbb_dec" ]] || [[ "$process" == "Wbbj" ]] || [[ "$process" == "WWJ" ]]; then
     # 4F
     is5FlavorScheme=0
     defaultPDF=320900

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -404,6 +404,10 @@ fi
 if [ "$process" = "ZZ" ]; then
     patch -l -p0 -i ${WORKDIR}/patches/zz_m4lcut.patch
 fi
+if [ "$process" = "WWJ" ]; then
+    patch -l -p0 -i ${WORKDIR}/patches/wwj-weights.patch
+    cp ${WORKDIR}/patches/rwl_write_weights2_extra.f POWHEG-BOX/$process/
+fi
 
 
 sed -i -e "s#500#1200#g"  POWHEG-BOX/include/pwhg_rwl.h
@@ -566,7 +570,7 @@ fi
 
 if [ "$process" = "WWJ" ]; then
   cp Makefile Makefile.orig
-  cat Makefile.orig |  sed -e "s#FASTJET_CONFIG=.\+#FASTJET_CONFIG=$(scram tool info fastjet | grep BASE | cut -d "=" -f2)/bin/fastjet-config#g" | sed -e "s#cs_angles.o#cs_angles.o fastjetfortran.o observables.o pwhg_bookhist-multi-new.o#g" | sed -e "s#\#\ FASTJET_CONFIG#FASTJET_CONFIG#g" | sed -e "s#\#\ LIBSFASTJET#LIBSFASTJET#g" | sed -e "s#\#\ FJCXXFLAGS#FJCXXFLAGS#g" > Makefile
+  cat Makefile.orig |  sed -e "s#FASTJET_CONFIG=.\+#FASTJET_CONFIG=$(scram tool info fastjet | grep BASE | cut -d "=" -f2)/bin/fastjet-config#g" | sed -e "s#cs_angles.o#cs_angles.o fastjetfortran.o observables.o pwhg_bookhist-multi-new.o#g" | sed -e "s#\#\ FASTJET_CONFIG#FASTJET_CONFIG#g" | sed -e "s#\#\ LIBSFASTJET#LIBSFASTJET#g" | sed -e "s#\#\ FJCXXFLAGS#FJCXXFLAGS#g" | sed -e "s#rwl_write_weights_extra.f#rwl_write_weights_extra.f\ rwl_write_weights2_extra.f#g"> Makefile
 fi
 
 if [ "$process" = "gg_H_2HDM" ] || [ "$process" = "gg_H_MSSM" ]; then
@@ -955,10 +959,12 @@ fi
 
 sed -i 's/pwggrid.dat ]]/pwggrid.dat ]] || [ -e ${WORKDIR}\/pwggrid-0001.dat ]/g' runcmsgrid.sh
 
-#if [ "$process" = "HJ" ]; then
-#  cat runcmsgrid.sh  | gawk '/produceWeightsNNLO/{gsub(/false/, \"true\")};{print}' > runcmsgrid_tmp.sh
-#  mv runcmsgrid_tmp.sh runcmsgrid.sh
-#fi  
+if [ "$process" = "WWJ" ]; then
+   cp -p ${WORKDIR}/$folderName/POWHEG-BOX/$process/testrun-nnlops/binvalues-WW.top .
+   cp -r ${WORKDIR}/$folderName/POWHEG-BOX/$process/testrun-nnlops/WW_MATRIX .
+   cp -r ${WORKDIR}/$folderName/POWHEG-BOX/$process/testrun-nnlops/WW_MINLO .
+   keepTop='1'
+fi  
 
 sed -i s/SCRAM_ARCH_VERSION_REPLACE/${SCRAM_ARCH}/g runcmsgrid.sh
 sed -i s/CMSSW_VERSION_REPLACE/${CMSSW_VERSION}/g runcmsgrid.sh

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -362,7 +362,7 @@ if [[ -s ./JHUGen.input ]]; then
 fi
 
 ### retrieve the powheg source tar ball
-export POWHEGSRC=powhegboxV2_rev3511_date20180410.tar.gz
+export POWHEGSRC=powhegboxV2_rev3592_date20180904.tar.gz
 
 if [ "$process" = "b_bbar_4l" ] || [ "$process" = "HWJ_ew" ] || [ "$process" = "HW_ew" ] || [ "$process" = "HZJ_ew" ] || [ "$process" = "HZ_ew" ]; then 
   export POWHEGSRC=powhegboxRES_rev3478_date20180122.tar.gz 
@@ -444,7 +444,7 @@ if [ `echo ${POWHEGSRC} | cut -d "_" -f 1` = "powhegboxV1" ]; then
    BOOK_HISTO="pwhg_bookhist.o"
 fi 
 
-if [ "$process" = "gg_H" ] || [ "$process" = "ggHH" ]; then
+if [ "$process" = "gg_H" ] || [ "$process" = "ggHH" ] || [ "$process" = "WWJ" ]; then
    BOOK_HISTO=""
    echo "Process using pwhg_bookhist-multi-new"
 fi
@@ -533,8 +533,6 @@ echo "ANALYSIS=none " >> tmpfile
 
 if [ "$process" = "Wgamma" ]; then
   echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-dummy.o uti.o " >> tmpfile
-#elif [ "$process" = "HW_ew" ] || [ "$process" = "HWJ_ew" ]; then 
-#  echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-HWnJ_res.o pwhg_analysis_paper-HWnJ_res.o observables.o multi_plot.o " >> tmpfile
 else
   echo "PWHGANAL=$BOOK_HISTO pwhg_analysis-dummy.o " >> tmpfile
 fi
@@ -565,6 +563,12 @@ if [ $jhugen = 1 ]; then
 
   cd ..
 fi
+
+if [ "$process" = "WWJ" ]; then
+  cp Makefile Makefile.orig
+  cat Makefile.orig |  sed -e "s#FASTJET_CONFIG=.\+#FASTJET_CONFIG=$(scram tool info fastjet | grep BASE | cut -d "=" -f2)/bin/fastjet-config#g" | sed -e "s#cs_angles.o#cs_angles.o fastjetfortran.o observables.o pwhg_bookhist-multi-new.o#g" | sed -e "s#\#\ FASTJET_CONFIG#FASTJET_CONFIG#g" | sed -e "s#\#\ LIBSFASTJET#LIBSFASTJET#g" | sed -e "s#\#\ FJCXXFLAGS#FJCXXFLAGS#g" > Makefile
+fi
+
 if [ "$process" = "gg_H_2HDM" ] || [ "$process" = "gg_H_MSSM" ]; then
   echo "Adding CHAPLIN 1.2 library"
   if [ ! -f chaplin-1.2.tar ]; then

--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -117,6 +117,12 @@ if [[ -d ${WORKDIR}/obj-gfortran ]]; then
     ln -s ${WORKDIR}/obj-gfortran .
     cp -p ${WORKDIR}/pwg*.dat .
 fi
+### For the bb4l process
+if [[ -d ${WORKDIR}/WW_MATRIX ]]; then
+    ln -s ${WORKDIR}/WW_MATRIX .
+    ln -s ${WORKDIR}/WW_MINLO .
+    cp -p ${WORKDIR}/binvalues-WW.top .
+fi
 
 if [[ ! -e ${card} ]]; then
  fail_exit "powheg.input not found!"


### PR DESCRIPTION
Several modifications:

- add missing libraries (e.g. fastjet)
- fix bug with reweighting format used in CMS
- as suggested by @intrepid42, run NNLOPS only for the desired weights (7 out of godzillions) -> this is the heaviest change

@govoni @bendavid : now WWJ NNLOPS is immediately available for testing
