### PR TITLE
Add cards for the leading NLO EW contribution to ttW production

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_madspin_card.dat
@@ -1,0 +1,30 @@
+#************************************************************
+#*                        MadSpin                           *
+#*                                                          *
+#*    P. Artoisenet, R. Frederix, R. Rietkerk, O. Mattelaer * 
+#*                                                          *
+#*    Part of the MadGraph5_aMC@NLO Framework:              *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#Some options (uncomment to apply)
+#
+#directory for gridpack mode
+set ms_dir ./madspingrid
+
+#initialization parameters
+ set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
+ set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+# 
+
+set max_running_process 1
+
+# specify the decay for the final state particles
+#(inclusive top decays in this case)
+decay t > w+ b, w+ > all all
+decay t~ > w- b~, w- > all all
+decay w+ > ell+ vl
+decay w- > ell- vl~
+# running the actual code
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_proc_card.dat
@@ -6,5 +6,5 @@ define ell- = e- mu- ta-
 generate p p > t t~ w+ j QED<=3 QCD<=1
 add process p p > t t~ w- j QED<=3 QCD<=1
 
-output TTWJetToLNuEWJetPt50_5f_NLO_FXFX -nojpeg
+output TTWJetToLNuEWJetPt50_5f -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_proc_card.dat
@@ -1,0 +1,10 @@
+import model loop_sm-no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+
+generate p p > t t~ w+ j QED<=3 QCD<=1
+add process p p > t t~ w- j QED<=3 QCD<=1
+
+output TTWJetToLNuEWJetPt50_5f_NLO_FXFX -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -1,0 +1,148 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500   = ebeam1  ! beam 1 energy in GeV
+ 6500   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+$DEFAULT_PDF_MEMBERS = reweight_PDF     ! reweight to get PDF uncertainty
+      ! First of the error PDF sets 
+      ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  20  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************
+#
+50.0   = ptj1min ! minimum pt for the leading jet in pt

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -1,148 +1,271 @@
-#***********************************************************************
-#                        MadGraph5_aMC@NLO                             *
-#                                                                      *
-#                      run_card.dat aMC@NLO                            *
-#                                                                      *
-#  This file is used to set the parameters of the run.                 *
-#                                                                      *
-#  Some notation/conventions:                                          *
-#                                                                      *
-#   Lines starting with a hash (#) are info or comments                *
-#                                                                      *
-#   mind the format:   value    = variable     ! comment               *
-#***********************************************************************
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
 #
 #*******************                                                 
 # Running parameters
 #*******************                                                 
-#
-#***********************************************************************
-# Tag name for the run (one word)                                      *
-#***********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
   tag_1     = run_tag ! name of the run 
