### PR TITLE
Port https://github.com/cms-sw/genproductions/pull/2289 to UL2019

### DIFF
--- a/bin/Powheg/make_rwl.py
+++ b/bin/Powheg/make_rwl.py
@@ -18,7 +18,7 @@ Example of usage for 4F:  python make_rwl.py 0 320900
 
 is5FlavorScheme = str(sys.argv[1])
 CentralPDF = str(sys.argv[2])
-forDYNNLOPS = str(sys.argv[3]) if len(sys.argv) > 3 else 0
+forDYNNLOPS = bool(int(sys.argv[3])) if len(sys.argv) > 3 else False
 
 # is5FlavorScheme = True
 # CentralPDF = 306000
@@ -48,8 +48,8 @@ for m_rensc in m_factor :
 		  
 fout.write("</weightgroup>\n")
 
-if int(forDYNNLOPS) == 1:
-  print("Scale variations will be duplicated 8 times for DYNNLOPS reweighting")
+if forDYNNLOPS:
+  print("DYNNLOPS: Scale variations will be duplicated for 9x9 final NNLOxMINLO weights")
   
   fout.write("<weightgroup name='scale_variation2' combine='envelope' >\n")
 
@@ -62,7 +62,38 @@ if int(forDYNNLOPS) == 1:
 		  
   fout.write("</weightgroup>\n")
 
-if int(is5FlavorScheme) == 1:
+  print("DYNNLOPS: PDF variations will be reduced for generation speed")
+    # reduced 5F PDF for DYNNLOPS
+  pdf_sets = {
+            # weight id, LHAPDF id, name, replicas to be written
+            "PDF_variation1 , hessian" :
+            [
+              [2000, 306000, 'NNPDF31_nnlo_hessian_pdfas', 103],
+              [2104, 322500, 'NNPDF31_nnlo_as_0108', 1],
+              [2105, 322700, 'NNPDF31_nnlo_as_0110', 1],
+              [2106, 322900, 'NNPDF31_nnlo_as_0112', 1],
+              [2107, 323100, 'NNPDF31_nnlo_as_0114', 1],
+              [2108, 323300, 'NNPDF31_nnlo_as_0117', 1],
+              [2109, 323500, 'NNPDF31_nnlo_as_0119', 1],
+              [2110, 323700, 'NNPDF31_nnlo_as_0122', 1],
+              [2111, 323900, 'NNPDF31_nnlo_as_0124', 1],
+              [2200, 325700, 'NNPDF31_nnlo_as_0118_CMSW1_hessian_100', 101],
+              [2400, 325900, 'NNPDF31_nnlo_as_0118_CMSW2_hessian_100', 101],
+              [2600, 326100, 'NNPDF31_nnlo_as_0118_CMSW3_hessian_100', 101],
+              [2800, 326300, 'NNPDF31_nnlo_as_0118_CMSW4_hessian_100', 101],
+              [5000, 13000, 'CT14nnlo', 57],
+              [5060, 13065, 'CT14nnlo_as_0116', 1],
+              [5070, 13069, 'CT14nnlo_as_0120', 1],
+              [7000, 25300, 'MMHT2014nnlo68cl', 51],
+              [7060, 25360, 'MMHT2014nnlo_asmzsmallrange', 3],
+              [8000, 42560, 'ABMP16_5_nnlo', 30],
+              [13000, 61200, 'HERAPDF20_NNLO_EIG', 29],
+              [13050, 61230, 'HERAPDF20_NNLO_VAR', 14],
+              [13100, 61740, 'HERAPDF20_NNLO_ALPHAS', 21],
+            ],
+          }
+
+elif int(is5FlavorScheme) == 1:
   # 5F PDF
   pdf_sets = {
             # weight id, LHAPDF id, name, replicas to be written
@@ -153,6 +184,7 @@ else:
             ],
           }
   
+pdf_count = 0
 for key, pdfsets in sorted(pdf_sets.iteritems()):
   weightgroup_name = key.replace(" ", "").split(',')[0]
   combine = key.replace(" ", "").split(',')[1]
@@ -166,8 +198,11 @@ for key, pdfsets in sorted(pdf_sets.iteritems()):
     for idx in range(pdf_member_start, pdf_member_end) :
       fout.write("<weight id='"+str(m_idx)+"'> lhapdf="+str(idx)+" </weight>\n")
       m_idx = m_idx + 1
+      pdf_count += 1
   fout.write("</weightgroup>\n")
 
 fout.write("</initrwgt>\n")
 
 fout.close()
