### PR TITLE
update POWHEG Wgamma fold parameters in order to reduce the number of negative weights

### DIFF
--- a/bin/Powheg/production/pre2017/13TeV/Wgamma/WmToLNu.input
+++ b/bin/Powheg/production/pre2017/13TeV/Wgamma/WmToLNu.input
@@ -20,9 +20,9 @@ itmx1   5      ! number of iterations for initializing the integration grid
 ncall2 100000  ! number of calls for computing the integral and finding upper bound
 itmx2   5      ! number of iterations for computing the integral and finding upper bound
 
-foldcsi   1     ! number of folds on csi integration
-foldy     1     ! number of folds on y integration
-foldphi   1     ! number of folds on phi integration
+foldcsi   2     ! number of folds on csi integration
+foldy     5     ! number of folds on y integration
+foldphi   2     ! number of folds on phi integration
 nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1      ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/Wgamma/WpToLNu.input
+++ b/bin/Powheg/production/pre2017/13TeV/Wgamma/WpToLNu.input
@@ -20,9 +20,9 @@ itmx1   5      ! number of iterations for initializing the integration grid
 ncall2 100000  ! number of calls for computing the integral and finding upper bound
 itmx2   5      ! number of iterations for computing the integral and finding upper bound
 
-foldcsi   1     ! number of folds on csi integration
-foldy     1     ! number of folds on y integration
-foldphi   1     ! number of folds on phi integration
+foldcsi   2     ! number of folds on csi integration
+foldy     5     ! number of folds on y integration
+foldphi   2     ! number of folds on phi integration
 nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1      ! <= 100, number of y subdivision when computing the upper bounds


### PR DESCRIPTION
We noticed that with the current cards, we get 23% negative weights, which was higher than what we expected with POWHEG. We asked the POWHEG about this, and they suggested that we can increase the parameters foldcsi, foldy, and foldphi in order to decrease the number of negative weights:

"In the default example they are set to

foldcsi   1     ! number of folds on csi integration
foldy     1     ! number of folds on y integration
foldphi   1     ! number of folds on phi integration

but they can be increased to (~6% negative weights)

foldcsi   2     ! number of folds on csi integration
foldy     5     ! number of folds on y integration
foldphi   2     ! number of folds on phi integration

or (~1% negative weights)

foldcsi   5     ! number of folds on csi integration
foldy     10     ! number of folds on y integration
foldphi   5     ! number of folds on phi integration
"

I have tried the 1% negative weight settings, but I could successfully produce a gridpack with them (increasing the fold parameters also increases the computation time).