### PR TITLE
Check OS vs SCRAM_ARCH in Madgraph gridpack generation (UL2019 version)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -91,7 +91,7 @@ make_gridpack () {
     
       export SCRAM_ARCH=${scram_arch}
       export RELEASE=${cmssw_version}
-    
+
       ############################
       #Create a workplace to work#
       ############################
@@ -615,6 +615,13 @@ if [ -n "$5" ]
     scram_arch=${5}
   else
     scram_arch=slc7_amd64_gcc700 #slc6_amd64_gcc630 
+fi
+
+# Require OS and scram_arch to be consistent
+export SYSTEM_RELEASE=`cat /etc/redhat-release`
+if { [[ $SYSTEM_RELEASE == "*release 6*" ]] && [[ $scram_arch == "*slc6*" ]]; } || { [[ $SYSTEM_RELEASE == "*release 7*" ]] && [[ $scram_arch == "*slc7*" ]]; }; then
+  echo "Mismatch between architecture and OS"
+  if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi
 
 if [ -n "$6" ]

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -88,10 +88,10 @@ make_gridpack () {
     
     #   export SCRAM_ARCH=slc6_amd64_gcc472 #Here one should select the correct architechture corresponding with the CMSSW release
     #   export RELEASE=CMSSW_5_3_32_patch3
-    
+      
       export SCRAM_ARCH=${scram_arch}
       export RELEASE=${cmssw_version}
-
+      
       ############################
       #Create a workplace to work#
       ############################
@@ -619,7 +619,7 @@ fi
 
 # Require OS and scram_arch to be consistent
 export SYSTEM_RELEASE=`cat /etc/redhat-release`
-if { [[ $SYSTEM_RELEASE == "*release 6*" ]] && [[ $scram_arch == "*slc6*" ]]; } || { [[ $SYSTEM_RELEASE == "*release 7*" ]] && [[ $scram_arch == "*slc7*" ]]; }; then
+if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc6"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc7"* ]]; }; then
   echo "Mismatch between architecture and OS"
   if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -88,7 +88,7 @@ make_gridpack () {
     
     #   export SCRAM_ARCH=slc6_amd64_gcc472 #Here one should select the correct architechture corresponding with the CMSSW release
     #   export RELEASE=CMSSW_5_3_32_patch3
-      
+
       export SCRAM_ARCH=${scram_arch}
       export RELEASE=${cmssw_version}
       
@@ -619,7 +619,7 @@ fi
 
 # Require OS and scram_arch to be consistent
 export SYSTEM_RELEASE=`cat /etc/redhat-release`
-if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc6"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc7"* ]]; }; then
+if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc7"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc6"* ]]; }; then
   echo "Mismatch between architecture and OS"
   if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -88,10 +88,10 @@ make_gridpack () {
     
     #   export SCRAM_ARCH=slc6_amd64_gcc472 #Here one should select the correct architechture corresponding with the CMSSW release
     #   export RELEASE=CMSSW_5_3_32_patch3
-
+    
       export SCRAM_ARCH=${scram_arch}
       export RELEASE=${cmssw_version}
-      
+    
       ############################
       #Create a workplace to work#
       ############################

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -620,7 +620,7 @@ fi
 # Require OS and scram_arch to be consistent
 export SYSTEM_RELEASE=`cat /etc/redhat-release`
 if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc7"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc6"* ]]; }; then
-  echo "Mismatch between architecture and OS"
+  echo "Mismatch between architecture (${scram_arch}) and OS (${SYSTEM_RELEASE})"
   if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi
 


### PR DESCRIPTION
A number of analyzers have produced nonfunctional gridpacks due to logging into lxplus7 and making a gridpack with an SLC6 SCRAM_ARCH. This PR adds a simple check to avoid this problem.

Port of #2419 