### PR TITLE
add 2017 POWHEG WGamma cards

### DIFF
--- a/bin/Powheg/production/2017/13TeV/Wgamma/WmToLNu.input
+++ b/bin/Powheg/production/2017/13TeV/Wgamma/WmToLNu.input
@@ -1,0 +1,42 @@
+idvecbos -24   ! PDG code for vector boson to be produced ( W+:24 W-:-24)
+vdecaymode 2  ! (1:electronic decay, 2: muonic decay, 3: tauonic decay)
+generate_e_mu_tau 3 
+
+numevts NEVENTS ! number of events to be generated
+ih1   1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0  ! energy of beam 1
+ebeam2 6500d0  ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1  306000 ! pdf set for hadron 1 (LHA numbering)
+lhans2  306000 ! pdf set for hadron 2 (LHA numbering)
+ 
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present (<> 1 regenerate)
+ 
+ncall1 30000   ! number of calls for initializing the integration grid
+itmx1   5      ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2   5      ! number of iterations for computing the integral and finding upper bound
+
+foldcsi   2     ! number of folds on csi integration
+foldy     5     ! number of folds on y integration
+foldphi   2     ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1      ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0    ! increase upper bound for radiation generation
+bornktmin  1d0       ! (default 0d0) generation cut. Minimum kt in underlying Born
+
+! process dependent settings
+minlo 1              ! (default=1) if 0 do not use MiNLO  
+phspseparation 0.5d0 ! (default=0.5d0) weight for phase space dual-channel sampling 
+kt2minqed 0.8d0      ! (default=0.8d0) kt2_rad_min for photon radiation from leptons 
+modept2gamlep 0      ! (default=0) pt_rel definition in setlocalscales 
+
+bornonly   0      ! (default 0) if 1 do Born only
+withdamp    1     ! (default 0, do not use) use Born-zero damping factor
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+ 
+iseed SEED     ! initialize random number sequence

--- a/bin/Powheg/production/2017/13TeV/Wgamma/WpToLNu.input
+++ b/bin/Powheg/production/2017/13TeV/Wgamma/WpToLNu.input
@@ -1,0 +1,42 @@
+idvecbos 24   ! PDG code for vector boson to be produced ( W+:24 W-:-24)
+vdecaymode 2  ! (1:electronic decay, 2: muonic decay, 3: tauonic decay)
+generate_e_mu_tau 3
+
+numevts NEVENTS ! number of events to be generated
+ih1   1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0  ! energy of beam 1
+ebeam2 6500d0  ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1  306000 ! pdf set for hadron 1 (LHA numbering)
+lhans2  306000 ! pdf set for hadron 2 (LHA numbering)
+ 
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present (<> 1 regenerate)
+ 
+ncall1 30000   ! number of calls for initializing the integration grid
+itmx1   5      ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2   5      ! number of iterations for computing the integral and finding upper bound
+
+foldcsi   2     ! number of folds on csi integration
+foldy     5     ! number of folds on y integration
+foldphi   2     ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1      ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1      ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0    ! increase upper bound for radiation generation
+bornktmin  1d0       ! (default 0d0) generation cut. Minimum kt in underlying Born
+
+! process dependent settings
+minlo 1              ! (default=1) if 0 do not use MiNLO  
+phspseparation 0.5d0 ! (default=0.5d0) weight for phase space dual-channel sampling 
+kt2minqed 0.8d0      ! (default=0.8d0) kt2_rad_min for photon radiation from leptons 
+modept2gamlep 0      ! (default=0) pt_rel definition in setlocalscales 
+
+bornonly   0      ! (default 0) if 1 do Born only
+withdamp    1     ! (default 0, do not use) use Born-zero damping factor
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+ 
+iseed SEED     ! initialize random number sequence


### PR DESCRIPTION
These cards are copied from the pre2017 directory (https://github.com/cms-sw/genproductions/tree/master/bin/Powheg/production/pre2017/13TeV/Wgamma) and only the PDF sets are changed (260000 --> 306000).