### PR TITLE
gridpack_generation.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -760,7 +760,7 @@ cp $CARDSDIR/* InputCards
 
 EXTRA_TAR_ARGS=""
 if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
-    EXTRA_TAR_ARGS="${name}_externaltarball.dat header_for_madspin.txt"
+    EXTRA_TAR_ARGS="${name}_externaltarball.dat header_for_madspin.txt external_tarball"
 fi
 XZ_OPT="$XZ_OPT" tar -cJpsf ${PRODHOME}/${name}_${scram_arch}_${cmssw_version}_tarball.tar.xz mgbasedir process runcmsgrid.sh gridpack_generation*.log InputCards $EXTRA_TAR_ARGS
 


### PR DESCRIPTION
Added external_tarball to line 763, required for single top t-channel 4FS gridpack production