### PR TITLE
Add special TT4L samples for HIG-19-001 and HIG-19-009

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,35 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ZZ/WW->2l2nu + T->b W+(->nu l+) + Tb->bb W-(->l- nub)
+generate p p > t t~ l- l+ vl vl~ / h, (t > dq vl l+) / h, (t~ > dq~ l- vl~) / h
+
+
+output TT2L2Nu_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Nu_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,35 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ZZ+ZW->2l2q + T->b W+(->nu l+) + Tb->bb W-(->l- nub)
+generate p p > t t~ l- l+ q q~ / h, (t > dq vl l+) / h, (t~ > dq~ l- vl~) / h
+
+
+output TT2L2Q_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L2Q_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,35 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ttZ
+generate p p > t t~ l- l+ / h, (t > dq l+ vl) / h, (t~ > dq~ l- vl~) / h
+
+
+output TT2L_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT2L_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,36 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ZW+ -> 2l l+ nu + TTb->b bb f fb' lnu
+generate p p > t t~ l- l+ l+ vl / h, (t > dq l+ vl) / h, (t~ > dq~ lvq lvq~) / h
+add process p p > t t~ l- l+ l+ vl / h, (t > dq lvq lvq~) / h, (t~ > dq~ vl~ l-) / h
+
+
+output TT3L1Nu_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nu_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,36 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ZW- -> 2l l- nub + TTb->b bb f fb' lnu
+generate p p > t t~ l- l+ l- vl~ / h, (t > dq l+ vl) / h, (t~ > dq~ lvq lvq~) / h
+add process p p > t t~ l- l+ l- vl~ / h, (t > dq lvq lvq~) / h, (t~ > dq~ vl~ l-) / h
+
+
+output TT3L1Nubar_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT3L1Nubar_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_proc_card.dat
@@ -1,0 +1,35 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# ZZ->4l + T->b W+(->f fb') + Tb->bb W-(->f fb')
+generate p p > t t~ l- l+ l- l+ / h, (t > dq lvq lvq~) / h, (t~ > dq~ lvq lvq~) / h
+
+
+output TT4L_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TT4L_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
@@ -11,7 +11,7 @@ set param_card decay 24 2.085
 set run_card use_syst True
 #set run_card pdlabel lhapdf
 set run_card lhaid 263000
-set run_card bwcutoff 15000
+set run_card bwcutoff 15
 set run_card ickkw 1
 set run_card ktscheme 1
 set run_card asrwgtflavor 5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
@@ -10,7 +10,7 @@ set param_card decay 24 2.085
 # Customization of run parameters
 set run_card use_syst True
 #set run_card pdlabel lhapdf
-#set run_card lhaid 263000
+set run_card lhaid 263000
 set run_card bwcutoff 15000
 set run_card ickkw 1
 set run_card ktscheme 1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
@@ -7,16 +7,6 @@ set param_card decay 23 2.4952
 set param_card mass 24 80.399
 set param_card decay 24 2.085
 
-# Customization of run parameters
-set run_card use_syst True
-#set run_card pdlabel lhapdf
-set run_card lhaid 263000
-set run_card bwcutoff 15
-set run_card ickkw 1
-set run_card ktscheme 1
-set run_card asrwgtflavor 5
-set run_card maxjetflavor 5
-
 # Kinematic cuts
 set run_card ptj 15.0
 set run_card etaj 6.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_customizecards.dat
@@ -1,0 +1,29 @@
+# Consistent parameters with signal generation
+set param_card yukawa 6 173.2
+set param_card mass 6 173.2
+set param_card decay 6 2.0
+set param_card mass 23 91.1876
+set param_card decay 23 2.4952
+set param_card mass 24 80.399
+set param_card decay 24 2.085
+
+# Customization of run parameters
+set run_card use_syst True
+#set run_card pdlabel lhapdf
+#set run_card lhaid 263000
+set run_card bwcutoff 15000
+set run_card ickkw 1
+set run_card ktscheme 1
+set run_card asrwgtflavor 5
+set run_card maxjetflavor 5
+
+# Kinematic cuts
+set run_card ptj 15.0
+set run_card etaj 6.5
+set run_card drjj 0.3
+set run_card ptl -1.0
+set run_card etal 3.0
+set run_card drll 0.2
+set run_card drjl -1
+set run_card mmjj 20
+set run_card mmll 4

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_proc_card.dat
@@ -1,0 +1,35 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+
+define p = p b b~
+define l- = e- mu- ta-
+define l+ = e+ mu+ ta+
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define q = d u s c b
+define q~ = d~ u~ s~ c~ b~
+define dq = d s b
+define dq~ = d~ s~ b~
+define uq = u c
+define uq~ = u~ c~
+define lv = l- vl
+define lv~ = l+ vl~
+define lvq = lv q
+define lvq~ = lv~ q~
+define lq = l- q
+define lq~ = l+ q~
+define vq = vl q
+define vq~ = vl~ q~
+
+
+# T Tb T Tb -> b bb b bb l- l+ l- l+
+generate p p > t t~ t t~ / h, (t > dq l+ vl) / h, (t~ > dq~ vl~ l-) / h
+
+
+output TTTT_4LFilter_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
@@ -47,7 +47,7 @@
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
   lhapdf	= pdlabel ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid
+263000 = lhaid
 $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
@@ -71,7 +71,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # Matching parameter (MLM only)
 #*********************************************************************
-  1	= ickkw ! 0 no matching, 1 MLM
+  0	= ickkw ! 0 no matching, 1 MLM
   1	=  highestmult       ! for ickkw=2, highest mult group
   1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
   1.0	= alpsfact ! scale factor for QCD emission vx

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
@@ -1,0 +1,280 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  1	= ickkw ! 0 no matching, 1 MLM
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  15.0	= ptj ! minimum pt for the jets 
+  0.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  -1.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5	= etaj ! max rap for the jets 
+  -1.0	= etab ! max rap for the b
+  2.5	= etaa ! max rap for the photons 
+  3.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.3	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.2	= drll ! min distance between leptons 
+  0.4	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.4	= draj ! min distance between gamma and jet 
+  -1.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.4	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  20.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  4.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  True	= use_syst ! Enable systematics studies
+#
+  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
+#  Additional hidden parameters
+#*********************************************************************
+  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
@@ -271,10 +271,3 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
   True	= use_syst ! Enable systematics studies
-#
-  systematics	= systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'#********************************************************************* 
-#  Additional hidden parameters
-#*********************************************************************
-  ['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset']	= systematics_arguments # Choose the argment to pass to the systematics command. like --mur=0.25,1,4. Look at the help of the systematics function for more details.

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT2LX_4LFilter_5f_LO/TTTT_4LFilter_5f_LO_run_card.dat
@@ -104,7 +104,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #*********************************************************************
 # BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
 #*********************************************************************
-  15000.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
 #*********************************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)


### PR DESCRIPTION
These are special samples needed for HIG-19-001 and HIG-19-009 as they proceed to approval/approval reprise:
- proc_cards are essentially the same except for the generate (or add process lines)
- run_cards and customizecards are identical.
- Making this PR myself after discussion with HZZ conveners and the HZZ MC contact.
- The preference is to request these samples for 2016-2018 with the same (NNPDF3.0) configurations in order to be consistent with the rest of the analysis elements, but I don't know exactly how to do that.

Please let me know if anything needs to be changed, and I will be happy to make the commit.

cc: @qyguo 