### PR TITLE
fix reweighting in NLO gridpack run script

### DIFF
--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -77,6 +77,11 @@ if [ -f ./Cards/madspin_card.dat ] ;then
   domadspin=1
 fi
 
+doreweighting=0
+if [ -f ./Cards/reweight_card.dat ]; then
+    doreweighting=1
+fi
+
 runname=cmsgrid
 
 
@@ -92,7 +97,9 @@ if [ ! -e $LHEWORKDIR/header_for_madspin.txt ]; then
       runlabel=${runname}_decayed_1
     fi
 
-    if [ -f ./Cards/.reweight_card.dat ] ;then
+    if [ "$doreweighting" -gt "0" ] ; then 
+        #when REWEIGHT=OFF is applied, mg5_aMC moves reweight_card.dat to .reweight_card.dat
+        mv ./Cards/.reweight_card.dat ./Cards/reweight_card.dat
         rwgt_dir="$LHEWORKDIR/process/rwgt"
         export PYTHONPATH=$rwgt_dir:$PYTHONPATH
         echo "0" | ./bin/aMCatNLO --debug reweight $runname

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -54,8 +54,8 @@ echo "lhapdf = $LHAPDFCONFIG" >> ./Cards/amcatnlo_configuration.txt
 echo "run_mode = 2" >> ./Cards/amcatnlo_configuration.txt
 echo "nb_core = $ncpu" >> ./Cards/amcatnlo_configuration.txt
 
-echo "done" > runscript.dat
-echo "reweight=OFF" >> runscript.dat
+echo "reweight=OFF" > runscript.dat
+echo "done" >> runscript.dat
 echo "set nevents $nevt" >> runscript.dat
 echo "set iseed $rnum" >> runscript.dat
 
@@ -92,7 +92,7 @@ if [ ! -e $LHEWORKDIR/header_for_madspin.txt ]; then
       runlabel=${runname}_decayed_1
     fi
 
-    if [ -f ./Cards/reweight_card.dat ] ;then
+    if [ -f ./Cards/.reweight_card.dat ] ;then
         rwgt_dir="$LHEWORKDIR/process/rwgt"
         export PYTHONPATH=$rwgt_dir:$PYTHONPATH
         echo "0" | ./bin/aMCatNLO --debug reweight $runname


### PR DESCRIPTION
Currently, the reweighting is done twice when the NLO gridpack script is run. The line `echo "reweight=OFF" >> runscript.dat` has no effect because it is after the first `done`. When `reweight=OFF` is applied correctly, `reweight_card.dat` is moved to `.reweight_card.dat`, so the if statement `if [ -f ./Cards/reweight_card.dat ] ;then` needed to be changed.