### PR TITLE
modify dytautau012j_5f_NLO_FXFX_run_card.dat

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dytautau012j_5f_NLO_FXFX/dytautau012j_5f_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dytautau012j_5f_NLO_FXFX/dytautau012j_5f_NLO_FXFX_run_card.dat
@@ -93,6 +93,7 @@ $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
   0.5     = rw_Fscale_down   ! lower bound for fact scale variations
   2.0     = rw_Fscale_up     ! upper bound for fact scale variations
 $DEFAULT_PDF_MEMBERS = reweight_PDF     ! reweight to get PDF uncertainty
+True = store_rwgt_info
 #***********************************************************************
 # Merging - WARNING! Applies merging only at the hard-event level.     *
 # After showering an MLM-type merging should be applied as well.       *


### PR DESCRIPTION
Hi. I made a gridpack for dytautau012j_nlo using current master branch (mg260)

You can find the output here -
http://147.47.242.72/USER/jhchoi/gridpack/dytautau012j_nlo/dytautau012j_5f_NLO_FXFX_slc6_amd64_gcc630_CMSSW_9_3_8_tarball.tar.xz

I also update the card by adding 'True = store_rwgt_info '.


I'll update some validation plot by comparing distribution between old and new dytautau012jnlo.
