### PR TITLE
Correct bug in request_fragment_check when checking Fall18 cmssw version

### DIFF
--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -260,8 +260,9 @@ for num in range(0,len(prepid)):
             if int(os.popen('grep -c "from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *" '+pi).read()) != 1 :
                 print "* [WARNING] No parton shower weights configuration in the fragment. In the Fall18 campaign, we recommend to include Parton Shower weights"
             if int(os.popen('grep -c "from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *" '+pi).read()) == 1 :
-                if '10_2_3' not in cmssw :
-                    print "* [ERROR] PS weights in config but CMSSW version is not 10_2_3 - please check!"	    
+                cmssw_version    = int(re.search("_[0-9]?[0-9]_[0-9]?[0-9]_[0-9]?[0-9]",cmssw).group().replace('_',''))
+                if cmssw_version < int('10_2_3'.replace('_','')) :
+                    print "* [ERROR] PS weights in config but CMSSW version is preavious 10_2_3 - please check!"	    
                 psweightscheck.append(int(os.popen('grep -c "from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *" '+pi).read()))
                 psweightscheck.append(int(os.popen('grep -c "pythia8PSweightsSettingsBlock," '+pi).read()))
                 psweightscheck.append(int(os.popen('grep -c "pythia8PSweightsSettings" '+pi).read()))

--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -262,7 +262,7 @@ for num in range(0,len(prepid)):
             if int(os.popen('grep -c "from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *" '+pi).read()) == 1 :
                 cmssw_version    = int(re.search("_[0-9]?[0-9]_[0-9]?[0-9]_[0-9]?[0-9]",cmssw).group().replace('_',''))
                 if cmssw_version < int('10_2_3'.replace('_','')) :
-                    print "* [ERROR] PS weights in config but CMSSW version is preavious 10_2_3 - please check!"	    
+                    print "* [ERROR] PS weights in config but CMSSW version is previous 10_2_3 - please check!"	    
                 psweightscheck.append(int(os.popen('grep -c "from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *" '+pi).read()))
                 psweightscheck.append(int(os.popen('grep -c "pythia8PSweightsSettingsBlock," '+pi).read()))
                 psweightscheck.append(int(os.popen('grep -c "pythia8PSweightsSettings" '+pi).read()))


### PR DESCRIPTION
Dear @efeyazgan @qliphy , I've found this error while testing with `request_fragment_check.py` some Fall18 requests that use **CMSSW_10_2_6**:

```
[ERROR] PS weights in config but CMSSW version is not 10_2_3 - please check!
[OK] Parton shower weight configuration probably OK in the fragment
```
I fix the script in order to print the error only if the CMSSW version in less than 10_2_3