-#***********************************************************************
-# Number of events (and their normalization) and the required          *
-# (relative) accuracy on the Xsec.                                     *
-# These values are ignored for fixed order runs                        *
-#***********************************************************************
-  1500 = nevents ! Number of unweighted events requested 
- 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
-    20 = nevt_job! Max number of events per job in event generation. 
-                 !  (-1= no split).
-average = event_norm ! Normalize events to sum or average to the X sect.
-#***********************************************************************
-# Number of points per itegration channel (ignored for aMC@NLO runs)   *
-#***********************************************************************
- 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
- 	                   ! number of points and iter. below)
-# These numbers are ignored except if req_acc_FO is equal to -1
- 5000   = npoints_FO_grid  ! number of points to setup grids
- 4      = niters_FO_grid   ! number of iter. to setup grids
- 10000  = npoints_FO       ! number of points to compute Xsec
- 6      = niters_FO        ! number of iter. to compute Xsec
-#***********************************************************************
-# Random number seed                                                   *
-#***********************************************************************
-     0    = iseed       ! rnd seed (0=assigned automatically=default))
-#***********************************************************************
-# Collider type and energy                                             *
-#***********************************************************************
-    1   = lpp1    ! beam 1 type (0 = no PDF)
-    1   = lpp2    ! beam 2 type (0 = no PDF)
- 6500   = ebeam1  ! beam 1 energy in GeV
- 6500   = ebeam2  ! beam 2 energy in GeV
-#***********************************************************************
-# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
-#***********************************************************************
- lhapdf    = pdlabel   ! PDF set                                     
-$DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
-#***********************************************************************
-# Include the NLO Monte Carlo subtr. terms for the following parton    *
-# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
-# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
-#***********************************************************************
-  PYTHIA8   = parton_shower
-#***********************************************************************
-# Renormalization and factorization scales                             *
-# (Default functional form for the non-fixed scales is the sum of      *
-# the transverse masses of all final state particles and partons. This *
-# can be changed in SubProcesses/set_scales.f)                         *
-#***********************************************************************
- F        = fixed_ren_scale  ! if .true. use fixed ren scale
- F        = fixed_fac_scale  ! if .true. use fixed fac scale
- 91.188   = muR_ref_fixed    ! fixed ren reference scale 
- 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
- 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
-#***********************************************************************
-# Renormalization and factorization scales (advanced and NLO options)  *
-#***********************************************************************
- F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
- 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
- 1        = muR_over_ref     ! ratio of current muR over reference muR
- 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
- 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
- 1        = QES_over_ref     ! ratio of current QES over reference QES
-#*********************************************************************** 
-# Reweight flags to get scale dependence and PDF uncertainty           *
-# For scale dependence: factor rw_scale_up/down around central scale   *
-# For PDF uncertainty: use LHAPDF with supported set                   *
-#***********************************************************************
- .true.   = reweight_scale   ! reweight to get scale dependence
-  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
-  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
-  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
-  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
-$DEFAULT_PDF_MEMBERS = reweight_PDF     ! reweight to get PDF uncertainty
-      ! First of the error PDF sets 
-      ! Last of the error PDF sets
-#***********************************************************************
-# Merging - WARNING! Applies merging only at the hard-event level.     *
-# After showering an MLM-type merging should be applied as well.       *
-# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
-#***********************************************************************
- 3        = ickkw            ! 0 no merging, 3 FxFx merging
-#***********************************************************************
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  100000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf = pdlabel ! PDF set
+  $DEFAULT_PDF_SETS = lhaid ! if pdlabel=lhapdf, this is the lhapdf number
+  $DEFAULT_PDF_MEMBERS  = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+ 0.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
 #
-#***********************************************************************
-# BW cutoff (M+/-bwcutoff*Gamma)                                       *
-#***********************************************************************
- 15  = bwcutoff
-#***********************************************************************
-# Cuts on the jets                                                     *
-# Jet clustering is performed by FastJet.
-# When matching to a parton shower, these generation cuts should be    *
-# considerably softer than the analysis cuts.                          *
-# (more specific cuts can be specified in SubProcesses/cuts.f)         *
-#***********************************************************************
-   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
- 1.0  = jetradius ! The radius parameter for the jet algorithm
-  20  = ptj       ! Min jet transverse momentum
-  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
-#***********************************************************************
-# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
-# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
-#***********************************************************************
-   0  = ptl     ! Min lepton transverse momentum
-  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
-   0  = drll    ! Min distance between opposite sign lepton pairs
-   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
-   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
-  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 20.0  = ptj       ! minimum pt for the jets 
+ 0.0  = ptb       ! minimum pt for the b 
+ 10.0  = pta       ! minimum pt for the photons 
+ 10.0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.4 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.4 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0.4 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+50.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
 #***********************************************************************
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
 #***********************************************************************
-  20  = ptgmin    ! Min photon transverse momentum
-  -1  = etagamma  ! Max photon abs(pseudo-rap)
- 0.4  = R0gamma   ! Radius of isolation code
- 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
- 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
- .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+ 0.0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
 #***********************************************************************
-# Maximal PDG code for quark to be considered a jet when applying cuts.*
-# At least all massless quarks of the model should be included here.   *
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
 #***********************************************************************
