### PR TITLE
[B2G Dihiggs] the CP2 python configuration file for X->HH->4b

### DIFF
--- a/python/ThirteenTeV/B2G/dihiggs/pythia8_hadronizer_HbbHbb_cff.py
+++ b/python/ThirteenTeV/B2G/dihiggs/pythia8_hadronizer_HbbHbb_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+                             pythia8CommonSettingsBlock,
+                             pythia8CP2SettingsBlock,
+                             processParameters = cms.vstring(
+                                 'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+                                 '25:m0 = 125.0',
+                                 '25:onMode = off',
+                                 '25:onIfMatch = 5 -5'
+                             ),
+                             parameterSets = cms.vstring('pythia8CommonSettings',
+                                                         'pythia8CP2Settings',
+                                                         'processParameters'
+                                                     )
+                         )
+                     )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Since in the dihiggs production, we are using NNPDF 3.1 LO as our default PDF set, we will use CP2 tunings in pythia. In addition, we want to re-use the inclusive gridpacks for various Higgs decay modes. Therefore, we decay Higgs only via Pythia (not in madgraph).
In this configuration file, both Higgs are forced to decay to bb.