### PR TITLE
Add zero jet component to WJetsToLNu_pdfwgt_F cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu_pdfwgt_F/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WJetsToLNu_pdfwgt_F/WJetsToLNu_13TeV-madgraphMLM-pythia8/WJetsToLNu_13TeV-madgraphMLM-pythia8_proc_card.dat
@@ -3,15 +3,17 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 
-generate p p > j l+ vl $$ t t~ h @0
-add process p p > j j l+ vl $$ t t~ h @1
-add process p p > j j j l+ vl $$ t t~ h @2
-add process p p > j j j j l+ vl $$ t t~ h @3
+generate p p > l+ vl $$ t t~ h @0
+add process p p > j l+ vl $$ t t~ h @1
+add process p p > j j l+ vl $$ t t~ h @2
+add process p p > j j j l+ vl $$ t t~ h @3
+add process p p > j j j j l+ vl $$ t t~ h @4
 
-add process p p > j l- vl~ $$ t t~ h @4
-add process p p > j j l- vl~ $$ t t~ h @5
-add process p p > j j j l- vl~ $$ t t~ h @6
-add process p p > j j j j l- vl~ $$ t t~ h @7
+add process p p > l- vl~ $$ t t~ h @5
+add process p p > j l- vl~ $$ t t~ h @6
+add process p p > j j l- vl~ $$ t t~ h @7
+add process p p > j j j l- vl~ $$ t t~ h @8
+add process p p > j j j j l- vl~ $$ t t~ h @9
 
 
 output WJetsToLNu_13TeV-madgraphMLM-pythia8 -nojpeg


### PR DESCRIPTION
This commit should fix the WJetsToLNu cards to have a 0 jet process available in the gridpack.