### PR TITLE
adjust width h->aa->2b2t

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/Wh01_M125_Toa01a01_Tobbtautau/Wh01_M125_Toa01a01_Tobbtautau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/Wh01_M125_Toa01a01_Tobbtautau/Wh01_M125_Toa01a01_Tobbtautau_customizecards.dat
@@ -1,2 +1,4 @@
 set param_card mass 25 125.0
 set param_card mass 36 A0MASS.0
+set param_card decay 25 0.003                                                                                                                                             
+set param_card decay 36 0.1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/Zh01_M125_Toa01a01_Tobbtautau/Zh01_M125_Toa01a01_Tobbtautau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/Zh01_M125_Toa01a01_Tobbtautau/Zh01_M125_Toa01a01_Tobbtautau_customizecards.dat
@@ -1,2 +1,4 @@
 set param_card mass 25 125.0
 set param_card mass 36 A0MASS.0
+set param_card decay 25 0.003                                                                                                                                             
+set param_card decay 36 0.1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_ggh01_M125_Toa01a01_Tobbtautau_2017.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_ggh01_M125_Toa01a01_Tobbtautau_2017.sh
@@ -20,3 +20,5 @@ do
     cd ../../
     echo the cards are created for $dir 
 done
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/ggh01_M125_Toa01a01_Tobbtautau/ggh01_M125_Toa01a01_Tobbtautau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/ggh01_M125_Toa01a01_Tobbtautau/ggh01_M125_Toa01a01_Tobbtautau_customizecards.dat
@@ -1,2 +1,4 @@
 set param_card mass 25 125.0
 set param_card mass 36 A0MASS.0
+set param_card decay 25 0.003
+set param_card decay 36 0.1

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/vbfh01_M125_Toa01a01_Tobbtautau/vbfh01_M125_Toa01a01_Tobbtautau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/vbfh01_M125_Toa01a01_Tobbtautau/vbfh01_M125_Toa01a01_Tobbtautau_customizecards.dat
@@ -1,2 +1,4 @@
 set param_card mass 25 125.0
 set param_card mass 36 A0MASS.0
+set param_card decay 25 0.003                                                                                                                                             
+set param_card decay 36 0.1


### PR DESCRIPTION
In these old datacards I have changed the width of the Higgs boson and light pseudoscalars. This leads to more resonable cross sections.