### PR TITLE
JHUGen v7.3.5 cards

### DIFF
--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WW2l2nu_withtaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WW2l2nu_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10     LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WW2l2nu_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WW2l2nu_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WplusAny_WminusLNu_withtaus_2losfilter.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WplusAny_WminusLNu_withtaus_2losfilter.input
@@ -1,0 +1,1 @@
+DecayMode1=11 DecayMode2=10 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2     LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WplusAny_WminusLNu_withtaus_2losfilter_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WplusAny_WminusLNu_withtaus_2losfilter_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=11 DecayMode2=10 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WplusLNu_WminusAny_withtaus_2losfilter.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WplusLNu_WminusAny_withtaus_2losfilter.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=11 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2     LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/WplusLNu_WminusAny_withtaus_2losfilter_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/WplusLNu_WminusAny_withtaus_2losfilter_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=11 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_notaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_notaus.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=0     LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_notaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_notaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=0 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_withtaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=8     LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2nu_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=8 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2q_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2q_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=8 DecayMode2=1 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2q_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2l2q_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=8 DecayMode2=1 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2nu2x_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2nu2x_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=9 DecayMode2=3 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2nu2x_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ2nu2x_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=9 DecayMode2=3 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ4q_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ4q_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=1 DecayMode2=1 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ4q_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2016/ZZ4q_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=1 DecayMode2=1 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF30_nlo_nf_5_pdfas/NNPDF30_nlo_nf_5_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WW2l2nu_withtaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WW2l2nu_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10     LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WW2l2nu_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WW2l2nu_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=10 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WplusAny_WminusLNu_withtaus_2losfilter.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WplusAny_WminusLNu_withtaus_2losfilter.input
@@ -1,0 +1,1 @@
+DecayMode1=11 DecayMode2=10 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2     LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WplusAny_WminusLNu_withtaus_2losfilter_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WplusAny_WminusLNu_withtaus_2losfilter_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=11 DecayMode2=10 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WplusLNu_WminusAny_withtaus_2losfilter.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WplusLNu_WminusAny_withtaus_2losfilter.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=11 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2     LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/WplusLNu_WminusAny_withtaus_2losfilter_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/WplusLNu_WminusAny_withtaus_2losfilter_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=10 DecayMode2=11 RandomizeVVdecays=0 NLepMin=2 NOSMin=1 CountTauAsAny=1 WriteFailedEvents=2 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMWWdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_notaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_notaus.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=0     LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_notaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_notaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=0 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_withtaus.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_withtaus.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=8     LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_withtaus_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2nu_withtaus_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=8 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2q_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2q_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=8 DecayMode2=1 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2q_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2l2q_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=8 DecayMode2=1 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2nu2x_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2nu2x_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=9 DecayMode2=3 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2nu2x_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ2nu2x_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=9 DecayMode2=3 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ4q_2lfilter_4lveto.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ4q_2lfilter_4lveto.input
@@ -1,0 +1,1 @@
+DecayMode1=1 DecayMode2=1 NLepMin=2 NLepMax=3     WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas

--- a/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ4q_2lfilter_4lveto_reweightdecay_CPS.input
+++ b/bin/JHUGen/cards/decay/v7.3.5/2017/ZZ4q_2lfilter_4lveto_reweightdecay_CPS.input
@@ -1,0 +1,1 @@
+DecayMode1=1 DecayMode2=1 NLepMin=2 NLepMax=3 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out WriteFailedEvents=2 LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas


### PR DESCRIPTION
- Updated JHUGen requires specification of LHAPDF in all processes
- Lepton filter flag names have changed.
- I believe this PR is also needed so that the inputs are approved for the POWHEG submission requests.