### PR TITLE
Fixes for disappearing tracks AMSB in 102X

### DIFF
--- a/python/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -2,8 +2,6 @@ COM_ENERGY = 13000.
 MCHI = XXX  # GeV
 CTAU = YYY  # mm
 CROSS_SECTION = ZZZ # pb
-SLHA_TABLE="""
-""" % (1.97326979e-13 / CTAU)
 
 import FWCore.ParameterSet.Config as cms
 
@@ -15,7 +13,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     pythiaPylistVerbosity = cms.untracked.int32(0),
     filterEfficiency = cms.untracked.double(-1),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
-    SLHATableForPythia8 = cms.string('%s' % SLHA_TABLE),
+    SLHAFileForPythia8 = cms.string('Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSB/slha_withDecay/%scm/AMSB_chargino_%sGeV_%scm_Isajet780.slha' % (CTAU/10, MCHI, CTAU/10)),
     comEnergy = cms.double(COM_ENERGY),
     crossSection = cms.untracked.double(CROSS_SECTION),
     maxEventsToPrint = cms.untracked.int32(0),
@@ -35,12 +33,11 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
         parameterSets = cms.vstring(
             'pythia8CommonSettings',
             'pythia8CP5Settings',
-            'pythia8PSweightsSettingsBlock',
+            'pythia8PSweightsSettings',
             'processParameters')
     ),
     # The following parameters are required by Exotica_HSCP_SIM_cfi:
     slhaFile = cms.untracked.string(''),   # value not used
-    SLHAFileForPythia8 = cms.untracked.string(''),   # value not used, used over slhaFile for CMSSW >= 10_2_X
     processFile = cms.untracked.string('SimG4Core/CustomPhysics/data/RhadronProcessList.txt'),
     useregge = cms.bool(False),
     hscpFlavor = cms.untracked.string('stau'),

--- a/python/ThirteenTeV/DisappTrksAMSB/README.md
+++ b/python/ThirteenTeV/DisappTrksAMSB/README.md
@@ -6,6 +6,8 @@ https://indico.cern.ch/event/725187/contributions/3018385/attachments/1656960/26
     cd $CMSSW_BASE/src
     scramv1 b -j 9
 
+**Important!** The `Exotica_HSCP_SIM_cfi` and `customiseSequentialSim` customisation fragments are **required** in order for the charginos to interact with the detector! The rest can be changed to suit the campaign as needed.
+
 94X e.g.:
 
     cmsDriver.py Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSB/test/AMSB_chargino_M-700GeV_CTau-100cm_TuneCP5_13TeV_pythia8_cff.py \

--- a/python/ThirteenTeV/DisappTrksAMSB/createPoints.py
+++ b/python/ThirteenTeV/DisappTrksAMSB/createPoints.py
@@ -55,13 +55,24 @@ for mass in xsecs:
 		os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile + ' > ' + outputConfigFile)
 		os.system('sed -i "s/YYY/' + str(int(ctau * 10.0)) + '/g" ' + outputConfigFile) # mm
 		os.system('sed -i "s/ZZZ/' + str(xsecs[mass]) + '/g" ' + outputConfigFile)
-		insertSLHA(outputConfigFile, mass)
-
-		mW1ss = findMassValue(outputConfigFile, 'w1ss')
-		mZ1ss = findMassValue(outputConfigFile, 'z1ss')
-
+		
 		tau = ctau / c * 1.e9 # ns
 		width = (1.97326979e-14 / ctau) # GeV
+
+		if os.environ["CMSSW_VERSION"].startswith('CMSSW_10_'):
+			if not os.path.exists('slha_withDecay/'):
+				os.mkdir('slha_withDecay')
+			if not os.path.exists('slha_withDecay/%dcm/' % ctau):
+				os.mkdir('slha_withDecay/%dcm' % ctau)
+			baseSLHA   = 'slha/AMSB_chargino_%dGeV_Isajet780.slha' % mass
+			outputSLHA = 'slha_withDecay/%scm/AMSB_chargino_%sGeV_%scm_Isajet780.slha' % (ctau, mass, ctau)
+			os.system('sed "s/%.9g # chargino decay/' + str(width) + ' # chargino decay/g" ' + baseSLHA + ' > ' + outputSLHA)
+			mW1ss = findMassValue(outputSLHA, 'w1ss')
+			mZ1ss = findMassValue(outputSLHA, 'z1ss')
+		else:
+			insertSLHA(outputConfigFile, mass)
+			mW1ss = findMassValue(outputConfigFile, 'w1ss')
+			mZ1ss = findMassValue(outputConfigFile, 'z1ss')
 
 		os.system('sed "s/_MW1SS/' + str(mW1ss) + '/g" ' + baseParticleFile + ' > ' + outputParticleFile)
 		os.system('sed -i "s/_MZ1SS/' + str(mZ1ss) + '/g" ' + outputParticleFile)

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/AMSB_gluinoToChargino_M-XXXGeV_M-YYYGeV_CTau-ZZZcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -3,8 +3,6 @@ MGLU = XXX  # GeV
 MCHI = YYY  # GeV
 CTAU = ZZZ  # mm
 CROSS_SECTION = WWW # pb
-SLHA_TABLE="""
-""" % (MGLU, (1.97326979e-13 / CTAU))
 
 import FWCore.ParameterSet.Config as cms
 
@@ -16,7 +14,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     pythiaPylistVerbosity = cms.untracked.int32(0),
     filterEfficiency = cms.untracked.double(-1),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
