### PR TITLE
changed way of checking Madgraph reweightcard

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -64,7 +64,7 @@ prepare_reweight () {
     scram_arch=$3
     reweight_card=$4
 
-    if ! cat $reweight_card | grep -q -e "change rwgt_dir \(\.\/\)\?rwgt"; then
+    if ! head -20 $reweight_card | grep -q -e "change rwgt_dir \(\.\/\)\?rwgt"; then
         echo "ERROR: Reweight card must contain the line"
         echo "    'change rwgt_dir ./rwgt'"
         echo "Refer to examples in genproductions repository."


### PR DESCRIPTION
This is changing the way the gridpack generation scripts check whether the madgraph reweight card contains the line `"change rwgt_dir \(\.\/\)\?rwgt"`

Now `head -20` is used (in the function prepare_reweight) instead of `cat` which caused the script to exit when the reweight card was larger than 98304 bytes.