### PR TITLE
update WJets and DYJets cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  5 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8/DYJetsToLL_M-10to50_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  DY     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
-  .true.     = gridpack  !True = setting up the grid pack
+  DYJets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  100 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- 'lhapdf'    = pdlabel     ! PDF set                                  
-$DEFAULT_PDF_SETS = lhaid
-$DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf number 
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15000  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
- 10  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1  = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1  = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0.4 = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
- 0.4 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
- 0.4 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ 0.0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
-10   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- 50  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,8 +3,8 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > w+ j, w+ > l+ vl $$ t t~ h @0
-add process p p > w- j, w- > l- vl~ $$ t t~ h @1
+generate p p > l+ vl j $$ t t~ h @0
+add process p p > l- vl~ j $$ t t~ h @1
 
 
 output W1JetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  4 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W1JetsToLNu_13TeV-madgraphMLM-pythia8/W1JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  Wjets     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
- .true.     = gridpack  !True = setting up the grid pack
+  W1Jets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
-  10 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  100 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- lhapdf = pdlabel ! PDF set
- $DEFAULT_PDF_SETS = lhaid
- $DEFAULT_PDF_MEMBERS  = reweight_PDF
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
-  0  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1 = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1 = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0   = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
+ 0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
  0.1 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
  0.1 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
- 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,8 +3,8 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > w+ j j, w+ > l+ vl $$ t t~ h @0
-add process p p > w- j j, w- > l- vl~ $$ t t~ h @1
+generate p p > l+ vl j j $$ t t~ h @0
+add process p p > l- vl~ j j $$ t t~ h @1
 
 
 output W2JetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  Wjets     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
- .true.     = gridpack  !True = setting up the grid pack
+  W2Jets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
-  10 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  100 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- lhapdf = pdlabel ! PDF set
- $DEFAULT_PDF_SETS = lhaid
- $DEFAULT_PDF_MEMBERS  = reweight_PDF
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
-  0  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1 = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1 = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0   = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
+ 0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
  0.1 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
  0.1 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
- 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W2JetsToLNu_13TeV-madgraphMLM-pythia8/W2JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  5 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,8 +3,8 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > w+ j j j, w+ > l+ vl $$ t t~ h @0
-add process p p > w- j j j, w- > l- vl~ $$ t t~ h @1
+generate p p > l+ vl j j j $$ t t~ h @0
+add process p p > l- vl~ j j j $$ t t~ h @1
 
 
 output W3JetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  5 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W3JetsToLNu_13TeV-madgraphMLM-pythia8/W3JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  Wjets     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
- .true.     = gridpack  !True = setting up the grid pack
+  W3Jets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
-  10 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  100 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- lhapdf = pdlabel ! PDF set
- $DEFAULT_PDF_SETS = lhaid
- $DEFAULT_PDF_MEMBERS  = reweight_PDF
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
-  0  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1 = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1 = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0   = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
+ 0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
  0.1 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
  0.1 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
- 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,8 +3,8 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > w+ j j j j, w+ > l+ vl $$ t t~ h @0
-add process p p > w- j j j j, w- > l- vl~ $$ t t~ h @1
+generate p p > l+ vl j j j j $$ t t~ h @0
+add process p p > l- vl~ j j j j $$ t t~ h @1
 
 
 output W4JetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  5 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/W4JetsToLNu_13TeV-madgraphMLM-pythia8/W4JetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  Wjets     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
- .true.     = gridpack  !True = setting up the grid pack
+  W4Jets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
-  10 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  100 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- lhapdf = pdlabel ! PDF set
- $DEFAULT_PDF_SETS = lhaid
- $DEFAULT_PDF_MEMBERS  = reweight_PDF
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
-  0  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1 = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1 = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0   = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
+ 0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
  0.1 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
+ 0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
  0.1 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
- 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,17 +3,17 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > w+, w+ > l+ vl $$ t t~ h @0
-add process p p > w+ j, w+ > l+ vl $$ t t~ h @1
-add process p p > w+ j j, w+ > l+ vl $$ t t~ h @2
-add process p p > w+ j j j, w+ > l+ vl $$ t t~ h @3
-add process p p > w+ j j j j, w+ > l+ vl $$ t t~ h @4
+generate p p > l+ vl $$ t t~ h @0
+add process p p > l+ vl j $$ t t~ h @1
+add process p p > l+ vl j j $$ t t~ h @2
+add process p p > l+ vl j j j $$ t t~ h @3
+add process p p > l+ vl j j j j $$ t t~ h @4
 
