### PR TITLE
adding cards with reweights for 2016

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.000000e+00 # kAgg  
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j / t [QCD]
+output GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.000000e+00 # kAgg  
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j j / t [QCD]
+output GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.000000e+00 # kAgg  
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+output GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.000000e+00 # kAgg  
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,17 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+add process p p > x0 j / t [QCD]
+add process p p > x0 j j / t [QCD]
+output GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j / t [QCD]
+output GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j j / t [QCD]
+output GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+output GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 1.414000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,17 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+add process p p > x0 j / t [QCD]
+add process p p > x0 j j / t [QCD]
+output GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 0.000000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j / t [QCD]
+output GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 0.000000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j j / t [QCD]
+output GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 0.000000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,15 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+output GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_param_card.dat
@@ -1,0 +1,127 @@
+######################################################################
+##  Process generated with '-heft' model restrictions	 	    ##
+##  5F scheme (MB=0)   				         	    ##
+##  GLUON FUSION AT NLO using the Higgs Effective Field Theory	    ##
+##  (i.e. in the limit Mtop->infinity)                              ##
+##                                                                  ##
+##  These restrictions should be used only to generate              ##
+##  X0 (plus jets) in the gluon fusion channel			    ##
+##                                                                  ##
+##  NB: 							    ##
+##  Please be sure that before generating this process,	 	    ##
+##  you have correctly set the content of the multiparticles        ##
+##  'p' (proton) and 'j' (jet) inside MG5_aMC,                      ##
+##  accordingly to the massless flavour scheme                      ##
+##  5F: p, j = g d d~ u u~ s s~ c c~ b b~                           ##
+##                                                                  ##
+##  Please be sure that you have filtered out all the top quark     ##
+##  loops using '/ t' in the generation command                     ##
+######################################################################
+
+###################################
+## INFORMATION FOR FRBLOCK
+###################################
+Block frblock 
+    1 1.000000e+03 # Lambda 
+    2 0.707000e+00 # cosa 
+    3 1.000000e+00 # kSM 
+    8 1.000000e+00 # kHll 
+    9 1.000000e+00 # kAll 
+   10 1.000000e+00 # kHaa 
+   11 1.000000e+00 # kAaa 
+   12 1.000000e+00 # kHza 
+   13 1.000000e+00 # kAza 
+   14 0.000000e+00 # kHgg  
+   15 0.943000e+00 # kAgg
+   16 0.000000e+00 # kHzz 
+   17 0.000000e+00 # kAzz 
+   18 0.000000e+00 # kHww 
+   19 0.000000e+00 # kAww 
+   20 0.000000e+00 # kHda 
+   21 0.000000e+00 # kHdz 
+   22 0.000000e+00 # kHdwR (real part of kHdw)
+   23 0.000000e+00 # kHdwI (imaginary part of kHdw)
+
+###################################
+### INFORMATION FOR LOOP
+####################################
+Block loop
+  1 9.118800e+01 # MU_R
+
+###################################
+## INFORMATION FOR SMINPUTS
+###################################
+Block SMINPUTS 
+    1 1.325070e+02 # aEWM1 
+    2 1.166390e-05 # Gf 
+    3 1.180000e-01 # aS 
+
+###################################
+## INFORMATION FOR MASS
+###################################
+Block MASS 
+    6 1.730000e+02 # MT 
+   15 1.777000e+00 # MTA 
+   23 9.118800e+01 # MZ 
+   25 1.250000e+02 # MX0 
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+  1 0.000000 # d : 0.0 
+  2 0.000000 # u : 0.0 
+  3 0.000000 # s : 0.0 
+  4 0.000000 # c : 0.0 
+  5 0.000000 # b : 0.0 
+  11 0.000000 # e- : 0.0 
+  12 0.000000 # ve : 0.0 
+  13 0.000000 # mu- : 0.0 
+  14 0.000000 # vm : 0.0 
+  16 0.000000 # vt : 0.0 
+  21 0.000000 # g : 0.0 
+  22 0.000000 # a : 0.0 
+  24 80.419002 # w+ : cmath.sqrt(MZ__exp__2/2. + cmath.sqrt(MZ__exp__4/4. - (aEW*cmath.pi*MZ__exp__2)/(Gf*sqrt__2))) 
+  82 0.000000 # gh : 0.0 
+
+###################################
+## INFORMATION FOR YUKAWA
+###################################
+Block YUKAWA 
+   15 1.777000e+00 # ymtau 
+
+###################################
+## INFORMATION FOR DECAY 
+###################################
+DECAY   6 1.491500e+00 	# top width
+DECAY  23 2.441404e+00  # Z width
+DECAY  24 2.047600e+00 	# W width
+DECAY  25 4.070000e-03  # X0 width
+## Dependent parameters, given by model restrictions.
+## Those values should be edited following the 
+## analytical expression. MG5 ignores those values 
+## but they are important for interfacing the output of MG5
+## to external program such as Pythia.
+DECAY  1 0.000000 # d : 0.0 
+DECAY  2 0.000000 # u : 0.0 
+DECAY  3 0.000000 # s : 0.0 
+DECAY  4 0.000000 # c : 0.0 
+DECAY  5 0.000000 # b : 0.0 
+DECAY  11 0.000000 # e- : 0.0 
+DECAY  12 0.000000 # ve : 0.0 
+DECAY  13 0.000000 # mu- : 0.0 
+DECAY  14 0.000000 # vm : 0.0 
+DECAY  15 0.000000 # ta- : 0.0 
+DECAY  16 0.000000 # vt : 0.0 
+DECAY  21 0.000000 # g : 0.0 
+DECAY  22 0.000000 # a : 0.0 
+DECAY  82 0.000000 # gh : 0.0 
+#===========================================================
+# QUANTUM NUMBERS OF NEW STATE(S) (NON SM PDG CODE)
+#===========================================================
+
+Block QNUMBERS 82  # gh 
+        1 0  # 3 times electric charge
+        2 1  # number of spin states (2S+1)
+        3 8  # colour rep (1: singlet, 3: triplet, 8: octet)
+        4 1  # Particle/Antiparticle distinction (0=own anti)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_proc_card.dat
@@ -1,0 +1,17 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 / t [QCD]
+add process p p > x0 j / t [QCD]
+add process p p > x0 j j / t [QCD]
+output GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,0 +1,12 @@
+change mode NLO
+change rwgt_dir rwgt
+
+launch --rwgt_name=sm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.000000
+launch --rwgt_name=ps_weight
+  set frblock 14 0.000000
+  set frblock 15 0.943000
+launch --rwgt_name=mm_weight
+  set frblock 14 1.414000
+  set frblock 15 0.943000

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 100 = nevents ! Number of unweighted events requested 
+ -1.0 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ 292200  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 3        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+ 30.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************


### PR DESCRIPTION
2016 cards for ggH + 0,1,2 jet events needed for CP studies. 
Cards are included for:
- CP-even, CP-odd, and CP-mixed scenarios
- inclusive ggH + 0-2 jet events, and for exclusive 0, 1, and 2 jet events needed to increase statistics
