### PR TITLE
changed the Tune CP2 to CP3

### DIFF
--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP3.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP3.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -10,7 +10,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
             '25:m0 = 125.0', 
@@ -22,7 +22,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
 
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters'
                                     )
         )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP3_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HWWllnunu_cff_CP3_PSweights_2018.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -11,7 +11,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
@@ -24,7 +24,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
 
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters',
                                     'pythia8PSweightsSettings'
                                     )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP3.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP3.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
-from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -11,18 +10,20 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
-        pythia8PSweightsSettingsBlock,
+        pythia8CP3SettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
-            '25:m0 = 125.0',
+            '25:m0 = 125.0', 
+            '23:mMin = 0.05',                 # Solve problem with mZ cut
             '25:onMode = off',
-            '25:onIfMatch = 22 22'
+            '25:onIfAll = 23 23',           # turn ON H->ZZ
+            '23:onMode = off',                # turn OFF all Z decays
+            '23:onIfAny = 11 13 15'           # turn ON Z->ll
+
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
-                                    'processParameters',
-                                    'pythia8PSweightsSettings'
+                                    'pythia8CP3Settings',
+                                    'processParameters'
                                     )
         )
                          )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP3_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_HZZ4l_cff_CP3_PSweights_2018.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -11,16 +11,20 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
-            '25:m0 = 125.0',
+            '25:m0 = 125.0', 
+            '23:mMin = 0.05',                 # Solve problem with mZ cut
             '25:onMode = off',
-            '25:onIfMatch = 5 -5'
+            '25:onIfAll = 23 23',           # turn ON H->ZZ
+            '23:onMode = off',                # turn OFF all Z decays
+            '23:onIfAny = 11 13 15'           # turn ON Z->ll
+
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters',
                                     'pythia8PSweightsSettings'
                                     )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP3.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP3.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
-from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -11,18 +10,16 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
-        pythia8PSweightsSettingsBlock,
+        pythia8CP3SettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
             '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfMatch = 15 -15'
+            '25:onIfMatch = 22 22'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
-                                    'processParameters',
-                                    'pythia8PSweightsSettings'
+                                    'pythia8CP3Settings',
+                                    'processParameters'
                                     )
         )
                          )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP3_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Haa_cff_CP3_PSweights_2018.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
@@ -11,20 +11,16 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
-            '25:m0 = 125.0', 
-            '23:mMin = 0.05',                 # Solve problem with mZ cut
+            '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfAll = 23 23',           # turn ON H->ZZ
-            '23:onMode = off',                # turn OFF all Z decays
-            '23:onIfAny = 11 13 15'           # turn ON Z->ll
-
+            '25:onIfMatch = 22 22'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters',
                                     'pythia8PSweightsSettings'
                                     )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP3.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP3.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -10,15 +10,15 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
             '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfMatch = 22 22'
+            '25:onIfMatch = 5 -5'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters'
                                     )
         )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP3_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Hbb_cff_CP3_PSweights_2018.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -10,16 +11,18 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
+        pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
             '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfMatch = 15 -15'
+            '25:onIfMatch = 5 -5'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
-                                    'processParameters'
+                                    'pythia8CP3Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
                                     )
         )
                          )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP3.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP3.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -10,15 +10,15 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
             '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfMatch = 5 -5'
+            '25:onIfMatch = 15 -15'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
+                                    'pythia8CP3Settings',
                                     'processParameters'
                                     )
         )

--- a/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP3_PSweights_2018.py
+++ b/python/ThirteenTeV/monoHiggs/pythia8_hadronizer_nomatching_Htautau_cff_CP3_PSweights_2018.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP3Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
                          maxEventsToPrint = cms.untracked.int32(1),
@@ -10,20 +11,18 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                          comEnergy = cms.double(13000.),
                          PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP2SettingsBlock,
+        pythia8CP3SettingsBlock,
+        pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
-            '25:m0 = 125.0', 
-            '23:mMin = 0.05',                 # Solve problem with mZ cut
+            '25:m0 = 125.0',
             '25:onMode = off',
-            '25:onIfAll = 23 23',           # turn ON H->ZZ
-            '23:onMode = off',                # turn OFF all Z decays
-            '23:onIfAny = 11 13 15'           # turn ON Z->ll
-
+            '25:onIfMatch = 15 -15'
             ),
         parameterSets = cms.vstring('pythia8CommonSettings',
-                                    'pythia8CP2Settings',
-                                    'processParameters'
+                                    'pythia8CP3Settings',
+                                    'processParameters',
+                                    'pythia8PSweightsSettings'
                                     )
         )
                          )


### PR DESCRIPTION
Now gridpacks are made using NNPDF3.1 NLO.
To keep ME and PS PDFs consistent, we adopt ME (NNPDF3.1 NLO) + PS (CP3) as suggested here 
https://twiki.cern.ch/twiki/bin/view/CMS/PhysicsComparisonAndGeneratorTunes#Recommendations_on_the_usage_of