-add process p p > w-, w- > l- vl~ $$ t t~ h @5
-add process p p > w- j, w- > l- vl~ $$ t t~ h @6
-add process p p > w- j j, w- > l- vl~ $$ t t~ h @7
-add process p p > w- j j j, w- > l- vl~ $$ t t~ h @8
-add process p p > w- j j j j, w- > l- vl~ $$ t t~ h @9
+add process p p > l- vl~ $$ t t~ h @5
+add process p p > l- vl~ j $$ t t~ h @6
+add process p p > l- vl~ j j $$ t t~ h @7
+add process p p > l- vl~ j j j $$ t t~ h @8
+add process p p > l- vl~ j j j j $$ t t~ h @9
 
 
 output WJetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -72,7 +72,7 @@
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
  5 = asrwgtflavor     ! highest quark flavor for a_s reweight
- False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
  False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
  10.0   = xqcut   ! minimum kt jet measure between partons
 #*********************************************************************
@@ -275,7 +275,3 @@
 # WARNING: Do not use for interference type of computation           *
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
-#
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_run_card.dat
@@ -10,6 +10,9 @@
 #   Lines starting with a '# ' are info or comments                  *
 #                                                                    *
 #   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
 #*********************************************************************
 #
 #*******************                                                 
@@ -19,251 +22,260 @@
 #*********************************************************************
 # Tag name for the run (one word)                                    *
 #*********************************************************************
-  Wjets     = run_tag ! name of the run 
-#*********************************************************************
-# Run to generate the grid pack                                      *
-#*********************************************************************
- .true.     = gridpack  !True = setting up the grid pack
+  WJets     = run_tag ! name of the run 
 #*********************************************************************
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 # If you want to run Pythia, avoid more than 50k events in a run.    *
 #*********************************************************************
   100 = nevents ! Number of unweighted events requested 
-      0       = iseed   ! rnd seed (0=assigned automatically=default))
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
 # lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
 #                                         3=photon from electron     *
 #*********************************************************************
-        1     = lpp1    ! beam 1 type 
-        1     = lpp2    ! beam 2 type
-     6500     = ebeam1  ! beam 1 total energy in GeV
-     6500     = ebeam2  ! beam 2 total energy in GeV
-#*********************************************************************
-# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
-#*********************************************************************
-        0     = polbeam1 ! beam polarization for beam 1
-        0     = polbeam2 ! beam polarization for beam 2
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
- lhapdf = pdlabel ! PDF set
- $DEFAULT_PDF_SETS = lhaid
- $DEFAULT_PDF_MEMBERS  = reweight_PDF
+     lhapdf = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS  = reweight_PDF
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.1880  = scale            ! fixed ren scale
- 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
- 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- 1        = scalefact        ! scale factor for event-by-event scales
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
-# Matching - Warning! ickkw > 1 is still beta
+# Type and output format
 #*********************************************************************
- 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
- 1        = highestmult      ! for ickkw=2, highest mult group
- 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
- 1        = alpsfact         ! scale factor for QCD emission vx
- F        = chcluster        ! cluster only according to channel diag
- T        = pdfwgt           ! for ickkw=1, perform pdf reweighting
- 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
- T        = clusinfo         ! include clustering tag in output
- 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
 #*********************************************************************
-#**********************************************************
-# Automatic ptj and mjj cuts if xqcut > 0
-# (turn off for VBF and single top processes)
-#**********************************************************
-   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
-#**********************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+ False        = pdfwgt           ! for ickkw=1, perform pdf reweighting 
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
 #                                                                    
