### PR TITLE
UL ST production cards: fix top width in t-channel 5f cards

### DIFF
--- a/bin/Powheg/production/2017/13TeV/st_tch_5f_ckm_13TeV/powheg_antitop_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_5f_ckm_13TeV/powheg_antitop_UL.input
@@ -46,7 +46,7 @@ wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
                      ! 0 means close, 1 open
 tdec/elbranching 0.108  ! W electronic branching fraction
 tdec/sin2cabibbo 0.051
-topwidth 1.31 ! 1.33 
+topwidth 1.33 
 
 topmass      172.5
 wmass        80.4

--- a/bin/Powheg/production/2017/13TeV/st_tch_5f_ckm_13TeV/powheg_top_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_5f_ckm_13TeV/powheg_top_UL.input
@@ -46,7 +46,7 @@ wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
                      ! 0 means close, 1 open
 tdec/elbranching 0.108  ! W electronic branching fraction
 tdec/sin2cabibbo 0.051
-topwidth 1.31 ! 1.33 
+topwidth 1.33 
 
 ! optional production parameters 
 ! (defaults defined in init_couplings.f)


### PR DESCRIPTION
change the top width of the ST t-channel 5f cards for UL production according to the other ST cards from the previous PR:
https://github.com/cms-sw/genproductions/pull/2480

The change of the 5f t-channel top width was missing in that PR
The other parameters were already synced in the previous PR