### PR TITLE
add patch for fixing rwgt name

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0023-fix-rwgt-name.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0023-fix-rwgt-name.patch
@@ -1,0 +1,11 @@
+--- a/madgraph/interface/reweight_interface.py	
++++ b/madgraph/interface/reweight_interface.py	
+@@ -467,6 +467,8 @@
+         if not self.has_standalone_dir:
+             if self.rwgt_dir and os.path.exists(pjoin(self.rwgt_dir,'rw_me','rwgt.pkl')):
+                 self.load_from_pickle()
++                if opts['rwgt_name']:
++                    self.options['rwgt_name'] = opts['rwgt_name']
+                 if not self.rwgt_dir:
+                     self.me_dir = self.rwgt_dir
+                 self.load_module()       # load the fortran information from the f2py module


### PR DESCRIPTION
This PR is to make reweight's name show its meaning.
(e.g)

[before]
\<weightgroup name='mg_reweighting'>
\<weight id='rwgt_1'>set param_card dim6 16 1.0 # orig: 0.0
\</weight>

[after]
\<weightgroup name='mg_reweighting'>
\<weight id='ctg_p1'>set param_card dim6 16 1.0 # orig: 0.0
\</weight>
