### PR TITLE
Patch to fix makefile for collier in mg260

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0022-fix-makefile-to-use-collier.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0022-fix-makefile-to-use-collier.patch
@@ -1,0 +1,12 @@
+--- a/Template/loop_material/StandAlone/SubProcesses/makefile	2017-08-17 00:25:24.000000001 +0200
++++ b/Template/loop_material/StandAlone/SubProcesses/makefile	2018-09-26 13:43:57.000000001 +0200
+@@ -94,6 +94,9 @@
+ $(DOTO) : $(DOTF) $(POLYNOMIAL) $(OLP_POLYNOMIAL)
+ 	$(FC) $(FFLAGS) -c $< -o $@ $(LOOP_INCLUDE)
+ 
++$(DOTO) : $(DOTF)
++	$(FC) $(FFLAGS) -c $< -o $@ $(LOOP_INCLUDE)
++
+ $(OLP): $(OLP_PROCESS) $(LIBS)
+ 	$(FC) -shared $(OLP_PROCESS) -o libMadLoop.$(dylibext) $(LINKLIBS)
+ 


### PR DESCRIPTION
The patch fixes the problem related to loop induced processes with the collier library discussed in this thread:
https://hypernews.cern.ch/HyperNews/CMS/get/generators/4099.html
The solution is the one proposed here:
https://answers.launchpad.net/mg5amcnlo/+question/488071
This problem is there only for mg260, mg261 already contains the same fix by the authors.