### PR TITLE
ChargedHiggs_taunu_intermediateNoNeutral_LO: extended the mass range

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ChargedHiggs_taunu/ChargedHiggs_taunu_intermediateNoNeutral_LO_cards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ChargedHiggs_taunu/ChargedHiggs_taunu_intermediateNoNeutral_LO_cards.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-masses=(145 150 155 160 165 170 175 180 190 200)
+masses=(80 90 100 120 140 145 150 155 160 165 170 175 180 190 200)
 
 sample=ChargedHiggs_taunu_intermediateNoNeutral_LO
 postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)


### PR DESCRIPTION
The mass range of the LO H+ -> taunu production with the intermediate model was extended down to 80 to cover the light H+ masses. 