+
+print 'pdf_count = ',pdf_count

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToENu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToENu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToMuNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToMuNu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToMuNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToMuNu-powheg.input
@@ -1,0 +1,85 @@
+! W^- + jet production parameter
+idvecbos -24
+vdecaymode 2
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Wmass   80.398d0
+Wwidth  2.08872d0
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+! CKM (as in dynnlo)
+CKM_Vud 0.97427d0
+CKM_Vus 0.2253d0
+CKM_Vub 0.00351d0
+CKM_Vcd 0.2252d0
+CKM_Vcs 0.97344d0
+CKM_Vcb 0.0412d0
+CKM_Vtd 1d-5
+CKM_Vts 1d-5
+CKM_Vtb 1d0
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13000d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed    SEED    ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+doublefsr 1
+bornzerodamp 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToTauNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToTauNu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToTauNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WminusJToTauNu-powheg.input
@@ -1,0 +1,85 @@
+! W^- + jet production parameter
+idvecbos -24
+vdecaymode 3
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Wmass   80.398d0
+Wwidth  2.08872d0
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+! CKM (as in dynnlo)
+CKM_Vud 0.97427d0
+CKM_Vus 0.2253d0
+CKM_Vub 0.00351d0
+CKM_Vcd 0.2252d0
+CKM_Vcs 0.97344d0
+CKM_Vcb 0.0412d0
+CKM_Vtd 1d-5
+CKM_Vts 1d-5
+CKM_Vtb 1d0
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13000d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed    SEED    ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+doublefsr 1
+bornzerodamp 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToENu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToENu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToMuNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToMuNu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToMuNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToMuNu-powheg.input
@@ -1,0 +1,85 @@
+! W^+ + jet production parameter
+idvecbos 24
+vdecaymode 2
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Wmass   80.398d0
+Wwidth  2.08872d0
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+! CKM (as in dynnlo)
+CKM_Vud 0.97427d0
+CKM_Vus 0.2253d0
+CKM_Vub 0.00351d0
+CKM_Vcd 0.2252d0
+CKM_Vcs 0.97344d0
+CKM_Vcb 0.0412d0
+CKM_Vtd 1d-5
+CKM_Vts 1d-5
+CKM_Vtb 1d0
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13000d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed    SEED    ! initialize random number sequence 
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+doublefsr 1
+bornzerodamp 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToTauNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToTauNu-powheg.input
@@ -58,7 +58,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToTauNu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/WplusJToTauNu-powheg.input
@@ -1,0 +1,85 @@
+! W^+ + jet production parameter
+idvecbos 24
+vdecaymode 3
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Wmass   80.398d0
+Wwidth  2.08872d0
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+! CKM (as in dynnlo)
+CKM_Vud 0.97427d0
+CKM_Vus 0.2253d0
+CKM_Vub 0.00351d0
+CKM_Vcd 0.2252d0
+CKM_Vcs 0.97344d0
+CKM_Vcb 0.0412d0
+CKM_Vtd 1d-5
+CKM_Vts 1d-5
+CKM_Vtb 1d0
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13000d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed    SEED    ! initialize random number sequence 
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+doublefsr 1
+bornzerodamp 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToEE-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToEE-powheg.input
@@ -45,7 +45,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToMuMu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToMuMu-powheg.input
@@ -45,7 +45,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToMuMu-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToMuMu-powheg.input
@@ -1,0 +1,72 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Zmass   91.1876d0   ! as in dynnlo
+Zwidth  2.49595d0   ! as in dynnlo
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+min_Z_mass 50d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 13000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+bornzerodamp 1
+doublefsr 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToTauTau-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToTauTau-powheg.input
@@ -45,7 +45,7 @@ ncall2 100000   ! number of calls for computing the integral and finding upper b
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
 foldcsi   5    ! number of folds on csi integration
 foldy     5    ! number of folds on  y  integration
-foldphi   5    ! number of folds on phi integration
+foldphi   2    ! number of folds on phi integration
 nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToTauTau-powheg.input
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/ZJToTauTau-powheg.input
@@ -1,0 +1,72 @@
+vdecaymode  3     ! Z decay products (default 2): 1 for electronic
+
+par_isrtinyy 5d-6
+par_fsrtinyy 5d-6
+par_isrtinycsi 5d-6
+par_fsrtinycsi 5d-6
+
+minlo 1            ! default 0
+minlo_nnll 1       ! (default 0)
+runningscales 0    ! 0 = fixed scale
+facscfact 1
+renscfact 1
+factsc2min 2
+frensc2min 2
+sudscalevar 1
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! EW parameters
+Zmass   91.1876d0   ! as in dynnlo
+Zwidth  2.49595d0   ! as in dynnlo
+alphaem 7.556254d-3 ! as computed by dynnlo
+sthw2   0.22264585  ! as computed by dynnlo
+
+min_Z_mass 50d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 13000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1 306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2 306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   5    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+withdamp  0        ! (default 0, do not use) use B
+withnegweights 1   ! (0 default) If 1 output negative weighted events. If 0 descard them.
+# olddij 0         ! turn this on to reproduce exactly the "old"
+                   ! behaviour of ref. JHEP 1305 (2013) 082
+
+testplots  0       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+
+bornzerodamp 1
+doublefsr 1

