### PR TITLE
increase ncalls for low mass POWHEG ggH_quark-mass-effects

### DIFF
--- a/bin/Powheg/examples/V2/gg_H_quark-mass-effects_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/V2/gg_H_quark-mass-effects_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV.input
@@ -16,13 +16,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/examples/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV.input
+++ b/bin/Powheg/examples/gg_H_quark-mass-effects_withJHUGen_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV.input
@@ -16,13 +16,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_WW_quark-mass-effects_NNPDF31_13TeV/gg_H_WW_quark-mass-effects_NNPDF31_13TeV_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_WW_quark-mass-effects_NNPDF31_13TeV/gg_H_WW_quark-mass-effects_NNPDF31_13TeV_template.input
@@ -11,13 +11,13 @@ lhans2 306000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 {ncall1}   ! number of calls for initializing the integration grid
-itmx1  {itmx1}    ! number of iterations for initializing the integration grid
-ncall2 {ncall2}    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   {foldcsi}    ! number of folds on csi integration
-foldy     {foldy}    ! number of folds on  y  integration
-foldphi   {foldphi}    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_WW_quark-mass-effects_NNPDF31_13TeV/makecards.py
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_WW_quark-mass-effects_NNPDF31_13TeV/makecards.py
@@ -48,10 +48,5 @@ with open("gg_H_WW_quark-mass-effects_NNPDF31_13TeV_template.input") as f:
 dct = {}
 
 for dct["mass"], dct["width"], dct["hfact"] in parameters:
-  if dct["mass"] < 300:
-    dct.update(ncall1=50000, itmx1=5, ncall2=50000, foldcsi=1, foldy=1, foldphi=1)
-  else:
-    dct.update(ncall1=550000, itmx1=7, ncall2=75000, foldcsi=2, foldy=5, foldphi=2)
-
   with open("gg_H_WW_quark-mass-effects_NNPDF31_13TeV_M{}.input".format(dct["mass"]), "w") as f:
     f.write(template.format(**dct))

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV_template.input
@@ -11,13 +11,13 @@ lhans2 306000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 {ncall1}   ! number of calls for initializing the integration grid
-itmx1  {itmx1}    ! number of iterations for initializing the integration grid
-ncall2 {ncall2}    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   {foldcsi}    ! number of folds on csi integration
-foldy     {foldy}    ! number of folds on  y  integration
-foldphi   {foldphi}    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV/makecards.py
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV/makecards.py
@@ -47,10 +47,5 @@ with open("gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV_template.input") as f:
 dct = {}
 
 for dct["mass"], dct["width"], dct["hfact"] in parameters:
-  if dct["mass"] < 300:
-    dct.update(ncall1=50000, itmx1=5, ncall2=50000, foldcsi=1, foldy=1, foldphi=1)
-  else:
-    dct.update(ncall1=550000, itmx1=7, ncall2=75000, foldcsi=2, foldy=5, foldphi=2)
-
   with open("gg_H_ZZ_quark-mass-effects_NNPDF31_13TeV_M{}.input".format(dct["mass"]), "w") as f:
     f.write(template.format(**dct))

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13TeV/gg_H_quark-mass-effects_NNPDF31_13TeV_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13TeV/gg_H_quark-mass-effects_NNPDF31_13TeV_template.input
@@ -11,13 +11,13 @@ lhans2 306000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 {ncall1}   ! number of calls for initializing the integration grid
-itmx1  {itmx1}    ! number of iterations for initializing the integration grid
-ncall2 {ncall2}    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   {foldcsi}    ! number of folds on csi integration
-foldy     {foldy}    ! number of folds on  y  integration
-foldphi   {foldphi}    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/2017/13TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13TeV/makecards.py
+++ b/bin/Powheg/production/2017/13TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13TeV/makecards.py
@@ -48,7 +48,5 @@ with open("gg_H_quark-mass-effects_NNPDF31_13TeV_template.input") as f:
 dct = {}
 
 for dct["mass"], dct["width"], dct["hfact"] in parameters:
-  dct.update(ncall1=50000, itmx1=5, ncall2=50000, foldcsi=1, foldy=1, foldphi=1)
-
   with open("gg_H_quark-mass-effects_NNPDF31_13TeV_M{}.input".format(dct["mass"]), "w") as f:
     f.write(template.format(**dct))

--- a/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
+++ b/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
@@ -14,13 +14,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
+++ b/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M200.input
@@ -14,13 +14,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
+++ b/bin/Powheg/production/pre2017/13TeV/gg_H_quark-mass-effects_JHUGenV628_HWWLNuQQ_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M250.input
@@ -14,13 +14,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/14TeV/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_14TeV/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_14TeV.input
+++ b/bin/Powheg/production/pre2017/14TeV/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_14TeV/gg_H_quark-mass-effects_JHUGen_HZZ4L_NNPDF30_14TeV.input
@@ -16,13 +16,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/14TeV/gg_H_quark-mass-effects_NNPDF30_14TeV/gg_H_quark-mass-effects_NNPDF30_14TeV_M125.input
+++ b/bin/Powheg/production/pre2017/14TeV/gg_H_quark-mass-effects_NNPDF30_14TeV/gg_H_quark-mass-effects_NNPDF30_14TeV_M125.input
@@ -12,13 +12,13 @@ lhans2 260000       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds


### PR DESCRIPTION
and require this in request_fragment_check.py

As I say in the comments there, it's probably ok for < 150 GeV, but we thought it was ok for < 300 GeV and this turned out to be wrong.  I'd prefer to be safe for future gridpacks.  However, the problem is only known to happen around 170 - 230 GeV.

Again this only applies to POWHEG ggH_quark-mass-effects.  As far as I know no other POWHEG processes are affected - at any rate VBF_H, HZJ, HWJ, and ttH seem to be fine for the mass ranges we generate in HZZ.  Gridpacks that don't use POWHEG definitely don't have this problem.

https://its.cern.ch/jira/browse/CMSCOMPPR-4735
https://its.cern.ch/jira/browse/CMSCOMPPR-4874