### PR TITLE
adding params card fix for UL branch

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -420,7 +420,11 @@ make_gridpack () {
       echo "copying custom reweight file"
       cp $CARDSDIR/${name}_reweight_card.dat ./Cards/reweight_card.dat
     fi
-    
+   
+    if [ -e $CARDSDIR/${name}_param_card.dat ]; then
+      echo "copying custom params file"
+      cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
+    fi 
     
     #automatically detect NLO mode or LO mode from output directory
     isnlo=0


### PR DESCRIPTION
Adding the fix to ensure the params card is not ignored when making gridpacks to the UL2019 branch, as requested in https://github.com/cms-sw/genproductions/pull/2499#issuecomment-577660862