-    SLHATableForPythia8 = cms.string('%s' % SLHA_TABLE),
+    SLHAFileForPythia8 = cms.string('Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSBCascade/slha_withDecay/%scm/AMSB_gluinoToChargino_%sGeV_%sGeV_%scm_Isajet780.slha' % (CTAU/10, MGLU, MCHI, CTAU/10)),
     comEnergy = cms.double(COM_ENERGY),
     crossSection = cms.untracked.double(CROSS_SECTION),
     maxEventsToPrint = cms.untracked.int32(0),
@@ -36,12 +34,11 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
         parameterSets = cms.vstring(
             'pythia8CommonSettings',
             'pythia8CP5Settings',
-            'pythia8PSweightsSettingsBlock',
+            'pythia8PSweightsSettings',
             'processParameters')
     ),
     # The following parameters are required by Exotica_HSCP_SIM_cfi:
     slhaFile = cms.untracked.string(''),   # value not used
-    SLHAFileForPythia8 = cms.untracked.string(''),   # value not used, used over slhaFile for CMSSW >= 10_2_X
     processFile = cms.untracked.string('SimG4Core/CustomPhysics/data/RhadronProcessList.txt'),
     useregge = cms.bool(False),
     hscpFlavor = cms.untracked.string('stau'),

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/README.md
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/README.md
@@ -7,6 +7,8 @@ https://indico.cern.ch/event/725187/contributions/3018385/attachments/1656960/26
     cd $CMSSW_BASE/src
     scramv1 b -j 9
 
+**Important!** The `Exotica_HSCP_SIM_cfi` and `customiseSequentialSim` customisation fragments are **required** in order for the charginos to interact with the detector! The rest can be changed to suit the campaign as needed.
+
 94X e.g.:
 
     cmsDriver.py Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSBCascade/test/AMSB_gluinoToChargino_M-2000GeV_M-700GeV_CTau-100cm_TuneCP5_13TeV_pythia8_cff.py \

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
@@ -66,13 +66,25 @@ for mass in xsecs:
                         os.system('sed -i "s/YYY/' + str(charginoMass) + '/g" ' + outputConfigFile) # mm
                         os.system('sed -i "s/ZZZ/' + str(int(ctau * 10.0)) + '/g" ' + outputConfigFile) # mm
                         os.system('sed -i "s/WWW/' + str(xsecs[mass]) + '/g" ' + outputConfigFile)
-                        insertSLHA(outputConfigFile, charginoMass)
-
-                        mW1ss = findMassValue(outputConfigFile, 'w1ss')
-                        mZ1ss = findMassValue(outputConfigFile, 'z1ss')
 
                         tau = ctau / c * 1.e9 # ns
                         width = (1.97326979e-14 / ctau) # GeV
+
+                        if os.environ["CMSSW_VERSION"].startswith('CMSSW_10_'):
+                                if not os.path.exists('slha_withDecay/'):
+                                        os.mkdir('slha_withDecay')
+                                if not os.path.exists('slha_withDecay/%dcm/' % ctau):
+                                        os.mkdir('slha_withDecay/%dcm' % ctau)
+                                baseSLHA   = 'slha/AMSB_chargino_%dGeV_Isajet780.slha' % charginoMass
+                                outputSLHA = 'slha_withDecay/%dcm/AMSB_gluinoToChargino_%dGeV_%dGeV_%dcm_Isajet780.slha' % (ctau, mass, charginoMass, ctau)
+                                os.system('sed "s/%.9g   #  glss/' + str(mass) + '   #  glss/g" ' + baseSLHA + ' > ' + outputSLHA)
+                                os.system('sed -i "s/%.9g # chargino decay/' + str(width) + ' # chargino decay/g" ' + outputSLHA)
+                                mW1ss = findMassValue(outputSLHA, 'w1ss')
+                                mZ1ss = findMassValue(outputSLHA, 'z1ss')
+                        else:
+                                insertSLHA(outputConfigFile, mass)
+                                mW1ss = findMassValue(outputConfigFile, 'w1ss')
+                                mZ1ss = findMassValue(outputConfigFile, 'z1ss')
 
                         os.system('sed "s/_MW1SS/' + str(mW1ss) + '/g" ' + baseParticleFile + ' > ' + outputParticleFile)
                         os.system('sed -i "s/_MZ1SS/' + str(mZ1ss) + '/g" ' + outputParticleFile)

--- a/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
+++ b/python/ThirteenTeV/DisappTrksAMSBCascade/createPoints.py
@@ -82,7 +82,7 @@ for mass in xsecs:
                                 mW1ss = findMassValue(outputSLHA, 'w1ss')
                                 mZ1ss = findMassValue(outputSLHA, 'z1ss')
                         else:
-                                insertSLHA(outputConfigFile, mass)
+                                insertSLHA(outputConfigFile, charginoMass)
                                 mW1ss = findMassValue(outputConfigFile, 'w1ss')
                                 mZ1ss = findMassValue(outputConfigFile, 'z1ss')
 


### PR DESCRIPTION
These commits fix an issue with the 102X configs for the disappearing tracks AMSB requests introduced in the previous PR #2258. A PR in CMSSW_10_2_X (https://github.com/cms-sw/cmssw/pull/22615) made `SLHAFileForPythia8` mandatory when using `Exotica_HSCP_SIM_cfi.py`, and PR #2258 did not implement it correctly.

With these changes, these configs will work in 102X with `SLHAFileForPythia8` pointing to an SLHA file with the chargino decays included.

There is no change in behavior when used in anything except 102X.