### PR TITLE
Change default SCRAM_ARCH to slc7_amd64_gcc630 (master)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -614,13 +614,16 @@ if [ -n "$5" ]
   then
     scram_arch=${5}
   else
-    scram_arch=slc6_amd64_gcc630 #slc6_amd64_gcc481
+    scram_arch=slc7_amd64_gcc630
+    #slc6_amd64_gcc630 
+    #slc6_amd64_gcc481
 fi
 
 # Require OS and scram_arch to be consistent
 export SYSTEM_RELEASE=`cat /etc/redhat-release`
 if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc7"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc6"* ]]; }; then
-  echo "Mismatch between architecture (${scram_arch}) and OS (${SYSTEM_RELEASE})"
+  echo "Mismatch between architecture (${scram_arch}) and OS (${SYSTEM_RELEASE})."
+  echo "Note: you can specify the architecture as a command line argument."
   if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi
 

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -623,7 +623,7 @@ fi
 export SYSTEM_RELEASE=`cat /etc/redhat-release`
 if { [[ $SYSTEM_RELEASE == *"release 6"* ]] && [[ $scram_arch == *"slc7"* ]]; } || { [[ $SYSTEM_RELEASE == *"release 7"* ]] && [[ $scram_arch == *"slc6"* ]]; }; then
   echo "Mismatch between architecture (${scram_arch}) and OS (${SYSTEM_RELEASE})."
-  echo "Note: you can specify the architecture as a command line argument."
+  echo "Note: you can specify the architecture as a command line argument. The default is slc7_amd64_gcc630."
   if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
 fi
 


### PR DESCRIPTION
I'm not sure whether this is appropriate, but this PR changes the default `scram_arch` to `slc7_amd64_gcc630` in gridpack_generation.sh. The recently added SCRAM_ARCH vs OS consistency check (https://github.com/cms-sw/genproductions/pull/2421) seems to be causing some confusion, because users don't know that the SCRAM_ARCH can be specified from the command-line argument, and end up with the default slc6 scram_arch on lxplus7. 

Alternatively, the consistency check could tell the user to login to lxplus6 instead.