### PR TITLE
Fix patch 0006 to restore the LHE header

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0006-add-central-weights.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0006-add-central-weights.patch
@@ -1,6 +1,6 @@
---- a/madgraph/various/systematics.py	2017-05-01 21:02:10.402600552 +0300
-+++ b/madgraph/various/systematics.py	2017-05-01 21:01:44.759601146 +0300
-@@ -228,7 +228,7 @@
+--- a/madgraph/various/systematics.py	2019-05-29 10:48:35.000000001 +0200
++++ b/madgraph/various/systematics.py	2019-05-28 16:02:38.000000001 +0200
+@@ -314,7 +314,7 @@
          else:
              lowest_id = self.get_id()        
  
@@ -9,7 +9,7 @@
          all_cross = [0 for i in range(len(self.args))]
          
          self.input.parsing = False
-@@ -261,7 +261,7 @@
+@@ -348,7 +348,7 @@
                  print event
                  raise Exception
              
@@ -18,14 +18,24 @@
              all_cross = [(all_cross[j] + event.wgt*wgts[j]/wgts[0]) for j in range(len(wgts))]
              
              rwgt_data = event.parse_reweight()
-@@ -416,7 +416,7 @@
+@@ -512,9 +512,9 @@
          text = ''
          
          default = self.args[0]
 -        for arg in self.args[1:]:
 +        for arg in self.args:
              mur, muf, alps, dyn, pdf = arg[:5]
-             if pdf == self.orig_pdf and alps ==1 and (mur!=1 or muf!=1 or dyn!=-1):
+-            if pdf == self.orig_pdf and alps ==1 and (mur!=1 or muf!=1 or dyn!=-1):
++            if (pdf == self.orig_pdf and alps ==1 and (mur!=1 or muf!=1 or dyn!=-1)) or (cid == lowest_id):
                  if not in_scale:
-         
-         
+                     text += "<weightgroup name=\"Central scale variation\" combine=\"envelope\">\n"
+                     in_scale=True
+@@ -533,7 +533,7 @@
+                 text += "</weightgroup> # ALPS\n"
+                 in_alps=False
+             
+-            if mur == muf == 1 and dyn==-1 and alps ==1:
++            if mur == muf == 1 and dyn==-1 and alps ==1 and (cid != lowest_id):
+                 if pdf.lhapdfID < 0:
+                     for central,sets in self.pdfsets.items():
+                         if pdf in sets.set():


### PR DESCRIPTION
@kdlong @covarell @agrohsje @efeyazgan @qliphy 

This is to fix the issue discussed in this thread:
https://hypernews.cern.ch/HyperNews/CMS/get/generators/4324.html

The patch was originally meant to add the central weight in the scale variation weight group of the LHE header, but the results was a messed up header.

Note that this is not the default in MG, i.e. the systematics module does not write the central weight in the scale variation group (checked with MG standalone), but it is consistent with what CMS has done so far.

The fix has been tested with the wplustest_4f_LO process.
OLD patch: http://lviliani.web.cern.ch/lviliani/test_patch_0006/cmsgrid_final_oldpatch.lhe
NEW patch: http://lviliani.web.cern.ch/lviliani/test_patch_0006/cmsgrid_final_newpatch.lhe

**NB**: While checking this I also noticed that pdfs for which we don't store variations, e.g.:
https://github.com/cms-sw/genproductions/blob/mg261/MetaData/pdflist_4f_2017.dat#L4-L6
get written in the LHE header outside weight groups (see the LHE files above). This also happens in MG standalone but seems not consistent with what we did in MG242.
I'm not sure whether this can be a problem or not.