-#**********************************
-# BW cutoff (M+/-bwcutoff*Gamma)
-#**********************************
-  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
-#**********************************************************
-# Apply pt/E/eta/dr/mij cuts on decay products or not
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
-#**********************************************************
-   F  = cut_decays    ! Cut decay products 
-#*************************************************************
-# Number of helicities to sum per event (0 = all helicities)
-# 0 gives more stable result, but longer run time (needed for
-# long decay chains e.g.).
-# Use >=2 if most helicities contribute, e.g. pure QCD.
-#*************************************************************
-   0  = nhel          ! Number of helicities used per event
-#*******************                                                 
-# Standard Cuts
-#*******************                                                 
-#                                                                    
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
  0.01  = ptj       ! minimum pt for the jets 
-  0  = ptb       ! minimum pt for the b 
-  0  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
-  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
-  0  = ptheavy   ! minimum pt for one heavy final state
-  0  = ptonium   ! minimum pt for the quarkonium states
- -1  = ptjmax    ! maximum pt for the jets
- -1  = ptbmax    ! maximum pt for the b
- -1  = ptamax    ! maximum pt for the photons
- -1  = ptlmax    ! maximum pt for the charged leptons
- -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ 0.0  = ptb       ! minimum pt for the b 
+ 0  = pta       ! minimum pt for the photons 
+ 0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Minimum and maximum E's (in the center of mass frame)              *
 #*********************************************************************
