### PR TITLE
parton shower weights for 2018 requests added

### DIFF
--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP2_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP2_PSweights_2018.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0', 
+            '25:onMode = off',
+            '25:onIfMatch = 24 -24',           # turn ON H->WW
+            '24:mMin = 0.05',                  #  
+            '24:onMode = off',                 # turn OFF all W decays
+            '24:onIfAny = 11 13 15 12 14 16'   # turn ON W->lnu
+
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP2_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP2_PSweights_2018.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0', 
+            '23:mMin = 0.05',                 # Solve problem with mZ cut
+            '25:onMode = off',
+            '25:onIfAll = 23 23',           # turn ON H->ZZ
+            '23:onMode = off',                # turn OFF all Z decays
+            '23:onIfAny = 11 13 15'           # turn ON Z->ll
+
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP2_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP2_PSweights_2018.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP2_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP2_PSweights_2018.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP2_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP2_PSweights_2018.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 15 -15'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
For 2018 samples, GEN has been asking people to incorporate parton shower weights, which requires a different hadronization fragment for the 2018 requests