### PR TITLE
Add MLM alps uncertainty to runcmsgrid_LO.

### DIFF
--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -166,7 +166,7 @@ mv process/$event_file process/madevent/Events/${runlabel}/events.lhe.gz
 #
 pushd process/madevent
 pdfsets="PDF_SETS_REPLACE"
-scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur,dyn --dyn=-1,1,2,3,4"
+scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur,dyn --dyn=-1,1,2,3,4 --alps=0.5,1,2"
 
 if [ "$doreweighting" -gt "0" ] ; then 
     echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent


### PR DESCRIPTION
For the moment, the scale variation is applied to all LO samples, no matter whether they use MLM merging or not. I have tested this change with the `wplusellnu01j_5f_LO_MLM` and `wplustest_5f_LO` processes, and confirmed that it works in both. If MLM merging is not used, the up/down variations are just identical. If that is deemed undesirable, we could also introduce a check in `runcmsgrid` to differentiate between MLM and non-MLM cases. This would then break the uniformity in number of weights / weight indices between the two cases.


The alps weight group is placed after the usual scale variations. In the LHE, the output looks like this:

```xml
<weightgroup name="Emission scale variation" combine="envelope">
<weight id="1046" MUR="1.0" MUF="1.0" ALPSFACT="0.5" PDF="263000" > alpsfact=0.5  </weight>
<weight id="1047" MUR="1.0" MUF="1.0" ALPSFACT="2.0" PDF="263000" > alpsfact=2.0  </weight>
</weightgroup> # ALPS
```