-  0  = ej     ! minimum E for the jets 
-  0  = eb     ! minimum E for the b 
-  0  = ea     ! minimum E for the photons 
-  0  = el     ! minimum E for the charged leptons 
- -1   = ejmax ! maximum E for the jets
- -1   = ebmax ! maximum E for the b
- -1   = eamax ! maximum E for the photons
- -1   = elmax ! maximum E for the charged leptons
+  0.0  = ej     ! minimum E for the jets 
+  0.0  = eb     ! minimum E for the b 
+  0.0  = ea     ! minimum E for the photons 
+  0.0  = el     ! minimum E for the charged leptons 
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+ {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-   5  = etaj    ! max rap for the jets 
-  -1 = etab    ! max rap for the b
-  -1  = etaa    ! max rap for the photons 
-  -1 = etal    ! max rap for the charged leptons 
-  -1  = etaonium ! max rap for the quarkonium states
-   0  = etajmin ! min rap for the jets
-   0  = etabmin ! min rap for the b
-   0  = etaamin ! min rap for the photons
-   0  = etalmin ! main rap for the charged leptons
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ -1  = etaa    ! max rap for the photons 
+ -1  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0   = drjj    ! min distance between jets 
- 0   = drbb    ! min distance between b's 
- 0   = drll    ! min distance between leptons 
- 0   = draa    ! min distance between gammas 
- 0   = drbj    ! min distance between b and jet 
+ 0.0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
  0.1 = draj    ! min distance between gamma and jet 
- 0   = drjl    ! min distance between jet and lepton 
- 0   = drab    ! min distance between gamma and b 
- 0   = drbl    ! min distance between b and lepton 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
  0.1 = dral    ! min distance between gamma and lepton 
- -1  = drjjmax ! max distance between jets
- -1  = drbbmax ! max distance between b's
- -1  = drllmax ! max distance between leptons
- -1  = draamax ! max distance between gammas
- -1  = drbjmax ! max distance between b and jet
- -1  = drajmax ! max distance between gamma and jet
- -1  = drjlmax ! max distance between jet and lepton
- -1  = drabmax ! max distance between gamma and b
- -1  = drblmax ! max distance between b and lepton
- -1  = dralmax ! maxdistance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
 #*********************************************************************
 # Minimum and maximum invariant mass for pairs                       *
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0   = mmjj    ! min invariant mass of a jet pair 
- 0   = mmbb    ! min invariant mass of a b pair 
- 0   = mmaa    ! min invariant mass of gamma gamma pair
- 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
- -1  = mmjjmax ! max invariant mass of a jet pair
- -1  = mmbbmax ! max invariant mass of a b pair
- -1  = mmaamax ! max invariant mass of gamma gamma pair
- -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
 #*********************************************************************
 # Minimum and maximum invariant mass for all letpons                 *
 #*********************************************************************
-  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
- -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
 #*********************************************************************
 # Minimum and maximum pt for 4-momenta sum of leptons                *
 #*********************************************************************
- 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
- -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0  = xptj ! minimum pt for at least one jet  
- 0  = xptb ! minimum pt for at least one b 
- 0  = xpta ! minimum pt for at least one photon 
- 0  = xptl ! minimum pt for at least one charged lepton 
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
 #*********************************************************************
 # Control the pt's of the jets sorted by pt                          *
 #*********************************************************************
- 0   = ptj1min ! minimum pt for the leading jet in pt
- 0   = ptj2min ! minimum pt for the second jet in pt
- 0   = ptj3min ! minimum pt for the third jet in pt
- 0   = ptj4min ! minimum pt for the fourth jet in pt
- -1  = ptj1max ! maximum pt for the leading jet in pt 
- -1  = ptj2max ! maximum pt for the second jet in pt
- -1  = ptj3max ! maximum pt for the third jet in pt
- -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
  0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
 #*********************************************************************
 # Control the pt's of leptons sorted by pt                           *
 #*********************************************************************
- 0   = ptl1min ! minimum pt for the leading lepton in pt
- 0   = ptl2min ! minimum pt for the second lepton in pt
- 0   = ptl3min ! minimum pt for the third lepton in pt
- 0   = ptl4min ! minimum pt for the fourth lepton in pt
- -1  = ptl1max ! maximum pt for the leading lepton in pt 
- -1  = ptl2max ! maximum pt for the second lepton in pt
- -1  = ptl3max ! maximum pt for the third lepton in pt
- -1  = ptl4max ! maximum pt for the fourth lepton in pt
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
 #*********************************************************************
 # Control the Ht(k)=Sum of k leading jets                            *
 #*********************************************************************
- 0   = htjmin ! minimum jet HT=Sum(jet pt)
- -1  = htjmax ! maximum jet HT=Sum(jet pt)
- 0   = ihtmin  !inclusive Ht for all partons (including b)
- -1  = ihtmax  !inclusive Ht for all partons (including b)
- 0   = ht2min ! minimum Ht for the two leading jets
- 0   = ht3min ! minimum Ht for the three leading jets
- 0   = ht4min ! minimum Ht for the four leading jets
- -1  = ht2max ! maximum Ht for the two leading jets
- -1  = ht3max ! maximum Ht for the three leading jets
- -1  = ht4max ! maximum Ht for the four leading jets
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 # When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-   0 = ptgmin ! Min photon transverse momentum
+ 0.0 = ptgmin ! Min photon transverse momentum
  0.4 = R0gamma ! Radius of isolation code
  1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
 #*********************************************************************
 # WBF cuts                                                           *
 #*********************************************************************
- 0   = xetamin ! minimum rapidity for two jets in the WBF case  
- 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
-#*********************************************************************
-# KT DURHAM CUT                                                      *
-#*********************************************************************
- -1    =  ktdurham        
- 0.4  =  dparameter 
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
 #*********************************************************************
 # maximal pdg code for quark to be considered as a light jet         *
 # (otherwise b cuts are applied)                                     *
 #*********************************************************************
  5 = maxjetflavor    ! Maximum jet pdg code
 #*********************************************************************
-# Jet measure cuts                                                   *
-#*********************************************************************
- 10   = xqcut   ! minimum kt jet measure between partons
-#*********************************************************************
 #
 #*********************************************************************
 # Store info for systematics studies                                 *
-# WARNING: If use_syst is T, matched Pythia output is                *
-#          meaningful ONLY if plotted taking matchscale              *
-#          reweighting into account!                                 *
+# WARNING: Do not use for interference type of computation           *
 #*********************************************************************
-   T  = use_syst      ! Enable systematics studies
+   True  = use_syst      ! Enable systematics studies
 #
-#**************************************
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'


### PR DESCRIPTION
As discussed in the MccM meeting on 2019-10-16, the BTV WJets and DYJets cards need to be updated, to remove intermediate W in prod_card.dat and set pdfwgt to false in run_card.dat.

https://docs.google.com/document/d/1gKKr8G3ZVKtwhiGX23eP0zob5srMsaQ8NKPiF1gz0pw/edit#heading=h.c3p5a3h1h0p4

This pull request updates those WJets and DYJets cards in mg265 master branch and the new gridpacks will be produced with new cards merged.


