### PR TITLE
Update Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max2j_qCut60_LHE_pythia8_…

### DIFF
--- a/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max2j_qCut60_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/Hadronizer/Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max2j_qCut60_LHE_pythia8_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
-
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaPylistVerbosity = cms.untracked.int32(1),
@@ -12,6 +12,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CUEP8M1SettingsBlock,
+        pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'JetMatching:setMad = off',
             'JetMatching:scheme = 1',
@@ -27,6 +28,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CUEP8M1Settings',
+                                    'pythia8PSweightsSettings'
                                     'processParameters',
                                     )
     )


### PR DESCRIPTION
…cff.py

 To take into account  that for  2018 fragment should include PS weights w.r.t 2017 production.