--- a/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/dynnlopsHelper.sh
+++ b/bin/Powheg/production/pre2017/13TeV/DYNNLOPS_NNPDF31_13TeV/dynnlopsHelper.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+trap "exit" INT
+
+WHAT=$1;
+if [ "$#" -ne 1 ]; then
+    echo "dynnlopsHelper.sh <OPTION>";
+    exit 1;
+fi
+
+PROCS=(WminusJToENu WminusJToMuNu WminusJToTauNu WplusJToENu WplusJToMuNu WplusJToTauNu ZJToEE ZJToMuMu ZJToTauTau)
+#PROCS=(ZJToEE ZJToMuMu ZJToTauTau)
+#PROCS=(WplusJToENu-522 WplusJToENu-552)
+#PROCS=(WplusJToENu-552)
+
+case $WHAT in
+
+    PRINT )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC}
+        done
+    ;;
+    
+    COMPILE )
+        for PROC in ${PROCS[@]}
+        do
+            python ./run_pwg_condor.py -p 0 -i DYNNLOPS_NNPDF31_13TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS
+        done
+    ;;
+
+    GRIDS )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 123 -i DYNNLOPS_NNPDF31_13TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS -q nextweek --step3pilot &
+        done
+    ;;
+    
+    GRIDS1 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 1 -i DYNNLOPS_NNPDF31_13TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS -q tomorrow &
+        done
+    ;;
+    
+    GRIDS2 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 2 -i DYNNLOPS_NNPDF31_13TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS -q nextweek &
+        done
+    ;;
+    
+    GRIDS3 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 3 -i DYNNLOPS_NNPDF31_13TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS -q tomorrow --step3pilot &
+        done
+    ;;
+    
+    COPY_GRIDS )
+        OLDDIR=/afs/cern.ch/work/m/mseidel/generator/CMSSW_10_0_5/src/
+        for PROC in ${PROCS[@]}
+        do
+            # integration grids
+            cp -n -v ${OLDDIR}/${PROC}-555-powheg/*.dat ${PROC}-powheg-NNLOPS/
+            
+            # files for NNLO reweighting
+            NNLOTOP=none
+            if [ ${PROC:0:2} = "Wm" ]; then
+                NNLOTOP=WminusJToENu
+            fi
+            if [ ${PROC:0:2} = "Wp" ]; then
+                NNLOTOP=WplusJToENu
+            fi
+            if [ ${PROC:0:1} = "Z" ]; then
+                NNLOTOP=ZJToEE
+            fi
+            cp -n -v ${OLDDIR}/${NNLOTOP}-555-powheg/DYNNLO* ${PROC}-powheg-NNLOPS/
+            cp -n -v ${OLDDIR}/${NNLOTOP}-555-powheg/MINLO*.top ${PROC}-powheg-NNLOPS/
+        done
+    ;;
+    
+    PACK )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            python ./run_pwg_condor.py -p 9 -m ${PROC:0:1}j -f ${PROC}-powheg-NNLOPS &
+        done
+    ;;
+    
+    TEST )
+        mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            mkdir ${PROC}; cd ${PROC}
+            tar -xzf ../../${PROC:0:1}j_slc7_amd64_gcc700_CMSSW_10_6_0_${PROC}-powheg-NNLOPS.tgz
+            ./runcmsgrid.sh 150 1 1 &
+            cd ..
+        done
+    ;;
+    
+
+esac

--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -1367,7 +1367,7 @@ def dynnlops_mergeminlo(folderName, process, eosdir):
 
 def make_nnlo_rwl(folderName):
     # check pwg-rwl.dat
-    rwlfile = 'pwg-rwl.dat'
+    rwlfile = folderName + '/pwg-rwl.dat'
     if 'scale_variation2' in open(rwlfile).read():
         print('Creating 9x9 NNLOxMINLO scale variations')
     else:

--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -933,8 +933,8 @@ def runEvents(parstage, folderName, EOSfolder, njobs, powInputName, jobtag, proc
     print 'run : submitting jobs'
     
     inputName = folderName + "/powheg.input"
-    
-    sedcommand = 'sed -i "s/NEVENTS/2000/ ; s/SEED/3/ " '+inputName
+
+    sedcommand = 'sed -i "s/NEVENTS/2000/ ; s/iseed.*/iseed '+str(seed)+'/" '+inputName
     runCommand(sedcommand)
     
     if (parstage in ['2', '3']) :


### PR DESCRIPTION
Critical fix by @intrepid42 ported to UL branch (the full PR is ported, so DYNNLOPS specific changes are also in, which I think is good...)

Markus, the PR as is will create a discrepancy w.r.t. default PDFs in DYNNLOPS and default (pos-def) PDFs for other samples, please check whether this is correct.