### PR TITLE
change the lepton pt cut to 0 in the ZA low mll sample

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX_proc_card.dat
@@ -8,4 +8,4 @@ define lep = e+ mu+ ta+ e- mu- ta-
 generate p p > lep lep a [QCD] @0
 add process p p > lep lep j a [QCD] @1
 
-output ZATo2LA01j_mll4_5f_NLO_FXFX -nojpeg
+output ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/pre2017/13TeV/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX/ZATo2LA01j_mll4_ptl0_5f_NLO_FXFX_run_card.dat
@@ -136,7 +136,7 @@
 # Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
 # (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
 #***********************************************************************
-   15  = ptl     ! Min lepton transverse momentum
+   0  = ptl     ! Min lepton transverse momentum
   -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
    0  = drll    ! Min distance between opposite sign lepton pairs
    0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs


### PR DESCRIPTION
Following up on https://github.com/cms-sw/genproductions/pull/1883, the lepton pt should also be reduced in addition to the mll cut. When the lepton pt cut is changed from 15 GeV to 0, the cross-section before matching increases from 76.98 pb to 146.6 pb