### PR TITLE
Remove b's from proc card

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/AJJ_EWK_SM_5f_NLO/AJJ_EWK_SM_5f_NLO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/AJJ_EWK_SM_5f_NLO/AJJ_EWK_SM_5f_NLO_proc_card.dat
@@ -6,7 +6,5 @@ set gauge unitary
 set complex_mass_scheme False
 set max_npoint_for_channel 0
 import model loop_sm
-define p = p b b~
-define j = j b b~
 generate p p > a j j  QCD=0 [QCD]
 output AJJ_EWK_SM_5f_NLO


### PR DESCRIPTION
Gridpack production with the original cards failed:
at NLO, we cannot run with massive incoming b's in the proton definition.