### PR TITLE
fix wrong tarball and max weights

### DIFF
--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -391,7 +391,7 @@ if [[ -s ./JHUGen.input ]]; then
 fi
 
 ### retrieve the powheg source tar ball
-export POWHEGSRC=powhegboxV2_rev3624_date20190201.tar.gz
+export POWHEGSRC=powhegboxV2_rev3624_date20190117.tar.gz
 
 if [ "$process" = "b_bbar_4l" ] || [ "$process" = "HWJ_ew" ] || [ "$process" = "HW_ew" ] || [ "$process" = "HZJ_ew" ] || [ "$process" = "HZ_ew" ]; then 
   export POWHEGSRC=powhegboxRES_rev3478_date20180122.tar.gz 
@@ -442,7 +442,7 @@ if [ "$process" = "Zj" ] || [ "$process" = "Wj" ]; then
 fi
 
 
-sed -i -e "s#500#1200#g"  POWHEG-BOX/include/pwhg_rwl.h
+sed -i -e "s#500#1350#g"  POWHEG-BOX/include/pwhg_rwl.h
 
 echo ${POWHEGSRC} > VERSION
 


### PR DESCRIPTION
Fix wrong tarball (should be deleted from AFS area) and augment number of maximum weights: at the moment there are 1284 in UL2019. 