### PR TITLE
use the provided powheg.input card for parallel stages 2 and 3

### DIFF
--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -1692,6 +1692,7 @@ if __name__ == "__main__":
         os.system('cd '+rootfolder+';bash '+scriptName)
 
     else                    :
+        os.system('cp -p '+args.inputTemplate+' '+args.folderName+'/powheg.input')
         runEvents(args.parstage, args.folderName,
                   args.eosFolder + '/' + EOSfolder, njobs, powInputName,
                   jobtag, args.prcName)


### PR DESCRIPTION
Currently, the powheg.input card provided with "-i" is ignored for parallel stages 2 and 3. For example, in these cases, it would be ignored:

```
# step 2
   python ./run_pwg_condor.py -p 2 -i powheg_Zj.input -m Zj -f my_Zj -q longlunch -j 10
# step 3
   python ./run_pwg_condor.py -p 3 -i powheg_Zj.input -m Zj -f my_Zj -q longlunch -j 10 
```

The powheg.input card may need to be changed between steps 1 and 2 and 3, e.g. the parameters `nubound` and `ncall1`.