### PR TITLE
Add PSweights for DisappTrks 10X requests

### DIFF
--- a/python/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -1,0 +1,51 @@
+COM_ENERGY = 13000.
+MCHI = XXX  # GeV
+CTAU = YYY  # mm
+CROSS_SECTION = ZZZ # pb
+SLHA_TABLE="""
+""" % (1.97326979e-13 / CTAU)
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    filterEfficiency = cms.untracked.double(-1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    SLHATableForPythia8 = cms.string('%s' % SLHA_TABLE),
+    comEnergy = cms.double(COM_ENERGY),
+    crossSection = cms.untracked.double(CROSS_SECTION),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SUSY:all = off',
+            'SUSY:qqbar2chi+chi- = on',
+            'SUSY:qqbar2chi+-chi0 = on',
+            '1000024:isResonance = false',
+            '1000024:oneChannel = 1 1.0 100 1000022 211',
+            '1000024:tau0 = %.1f' % CTAU,
+            'ParticleDecays:tau0Max = %.1f' % (CTAU * 10),
+       ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettingsBlock',
+            'processParameters')
+    ),
+    # The following parameters are required by Exotica_HSCP_SIM_cfi:
+    slhaFile = cms.untracked.string(''),   # value not used
+    SLHAFileForPythia8 = cms.untracked.string(''),   # value not used, used over slhaFile for CMSSW >= 10_2_X
+    processFile = cms.untracked.string('SimG4Core/CustomPhysics/data/RhadronProcessList.txt'),
+    useregge = cms.bool(False),
+    hscpFlavor = cms.untracked.string('stau'),
+    massPoint = cms.untracked.int32(MCHI),  # value not used
+    particleFile = cms.untracked.string('Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSB/test/geant4_AMSB_chargino_%sGeV_ctau%scm.slha' % (MCHI, CTAU/10))
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/DisappTrksAMSB/createPoints.py
+++ b/python/ThirteenTeV/DisappTrksAMSB/createPoints.py
@@ -18,7 +18,11 @@ def findMassValue(fileName, particleName):
 		if particleName in line:
 			return line.split()[1]
 
-baseConfigFile = 'AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_13TeV_pythia8_cff.py'
+tuneName = '_TuneCP5_'
+if os.environ["CMSSW_VERSION"].startswith('CMSSW_10_'):
+	tuneName = '_TuneCP5_PSweights_'
+
+baseConfigFile = 'AMSB_chargino_M-XXXGeV_CTau-YYYcm' + tuneName + '13TeV_pythia8_cff.py'
 baseParticleFile = 'geant4_AMSB_chargino.slha'
 
 c = 299792458.0 * 100.0 # cm/s
@@ -40,9 +44,12 @@ xsecs = {
 
 ctaus = [10, 100, 1000, 10000] # cm
 
+if not os.path.exists('test/'):
+	os.mkdir('test')
+
 for mass in xsecs:
 	for ctau in ctaus:
-		outputConfigFile = 'test/AMSB_chargino_M-%dGeV_CTau-%dcm_TuneCP5_13TeV_pythia8_cff.py' % (mass, ctau)
+		outputConfigFile = ('test/AMSB_chargino_M-%dGeV_CTau-%dcm' % (mass, ctau)) + tuneName + '13TeV_pythia8_cff.py'
 		outputParticleFile = 'test/geant4_AMSB_chargino_%dGeV_ctau%dcm.slha' % (mass, ctau)
 
 		os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile + ' > ' + outputConfigFile)

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -1,0 +1,52 @@
+COM_ENERGY = 13000.
+MGLU = XXX  # GeV
+MCHI = YYY  # GeV
+CTAU = ZZZ  # mm
+CROSS_SECTION = WWW # pb
+SLHA_TABLE="""
+""" % (MGLU, (1.97326979e-13 / CTAU))
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    filterEfficiency = cms.untracked.double(-1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    SLHATableForPythia8 = cms.string('%s' % SLHA_TABLE),
+    comEnergy = cms.double(COM_ENERGY),
+    crossSection = cms.untracked.double(CROSS_SECTION),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SUSY:all = off',
+            'SUSY:gg2gluinogluino = on',
+            'SUSY:qqbar2gluinogluino = on',
+            '1000024:isResonance = false',
+            '1000024:oneChannel = 1 1.0 100 1000022 211',
+            '1000024:tau0 = %.1f' % CTAU,
+            'ParticleDecays:tau0Max = %.1f' % (CTAU * 10),
+       ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettingsBlock',
+            'processParameters')
+    ),
+    # The following parameters are required by Exotica_HSCP_SIM_cfi:
+    slhaFile = cms.untracked.string(''),   # value not used
+    SLHAFileForPythia8 = cms.untracked.string(''),   # value not used, used over slhaFile for CMSSW >= 10_2_X
+    processFile = cms.untracked.string('SimG4Core/CustomPhysics/data/RhadronProcessList.txt'),
+    useregge = cms.bool(False),
+    hscpFlavor = cms.untracked.string('stau'),
+    massPoint = cms.untracked.int32(MCHI),  # value not used
+    particleFile = cms.untracked.string('Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSBCascade/test/geant4_AMSB_chargino_%sGeV_ctau%scm.slha' % (MCHI, CTAU/10))
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
@@ -18,7 +18,11 @@ def findMassValue(fileName, particleName):
 		if particleName in line:
 			return line.split()[1]
 
-baseConfigFile = 'AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm_TuneCP5_13TeV_pythia8_cff.py'
+tuneName = '_TuneCP5_'
+if os.environ["CMSSW_VERSION"].startswith('CMSSW_10_'):
+        tuneName = '_TuneCP5_PSweights_'
+
+baseConfigFile = 'AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm' + tuneName + '13TeV_pythia8_cff.py'
 baseParticleFile = 'geant4_AMSB_chargino.slha'
 
 c = 299792458.0 * 100.0 # cm/s
@@ -47,12 +51,15 @@ xsecs = {
 
 ctaus = [10, 100, 1000, 10000] # cm
 
+if not os.path.exists('test/'):
+        os.mkdir('test')
+
 for mass in xsecs:
         for charginoMass in charginoMasses:
                 if charginoMass >= mass:
                         continue
                 for ctau in ctaus:
-                        outputConfigFile = 'test/AMSB_gluinoToChargino_M-%dGeV_M-%dGeV_CTau-%dcm_TuneCP5_13TeV_pythia8_cff.py' % (mass, charginoMass, ctau)
+                        outputConfigFile = ('test/AMSB_gluinoToChargino_M-%dGeV_M-%dGeV_CTau-%dcm' % (mass, charginoMass, ctau)) + tuneName + '13TeV_pythia8_cff.py'
                         outputParticleFile = 'test/geant4_AMSB_chargino_%dGeV_ctau%dcm.slha' % (charginoMass, ctau)
 
                         os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile + ' > ' + outputConfigFile)


### PR DESCRIPTION
Adds `pythia8PSweightsSettingsBlock` to the fragments for 2018 requests. The `CMSSW_VERSION` environmental variable controls whether they are used or not.

Adds `SLHAFileForPythia8` for 2018 fragments, since in 10_2_X `slhaFile` was changed in Exotica_HSCP_SIM_cfi.

Also adds the creation of the `test/` directory to make running the script simpler.