### PR TITLE
Fix false hold job warning

### DIFF
--- a/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
+++ b/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
@@ -360,8 +360,9 @@ class CMSCondorCluster(CondorCluster):
                         else:
                             self.hold_msg = "ClusterId %s with HoldReason: %s" % (str(id), job["HoldReason"])
                             fail += 1
-                elif status == 'C' and self.spool:
-                    self.retrieve_output(id)
+                elif status == 'C':
+                    if self.spool:
+                        self.retrieve_output(id)
                 else:
                     logger.warning("Failed condor job = " + str(id))
                     logger.warning( job )

--- a/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
+++ b/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
@@ -359,12 +359,13 @@ class CMSCondorCluster(CondorCluster):
                             run += 1
                         else:
                             self.hold_msg = "ClusterId %s with HoldReason: %s" % (str(id), job["HoldReason"])
+                            logger.warning(self.hold_msg)
                             fail += 1
                 elif status == 'C':
                     if self.spool:
                         self.retrieve_output(id)
                 else:
-                    logger.warning("Failed condor job = " + str(id))
+                    logger.warning("Failed condor job " + str(id) + " with status " + status)
                     logger.warning( job )
                     fail += 1
 


### PR DESCRIPTION
When generating gridpack with the cms_condor queue I'm getting a warning  "WARNING: Failed condor job ...". I believe it's a false warning due to a bug in PLUGIN/CMS_CLUSTER/__init__.py. See proposed changes Line 363-364. Other changes are improvement of warning messages.