### PR TITLE
Add NoPSWeights version of Hadronizer_TuneCP5_13TeV_aMCatNLO_0p...

### DIFF
--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_NoPSweights_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8_NoPSweights_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'TimeShower:nPartonsInBorn = 0', #number of coloured particles (before resonance decays) in born matrix element
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)
+


### PR DESCRIPTION
Adds a version of Hadronizer_TuneCP5_13TeV_aMCatNLO_0p_LHE_pythia8 with no parton shower weights (the _PSWeights_cff.py and _cff.py versions are identical, and both have PS weights imported...). This prevents this hadronizer from crashing in CMSSW_9_3_13. 