### PR TITLE
MonoZ pythia-based signals

### DIFF
--- a/python/ThirteenTeV/MonoZ/add/ADDmonoZ_MD_1_d_2_TuneCP5_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/MonoZ/add/ADDmonoZ_MD_1_d_2_TuneCP5_13TeV_pythia8_cfi.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+    pythia8CommonSettingsBlock,
+    pythia8CP5SettingsBlock,
+    pythia8PSweightsSettingsBlock,
+    processParameters = cms.vstring(
+    'ExtraDimensionsLED:ffbar2GZ = on',
+    'ExtraDimensionsLED:t = 0.5',
+    'ExtraDimensionsLED:n = 2',         ####
+    'ExtraDimensionsLED:MD = 1000.',    ####
+    'ExtraDimensionsLED:LambdaT = 1000.',
+    '5000039:m0 = 1200.',
+    '5000039:mWidth = 1000.',
+    '5000039:mMin = 1.',
+    '5000039:mMax = 13990.',
+    '23:onMode=off',
+    '23:mMin=50',
+    '23:onIfAny=11 13',
+    'PhaseSpace:pTHatMin = 30.'
+    ),
+    parameterSets = cms.vstring('pythia8CommonSettings',
+                                'pythia8CP5Settings',
+                                'processParameters',)
+    )
+                         )
+
+
+
+

--- a/python/ThirteenTeV/MonoZ/add/ADDmonoZ_template.py
+++ b/python/ThirteenTeV/MonoZ/add/ADDmonoZ_template.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+    pythia8CommonSettingsBlock,
+    pythia8CP5SettingsBlock,
+    pythia8PSweightsSettingsBlock,
+    processParameters = cms.vstring(
+    'ExtraDimensionsLED:ffbar2GZ = on',
+    'ExtraDimensionsLED:t = 0.5',
+    'ExtraDimensionsLED:n = @N',         ####
+    'ExtraDimensionsLED:MD = @MD',    ####
+    'ExtraDimensionsLED:LambdaT = 1000.',
+    '5000039:m0 = 1200.',
+    '5000039:mWidth = 1000.',
+    '5000039:mMin = 1.',
+    '5000039:mMax = 13990.',
+    '23:onMode=off',
+    '23:mMin=50',
+    '23:onIfAny=11 13',
+    'PhaseSpace:pTHatMin = 30.'
+    ),
+    parameterSets = cms.vstring('pythia8CommonSettings',
+                                'pythia8CP5Settings',
+                                'processParameters',)
+    )
+                         )
+
+
+
+

--- a/python/ThirteenTeV/MonoZ/add/make_cards.sh
+++ b/python/ThirteenTeV/MonoZ/add/make_cards.sh
@@ -1,0 +1,9 @@
+TEMPLATE=ADDmonoZ_template.py
+for MD in 1 2 3; do
+    for N in $(seq 2 1 8); do
+        NAME="ADDmonoZ_MD_${MD}_d_${N}_TuneCP5_13TeV_pythia8_cfi.py"
+        cp $TEMPLATE $NAME
+        sed -i "s|@N|${N}|g" $NAME
+        sed -i "s|@MD|$((1000*${MD})).|g" $NAME
+    done
+done

--- a/python/ThirteenTeV/MonoZ/unparticle/Unpart_ZToEEAndMuMu_SU_0_dU_1p01_LU_15_TuneCP5_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/MonoZ/unparticle/Unpart_ZToEEAndMuMu_SU_0_dU_1p01_LU_15_TuneCP5_13TeV_pythia8_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+                                     pythia8CommonSettingsBlock,
+                                     pythia8CP5SettingsBlock,
+                                     pythia8PSweightsSettingsBlock,
+                                     processParameters = cms.vstring(
+
+                                             'ExtraDimensionsUnpart:ffbar2UZ = on',
+
+
+                                             'ExtraDimensionsUnpart:spinU = 0',
+                                             'ExtraDimensionsUnpart:dU = 1.01',
+                                             'ExtraDimensionsUnpart:LambdaU = 15000.000000',
+                                             'ExtraDimensionsUnpart:lambda = 1.0',
+                                             'ExtraDimensionsUnpart:CutOffmode = 0',
+                                             '5000039:m0 = 500.',
+                                             '5000039:mWidth = 1000.',
+                                             '5000039:mMin = 1.',
+                                             '5000039:mMax = 13990.',
+                                             'PhaseSpace:sameForSecond = off',
+                                             'PhaseSpace:pTHatMin = 30.',
+                                             '23:onMode=off',
+                                             '23:mMin=50',
+					     '23:onIfAny=11 13'
+                                             ),
+                                     parameterSets = cms.vstring('pythia8CommonSettings',
+                                             'pythia8CP5Settings',
+                                             'processParameters',
+                                             'pythia8PSweightsSettings')
+                                 )
+                        )

--- a/python/ThirteenTeV/MonoZ/unparticle/Unpart_ZToEEAndMuMu_template.py
+++ b/python/ThirteenTeV/MonoZ/unparticle/Unpart_ZToEEAndMuMu_template.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+                                     pythia8CommonSettingsBlock,
+                                     pythia8CP5SettingsBlock,
+                                     pythia8PSweightsSettingsBlock,
+                                     processParameters = cms.vstring(
+
+                                             'ExtraDimensionsUnpart:ffbar2UZ = on',
+
+
+                                             'ExtraDimensionsUnpart:spinU = 0',
+                                             'ExtraDimensionsUnpart:dU = @DU',
+                                             'ExtraDimensionsUnpart:LambdaU = 15000.000000',
+                                             'ExtraDimensionsUnpart:lambda = 1.0',
+                                             'ExtraDimensionsUnpart:CutOffmode = 0',
+                                             '5000039:m0 = 500.',
+                                             '5000039:mWidth = 1000.',
+                                             '5000039:mMin = 1.',
+                                             '5000039:mMax = 13990.',
+                                             'PhaseSpace:sameForSecond = off',
+                                             'PhaseSpace:pTHatMin = 30.',
+                                             '23:onMode=off',
+                                             '23:mMin=50',
+					     '23:onIfAny=11 13'
+                                             ),
+                                     parameterSets = cms.vstring('pythia8CommonSettings',
+                                             'pythia8CP5Settings',
+                                             'processParameters',
+                                             'pythia8PSweightsSettings')
+                                 )
+                        )

--- a/python/ThirteenTeV/MonoZ/unparticle/make_cards.sh
+++ b/python/ThirteenTeV/MonoZ/unparticle/make_cards.sh
@@ -1,0 +1,6 @@
+TEMPLATE=Unpart_ZToEEAndMuMu_template.py
+for DU in 1.01 1.02 1.04 1.06 1.09 1.10 1.20 1.30 1.40 1.50 1.60 1.70 1.80 1.90 2.00 2.20; do
+    NAME="Unpart_ZToEEAndMuMu_SU_0_dU_$(echo $DU | sed 's|\.|p|')_LU_15_TuneCP5_13TeV_pythia8_cff.py"
+    cp $TEMPLATE $NAME
+    sed -i "s|@DU|${DU}|g" $NAME
+done


### PR DESCRIPTION
Cards for the Mono-Z ADD and unparticle signals. I committed one fragment each and scripts to generate all points. The main difference to the old cards is that they were updated to use CP5. I have checked that I do not see any events with negative weights.