### PR TITLE
add 2017 POWHEG WGamma hadronizers

### DIFF
--- a/python/ThirteenTeV/Wgamma_WmToLNu_TuneCP5_13TeV_powhegEmissionVeto1_pythia8_cff.py
+++ b/python/ThirteenTeV/Wgamma_WmToLNu_TuneCP5_13TeV_powhegEmissionVeto1_pythia8_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/powheg/V2/WG/Wgamma_slc6_amd64_gcc630_CMSSW_9_3_0_WgammaWmToLNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         emissionVeto1 = cms.untracked.PSet(),
+                         EV1_nFinal = cms.int32(2),
+                         EV1_nFinalMode = cms.int32(0),
+                         EV1_vetoOn = cms.bool(True),
+                         EV1_maxVetoCount = cms.int32(10),
+                         EV1_pThardMode = cms.int32(0),
+                         EV1_pTempMode = cms.int32(0),
+                         EV1_emittedMode = cms.int32(0),
+                         EV1_pTdefMode = cms.int32(1),
+                         EV1_MPIvetoOn = cms.bool(False),
+                         EV1_QEDvetoMode = cms.int32(1),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings')
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/Wgamma_WpToLNu_TuneCP5_13TeV_powhegEmissionVeto1_pythia8_cff.py
+++ b/python/ThirteenTeV/Wgamma_WpToLNu_TuneCP5_13TeV_powhegEmissionVeto1_pythia8_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/2017/13TeV/powheg/V2/WG/Wgamma_slc6_amd64_gcc630_CMSSW_9_3_0_WgammaWpToLNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         emissionVeto1 = cms.untracked.PSet(),
+                         EV1_nFinal = cms.int32(2),
+                         EV1_nFinalMode = cms.int32(0),
+                         EV1_vetoOn = cms.bool(True),
+                         EV1_maxVetoCount = cms.int32(10),
+                         EV1_pThardMode = cms.int32(0),
+                         EV1_pTempMode = cms.int32(0),
+                         EV1_emittedMode = cms.int32(0),
+                         EV1_pTdefMode = cms.int32(1),
+                         EV1_MPIvetoOn = cms.bool(False),
+                         EV1_QEDvetoMode = cms.int32(1),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings')
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
These special hadronizers for POWHEG WGamma are copied from the 2016 ones (https://github.com/cms-sw/genproductions/blob/master/python/ThirteenTeV/Wgamma_WmToLNu_TuneCUEP8M1_13TeV_powhegEmissionVeto1_pythia8_cff.py and https://github.com/cms-sw/genproductions/blob/master/python/ThirteenTeV/Wgamma_WpToLNu_TuneCUEP8M1_13TeV_powhegEmissionVeto1_pythia8_cff.py) with the gridpack location changed and the pythia tune changed.