### PR TITLE
[B2G Dihiggs] add HH->2b2W python file

### DIFF
--- a/python/ThirteenTeV/B2G/dihiggs/pythia8_hadronizer_HWWHbb_cff.py
+++ b/python/ThirteenTeV/B2G/dihiggs/pythia8_hadronizer_HWWHbb_cff.py
@@ -13,9 +13,16 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                              pythia8CP2SettingsBlock,
                              processParameters = cms.vstring(
                                  'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+                                 '24:mMin = 0.05',                  
+                                 '24:onMode = on',                 
                                  '25:m0 = 125.0',
                                  '25:onMode = off',
                                  '25:onIfMatch = 5 -5'
+                                 '25:onIfMatch = 24 -24',           # turn ON H->WW
+                                 'ResonanceDecayFilter:filter = on',
+                                 'ResonanceDecayFilter:exclusive = on', #off: require at least the specified number of daughters, on: require exactly the specified number of daughters
+                                 'ResonanceDecayFilter:mothers = 25', #list of mothers not specified -> count all particles in hard process+resonance decays (better to avoid specifying mothers when including leptons from the lhe in counting, since intermediate resonances are not gauranteed to appear in general
+                                 'ResonanceDecayFilter:daughters = 5,5,24,-24'
                                  ),
                              parameterSets = cms.vstring('pythia8CommonSettings',
                                                          'pythia8CP2Settings',


### PR DESCRIPTION
1) small changes in HH->4b python file (indentation)
2) Add HH->2b2W (inclusive W decays) python file 

Both are with CP2 Tunes since we are using NNPDF 3.1 LOs and both will share the same inclusive gridpacks.