### PR TITLE
add Qstar -> QW and QZ sample cards with CP2 tune

### DIFF
--- a/python/ThirteenTeV/QstarToQW/QstarToQW_M_1000_TuneCP2_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQW/QstarToQW_M_1000_TuneCP2_13TeV_pythia8_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(1),
+    filterEfficiency = cms.untracked.double(1),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+            'ExcitedFermion:dg2dStar = on',
+            'ExcitedFermion:ug2uStar = on',
+            'ExcitedFermion:Lambda = 1000',
+            '4000001:m0 = 1000',
+            '4000001:onMode = off',
+            '4000001:onIfMatch = 2 24',
+            '4000002:m0 = 1000',
+            '4000002:onMode = off',
+            '4000002:onIfMatch = 1 24',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters')
+    )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/QstarToQW/create_QstarToQW_TuneCP2.sh
+++ b/python/ThirteenTeV/QstarToQW/create_QstarToQW_TuneCP2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for i in 500 600 800 1200 1400 1600 1800 2000 2500 3000 3500 4000 4500 5000 5500 6000 6500 7000 7500; do
+    cp -v QstarToQW_M_1000_TuneCP2_13TeV_pythia8_cfi.py $(echo QstarToQW_M_1000_TuneCP2_13TeV_pythia8_cfi.py | sed "s/1000/$i/")
+done
+
+for i in QstarToQW_M_*_TuneCP2_13TeV_pythia8_cfi.py; do
+    ENERGY=$(echo $i | awk -F_ '{ print $3 }')
+    sed -i "s/1000/$ENERGY/" $i
+done

--- a/python/ThirteenTeV/QstarToQZ/QstarToQZ_M_1000_TuneCP2_13TeV_pythia8_cfi.py
+++ b/python/ThirteenTeV/QstarToQZ/QstarToQZ_M_1000_TuneCP2_13TeV_pythia8_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    comEnergy = cms.double(13000.0),
+    crossSection = cms.untracked.double(1),
+    filterEfficiency = cms.untracked.double(1),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+            'ExcitedFermion:dg2dStar = on',
+            'ExcitedFermion:ug2uStar = on',
+            'ExcitedFermion:Lambda = 1000',
+            '4000001:m0 = 1000',
+            '4000001:onMode = off',
+            '4000001:onIfMatch = 1 23',
+            '4000002:m0 = 1000',
+            '4000002:onMode = off',
+            '4000002:onIfMatch = 2 23',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP2Settings',
+                                    'processParameters')
+    )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/QstarToQZ/create_QstarToQZ_TuneCP2.sh
+++ b/python/ThirteenTeV/QstarToQZ/create_QstarToQZ_TuneCP2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for i in 500 600 800 1200 1400 1600 1800 2000 2500 3000 3500 4000 4500 5000 5500 6000 6500 7000 7500; do
+    cp -v QstarToQZ_M_1000_TuneCP2_13TeV_pythia8_cfi.py $(echo QstarToQZ_M_1000_TuneCP2_13TeV_pythia8_cfi.py | sed "s/1000/$i/")
+done
+
+for i in QstarToQZ_M_*_TuneCP2_13TeV_pythia8_cfi.py; do
+    ENERGY=$(echo $i | awk -F_ '{ print $3 }')
+    sed -i "s/1000/$ENERGY/" $i
+done


### PR DESCRIPTION
These are the Pythia cards for the Q* samples to be used in the Run-2 legacy B2G diboson analysis. With respect to the already existing ones, they have the new tune CP2 to avoid issues with negative PDF weights. Cross sections are set to 1 consistently.

FYI @ahinzmann