### PR TITLE
DisplacedSUSY MC update for 2018 - remove filter with 100% efficiency

### DIFF
--- a/python/ThirteenTeV/DisplacedSUSY/DisplacedSUSY_stopToBottom_M_XXX_YYYmm_TuneCP5_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisplacedSUSY/DisplacedSUSY_stopToBottom_M_XXX_YYYmm_TuneCP5_13TeV_pythia8_cff.py
@@ -788,14 +788,4 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     )
 )
 
-dirhadrongenfilter = cms.EDFilter("MCParticlePairFilter",
-    MinPt = cms.untracked.vdouble(0., 0.),
-    MinP = cms.untracked.vdouble(0., 0.),
-    MaxEta = cms.untracked.vdouble(100., 100.),
-    MinEta = cms.untracked.vdouble(-100, -100),
-    ParticleCharge = cms.untracked.int32(0),
-    ParticleID1 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333),
-    ParticleID2 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333)
-)
-
-ProductionFilterSequence = cms.Sequence(generator*dirhadrongenfilter)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/DisplacedSUSY/DisplacedSUSY_stopToLD_M_XXX_YYYmm_TuneCP5_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisplacedSUSY/DisplacedSUSY_stopToLD_M_XXX_YYYmm_TuneCP5_13TeV_pythia8_cff.py
@@ -788,14 +788,4 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     )
 )
 
-dirhadrongenfilter = cms.EDFilter("MCParticlePairFilter",
-    MinPt = cms.untracked.vdouble(0., 0.),
-    MinP = cms.untracked.vdouble(0., 0.),
-    MaxEta = cms.untracked.vdouble(100., 100.),
-    MinEta = cms.untracked.vdouble(-100, -100),
-    ParticleCharge = cms.untracked.int32(0),
-    ParticleID1 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333),
-    ParticleID2 = cms.untracked.vint32(1000612,1000622,1000632,1000642,1000652,1006113,1006211,1006213,1006223,1006311,1006313,1006321,1006323,1006333)
-)
-
-ProductionFilterSequence = cms.Sequence(generator*dirhadrongenfilter)
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
for EXO-18-003. 

MCParticlePairFilter wasn't actually filtering any events, so better to remove it.