### PR TITLE
Adding hadronizers for VBF photon

### DIFF
--- a/python/ThirteenTeV/GJetsVBF/GJets_Mjj-400_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_qCut45_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/GJetsVBF/GJets_Mjj-400_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_qCut45_LHE_pythia8_cff.py
@@ -1,0 +1,88 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off', 
+            'JetMatching:scheme = 1', 
+            'JetMatching:merge = on', 
+            'JetMatching:jetAlgorithm = 2', 
+            'JetMatching:etaJetMax = 999.', 
+            'JetMatching:coneRadius = 1.', 
+            'JetMatching:slowJetPower = 1', 
+            'JetMatching:qCut = 45.', 
+            'JetMatching:doFxFx = on', 
+            'JetMatching:qCutME = 30.', 
+            'JetMatching:nQmatch = 5', 
+            'JetMatching:nJetMax = 2', 
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings', 
+            'pythia8CP5Settings', 
+            'pythia8aMCatNLOSettings', 
+            'pythia8PSweightsSettings',
+            'processParameters'
+        )
+    )
+)
+
+from RecoJets.Configuration.GenJetParticles_cff import genParticlesForJetsNoNu
+from RecoJets.Configuration.RecoGenJets_cff import ak4GenJetsNoNu
+
+# Filter out PromptFinalState photons
+genParticlesNoGamma = cms.EDFilter('CandPtrSelector',
+    src = cms.InputTag('genParticles'),
+    cut = cms.string('pdgId != 22 || !isPromptFinalState')
+)
+
+genParticlesForJetsNoNuNoGamma = genParticlesForJetsNoNu.clone(
+    src = cms.InputTag("genParticlesNoGamma")
+)
+
+ak4GenJetsNoNuNoGamma = ak4GenJetsNoNu.clone(
+    src = cms.InputTag("genParticlesForJetsNoNuNoGamma")
+)
+
+vbfGenJetFilterD = cms.EDFilter("VBFGenJetFilter",
+    inputTag_GenJetCollection = cms.untracked.InputTag("ak4GenJetsNoNuNoGamma"),
+    maxEta = cms.untracked.double(99999.0),
+    minEta = cms.untracked.double(-99999.0),
+    minInvMass = cms.untracked.double(400.),
+    minPt = cms.untracked.double(30.)
+)
+
+from GeneratorInterface.Core.generatorSmeared_cfi import generatorSmeared
+from PhysicsTools.HepMCCandAlgos.genParticles_cfi import genParticles
+
+ProductionFilterSequence = cms.Sequence(
+    generator+
+    cms.SequencePlaceholder('randomEngineStateProducer')+
+    cms.SequencePlaceholder('VtxSmeared')+
+    generatorSmeared+
+    genParticles+
+    genParticlesNoGamma+
+    genParticlesForJetsNoNuNoGamma+
+    ak4GenJetsNoNuNoGamma+
+    vbfGenJetFilterD+
+    cms.SequencePlaceholder("pgen")
+)
+
+SimFilterSequence = cms.Sequence(
+    vbfGenJetFilterD+
+    cms.SequencePlaceholder("psim")
+)

--- a/python/ThirteenTeV/GJetsVBF/GJets_Mjj-800_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_qCut45_LHE_pythia8_cff.py
+++ b/python/ThirteenTeV/GJetsVBF/GJets_Mjj-800_TuneCP5_13TeV_aMCatNLO_FXFX_5f_max2j_qCut45_LHE_pythia8_cff.py
@@ -1,0 +1,88 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off', 
+            'JetMatching:scheme = 1', 
+            'JetMatching:merge = on', 
+            'JetMatching:jetAlgorithm = 2', 
+            'JetMatching:etaJetMax = 999.', 
+            'JetMatching:coneRadius = 1.', 
+            'JetMatching:slowJetPower = 1', 
+            'JetMatching:qCut = 45.', 
+            'JetMatching:doFxFx = on', 
+            'JetMatching:qCutME = 30.', 
+            'JetMatching:nQmatch = 5', 
+            'JetMatching:nJetMax = 2', 
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings', 
+            'pythia8CP5Settings', 
+            'pythia8aMCatNLOSettings', 
+            'pythia8PSweightsSettings',
+            'processParameters'
+        )
+    )
+)
+
+from RecoJets.Configuration.GenJetParticles_cff import genParticlesForJetsNoNu
+from RecoJets.Configuration.RecoGenJets_cff import ak4GenJetsNoNu
+
+# Filter out PromptFinalState photons
+genParticlesNoGamma = cms.EDFilter('CandPtrSelector',
+    src = cms.InputTag('genParticles'),
+    cut = cms.string('pdgId != 22 || !isPromptFinalState')
+)
+
+genParticlesForJetsNoNuNoGamma = genParticlesForJetsNoNu.clone(
+    src = cms.InputTag("genParticlesNoGamma")
+)
+
+ak4GenJetsNoNuNoGamma = ak4GenJetsNoNu.clone(
+    src = cms.InputTag("genParticlesForJetsNoNuNoGamma")
+)
+
+vbfGenJetFilterD = cms.EDFilter("VBFGenJetFilter",
+    inputTag_GenJetCollection = cms.untracked.InputTag("ak4GenJetsNoNuNoGamma"),
+    maxEta = cms.untracked.double(99999.0),
+    minEta = cms.untracked.double(-99999.0),
+    minInvMass = cms.untracked.double(800.),
+    minPt = cms.untracked.double(30.)
+)
+
+from GeneratorInterface.Core.generatorSmeared_cfi import generatorSmeared
+from PhysicsTools.HepMCCandAlgos.genParticles_cfi import genParticles
+
+ProductionFilterSequence = cms.Sequence(
+    generator+
+    cms.SequencePlaceholder('randomEngineStateProducer')+
+    cms.SequencePlaceholder('VtxSmeared')+
+    generatorSmeared+
+    genParticles+
+    genParticlesNoGamma+
+    genParticlesForJetsNoNuNoGamma+
+    ak4GenJetsNoNuNoGamma+
+    vbfGenJetFilterD+
+    cms.SequencePlaceholder("pgen")
+)
+
+SimFilterSequence = cms.Sequence(
+    vbfGenJetFilterD+
+    cms.SequencePlaceholder("psim")
+)


### PR DESCRIPTION
We are going to request background samples for a VBF photon production cross section measurement. The samples will be aMC@NLO GJets with FxFx merging (which is technically not valid for GJets final state but could be usable at high photon pT; we have been encouraged to give it a try). We will apply a phase space cut with dijet mass because otherwise the cross sections are enormous.
There is already a EDFilter that applies a dijet mass cut using GenJets, but since the module cleans the jets only against leptons, we have to create a photon-vetoed jet collection first to feed to the module.
The fragment has been validated with the GJets gridpack that we are going to use in the production.

I should point out that the ak4GenJetsNoNuNoGamma collection produced by this fragment stayed in the event (the standard event content commands seem to keep the collection). If that can cause issues downstream in the production, I can add an explicit drop statement at the end of event content configurations.