### PR TITLE
TT FCNC top-photon: enable systematics in run card

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-T2AJ_aTleptonic_kappa_act_LO/TT_FCNC-T2AJ_aTleptonic_kappa_act_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-T2AJ_aTleptonic_kappa_act_LO/TT_FCNC-T2AJ_aTleptonic_kappa_act_LO_run_card.dat
@@ -262,3 +262,11 @@ True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 20.0	=  xqcut    ! minimum kt jet measure between partons
 #*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True	=  use_syst       ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-T2AJ_aTleptonic_kappa_aut_LO/TT_FCNC-T2AJ_aTleptonic_kappa_aut_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-T2AJ_aTleptonic_kappa_aut_LO/TT_FCNC-T2AJ_aTleptonic_kappa_aut_LO_run_card.dat
@@ -262,3 +262,11 @@ True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 20.0	=  xqcut    ! minimum kt jet measure between partons
 #*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True	=  use_syst       ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-aT2AJ_Tleptonic_kappa_act_LO/TT_FCNC-aT2AJ_Tleptonic_kappa_act_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-aT2AJ_Tleptonic_kappa_act_LO/TT_FCNC-aT2AJ_Tleptonic_kappa_act_LO_run_card.dat
@@ -262,3 +262,11 @@ True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 20.0	=  xqcut    ! minimum kt jet measure between partons
 #*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True	=  use_syst       ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-aT2AJ_Tleptonic_kappa_aut_LO/TT_FCNC-aT2AJ_Tleptonic_kappa_aut_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/TT_FCNC-aT2AJ_Tleptonic_kappa_aut_LO/TT_FCNC-aT2AJ_Tleptonic_kappa_aut_LO_run_card.dat
@@ -262,3 +262,11 @@ True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 20.0	=  xqcut    ! minimum kt jet measure between partons
 #*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True	=  use_syst       ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/refcards/madgraph_card/TT_no_top_decay_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_FCNC/refcards/madgraph_card/TT_no_top_decay_LO_run_card.dat
@@ -262,3 +262,11 @@ True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 20.0	=  xqcut    ! minimum kt jet measure between partons
 #*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True	=  use_syst       ! Enable systematics studies


### PR DESCRIPTION
Changes proposed in this PR:

- enabling systematics in TT FCNC top-photon run cards

The "use_syst" line was missing, such that systematic weights in the corresponding Fall17 and Fall18 requests were absent. This was noted initially by [Qiang](https://github.com/cms-sw/genproductions/pull/2051#issuecomment-452925378).

