### PR TITLE
Added fragment file for PowhegBox HZJ production of ZH->4b

### DIFF
--- a/python/ThirteenTeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.py
+++ b/python/ThirteenTeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/2017/13TeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic.input
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-                                     args = cms.vstring('/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.tgz'),
+                                     args = cms.vstring('/afs/cern.ch/user/p/pbryant/public/HZJ_slc6_amd64_gcc630_CMSSW_9_3_8_HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.tgz'),
                                      nEvents = cms.untracked.uint32(5000),
                                      numberOfParameters = cms.uint32(1),
                                      outputFile = cms.string('cmsgrid_final.lhe'),


### PR DESCRIPTION
This new fragment file applies a filter to the external LHE producer to select Z->bb. A tarball has been successfully created and tested locally. The tarball can be found here:
/afs/cern.ch/user/p/pbryant/public/HZJ_slc6_amd64_gcc630_CMSSW_9_3_8_HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.tgz
 It uses the existing Powheg input card:
bin/Powheg/production/2017/13TeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic.input 
