### PR TITLE
Patch for fixing logging issue

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0025-fix-logging-info.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0025-fix-logging-info.patch
@@ -1,5 +1,5 @@
 --- a/madgraph/interface/amcatnlo_run_interface.py	2019-02-04 12:19:42.000000000 +0100
-+++ b/madgraph/interface/amcatnlo_run_interface_new.py	2019-04-30 10:59:55.718456046 +0200
++++ b/madgraph/interface/amcatnlo_run_interface.py	2019-04-30 10:59:55.718456046 +0200
 @@ -2942,7 +2942,7 @@
                  # check for PLUGIN format
                  cluster_class = misc.from_plugin_import(self.plugin_path, 

--- a/bin/MadGraph5_aMCatNLO/patches/0025-fix-logging-info.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0025-fix-logging-info.patch
@@ -1,0 +1,11 @@
+--- a/madgraph/interface/amcatnlo_run_interface.py	2019-02-04 12:19:42.000000000 +0100
++++ b/madgraph/interface/amcatnlo_run_interface_new.py	2019-04-30 10:59:55.718456046 +0200
+@@ -2942,7 +2942,7 @@
+                 # check for PLUGIN format
+                 cluster_class = misc.from_plugin_import(self.plugin_path, 
+                                             'new_cluster', cluster_name,
+-                                            info = 'cluster handling will be done with PLUGIN: %{plug}s' )
++                                            info = 'cluster handling will be done with PLUGIN: %(plug)s' )
+                 if cluster_class:
+                     self.cluster = cluster_class(**self.options)
+         


### PR DESCRIPTION
Simple fix to avoid `ValueError : unsupported format character '{' (0x7b) at index 44` when submitting NLO processes to clusters.

The issue is discussed here #2203 