- 5 = maxjetflavor
-#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21, 82  =  pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
 #
-50.0   = ptj1min ! minimum pt for the leading jet in pt
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -266,6 +266,3 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
-# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -71,7 +71,7 @@
  0 = ickkw            ! 0 no matching, 1 MLM
  1.0 = alpsfact         ! scale factor for QCD emission vx
  False = chcluster        ! cluster only according to channel diag
- 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
  True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
                                    ! (turn off for VBF and single top processes) 
  0.0   = xqcut   ! minimum kt jet measure between partons

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -109,7 +109,7 @@
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
- 20.0  = ptj       ! minimum pt for the jets 
+ 10.0  = ptj       ! minimum pt for the jets 
  0.0  = ptb       ! minimum pt for the b 
  10.0  = pta       ! minimum pt for the photons 
  10.0  = ptl       ! minimum pt for the charged leptons 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetToLNuEWJetPt50_5f/TTWJetToLNuEWJetPt50_5f_run_card.dat
@@ -127,10 +127,10 @@
 #*********************************************************************
 # Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
 #*********************************************************************
-  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etaj    ! max rap for the jets 
   -1.0  = etab    ! max rap for the b
- 2.5  = etaa    ! max rap for the photons 
- 2.5  = etal    ! max rap for the charged leptons 
+  -1.0  = etaa    ! max rap for the photons 
+  -1.0  = etal    ! max rap for the charged leptons 
  0.0  = etajmin ! min rap for the jets
  0.0  = etabmin ! min rap for the b
  0.0  = etaamin ! min rap for the photons
@@ -140,16 +140,16 @@
 #*********************************************************************
 # Minimum and maximum DeltaR distance                                *
 #*********************************************************************
- 0.4 = drjj    ! min distance between jets 
- 0.0   = drbb    ! min distance between b's 
- 0.4 = drll    ! min distance between leptons 
- 0.4 = draa    ! min distance between gammas 
- 0.0   = drbj    ! min distance between b and jet 
- 0.4 = draj    ! min distance between gamma and jet 
- 0.4 = drjl    ! min distance between jet and lepton 
- 0.0   = drab    ! min distance between gamma and b 
- 0.0   = drbl    ! min distance between b and lepton 
- 0.4 = dral    ! min distance between gamma and lepton 
+ -1.0 = drjj    ! min distance between jets 
+ -1.0   = drbb    ! min distance between b's 
+ -1.0 = drll    ! min distance between leptons 
+ -1.0 = draa    ! min distance between gammas 
+ -1.0   = drbj    ! min distance between b and jet 
+ -1.0 = draj    ! min distance between gamma and jet 
+ -1.0 = drjl    ! min distance between jet and lepton 
+ -1.0   = drab    ! min distance between gamma and b 
+ -1.0   = drbl    ! min distance between b and lepton 
+ -1.0 = dral    ! min distance between gamma and lepton 
  -1.0  = drjjmax ! max distance between jets
  -1.0  = drbbmax ! max distance between b's
  -1.0  = drllmax ! max distance between leptons


### PR DESCRIPTION
These cards simulate pp > ttW+jet through EW diagrams (by excluding diagrams with more than one QCD coupling), which is the dominant NLO EW contribution (real diagrams) to ttW production; a pt > 50GeV cut on the leading jet is added to avoid the region where a full NLO treatment is necessary.
It should be safe to combine this with the existing TTWJetsToLNu samples; I first tried using the cards for that process, but ran into problems when generating a gridpack, so I used the run card from the MG 2.6.7 session where I checked the diagrams (and compared with one that was recently added, DarkHigs_WW - I changed the defaults where I knew they needed changing (maxjetflavor=5, pdf settings), but left the following: `average` instead of `sum` for event_norm (TTWJetsToLNu uses average), auto_pt_mjj (which should matter without xqcut, if I read the comment correctly), and the syscalc settings which look similar in a different format) - please let me know if there is a guideline on this, or a list of things to check to make sure this is all correct - thanks in advance!