### PR TITLE
Fix for default params not being overwritten and for reweighting bug

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToMaxmixHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusOneJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusTwoJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTauPlusZeroJets_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8_reweight_card.dat
@@ -1,4 +1,4 @@
-change mode NLO
+change mode LO+NLO
 change rwgt_dir rwgt
 
 launch --rwgt_name=sm_weight

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -245,7 +245,6 @@ make_gridpack () {
       
       cp $CARDSDIR/${name}_proc_card.dat ${name}_proc_card.dat
      
- 
       #*FIXME* workaround for broken cluster_local_path handling. 
       # This needs to happen before the code-generation step, as fortran templates
       # are modified based on this parameter.

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -244,7 +244,8 @@ make_gridpack () {
       fi  
       
       cp $CARDSDIR/${name}_proc_card.dat ${name}_proc_card.dat
-      
+     
+ 
       #*FIXME* workaround for broken cluster_local_path handling. 
       # This needs to happen before the code-generation step, as fortran templates
       # are modified based on this parameter.
@@ -422,6 +423,13 @@ make_gridpack () {
     fi
     
     
+    if [ -e $CARDSDIR/${name}_param_card.dat ]; then
+      echo "copying custom params file"
+      echo testtest
+      pwd
+      cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
+    fi
+
     #automatically detect NLO mode or LO mode from output directory
     isnlo=0
     if [ -e ./MCatNLO ]; then
@@ -562,7 +570,12 @@ make_gridpack () {
     
     sed -i s/SCRAM_ARCH_VERSION_REPLACE/${scram_arch}/g runcmsgrid.sh
     sed -i s/CMSSW_VERSION_REPLACE/${cmssw_version}/g runcmsgrid.sh
-    
+
+    if [ -e $CARDSDIR/${name}_reweight_card.dat ]; then
+      # ensure that the desired weights aren't removed
+      sed -i s/remove_wgts=all/remove_wgts=1001,1002,1003,1004,1005,1006,1007,1008,1009/g runcmsgrid.sh
+    fi   
+ 
     pdfExtraArgs=""
     if [ $is5FlavorScheme -eq 1 ]; then
       pdfExtraArgs+="--is5FlavorScheme "

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -244,7 +244,7 @@ make_gridpack () {
       fi  
       
       cp $CARDSDIR/${name}_proc_card.dat ${name}_proc_card.dat
-     
+      
       #*FIXME* workaround for broken cluster_local_path handling. 
       # This needs to happen before the code-generation step, as fortran templates
       # are modified based on this parameter.
@@ -420,20 +420,12 @@ make_gridpack () {
       echo "copying custom reweight file"
       cp $CARDSDIR/${name}_reweight_card.dat ./Cards/reweight_card.dat
     fi
-    
-    
-    if [ -e $CARDSDIR/${name}_param_card.dat ]; then
-      echo "copying custom params file"
-      echo testtest
-      pwd
-      cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
-    fi
-
+   
     if [ -e $CARDSDIR/${name}_param_card.dat ]; then
       echo "copying custom params file"
       cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
     fi
-
+     
     #automatically detect NLO mode or LO mode from output directory
     isnlo=0
     if [ -e ./MCatNLO ]; then
@@ -574,7 +566,7 @@ make_gridpack () {
     
     sed -i s/SCRAM_ARCH_VERSION_REPLACE/${scram_arch}/g runcmsgrid.sh
     sed -i s/CMSSW_VERSION_REPLACE/${cmssw_version}/g runcmsgrid.sh
- 
+    
     pdfExtraArgs=""
     if [ $is5FlavorScheme -eq 1 ]; then
       pdfExtraArgs+="--is5FlavorScheme "

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -429,6 +429,11 @@ make_gridpack () {
       cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
     fi
 
+    if [ -e $CARDSDIR/${name}_param_card.dat ]; then
+      echo "copying custom params file"
+      cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
+    fi
+
     #automatically detect NLO mode or LO mode from output directory
     isnlo=0
     if [ -e ./MCatNLO ]; then

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -569,11 +569,6 @@ make_gridpack () {
     
     sed -i s/SCRAM_ARCH_VERSION_REPLACE/${scram_arch}/g runcmsgrid.sh
     sed -i s/CMSSW_VERSION_REPLACE/${cmssw_version}/g runcmsgrid.sh
-
-    if [ -e $CARDSDIR/${name}_reweight_card.dat ]; then
-      # ensure that the desired weights aren't removed
-      sed -i s/remove_wgts=all/remove_wgts=1001,1002,1003,1004,1005,1006,1007,1008,1009/g runcmsgrid.sh
-    fi   
  
     pdfExtraArgs=""
     if [ $is5FlavorScheme -eq 1 ]; then


### PR DESCRIPTION
1. fixing bug in gridpack script where specified params card is ignored and default parameters are always used
2. fixing bug in gridpack script that causes weights computed using reweighting feature to be removed
3. Adding LO weights in addition to NLO weights to cards used for ggH CP gridpacks