### PR TITLE
Fix reading of stage2 grids

### DIFF
--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -13,6 +13,12 @@ rm -f $$WORKDIR/$$folderName'_'$$process'.tgz'
 
 cp -p $$WORKDIR/run_pwg.py $$WORKDIR/$$folderName
 
+if [ -e $WORKDIR/$folderName/pwg-0001-stat.dat ]; then
+  cp -p $WORKDIR/$folderName/pwg-0001-stat.dat $WORKDIR/$folderName/pwg-stat.dat
+fi
+if [ -e $WORKDIR/$folderName/pwg-st3-0001-stat.dat ]; then
+  cp -p $WORKDIR/$folderName/pwg-st3-0001-stat.dat $WORKDIR/$folderName/pwg-stat.dat
+fi
 
 FULLGRIDRM=`ls $${WORKDIR}/$${folderName} | grep fullgrid-rm`
 FULLGRIDBTL=`ls $${WORKDIR}/$${folderName} | grep fullgrid-btl`

--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -13,11 +13,11 @@ rm -f $$WORKDIR/$$folderName'_'$$process'.tgz'
 
 cp -p $$WORKDIR/run_pwg.py $$WORKDIR/$$folderName
 
-if [ -e $WORKDIR/$folderName/pwg-0001-stat.dat ]; then
-  cp -p $WORKDIR/$folderName/pwg-0001-stat.dat $WORKDIR/$folderName/pwg-stat.dat
+if [ -e $$WORKDIR/$$folderName/pwg-0001-stat.dat ]; then
+  cp -p $$WORKDIR/$$folderName/pwg-0001-stat.dat $$WORKDIR/$$folderName/pwg-stat.dat
 fi
-if [ -e $WORKDIR/$folderName/pwg-st3-0001-stat.dat ]; then
-  cp -p $WORKDIR/$folderName/pwg-st3-0001-stat.dat $WORKDIR/$folderName/pwg-stat.dat
+if [ -e $$WORKDIR/$$folderName/pwg-st3-0001-stat.dat ]; then
+  cp -p $$WORKDIR/$$folderName/pwg-st3-0001-stat.dat $$WORKDIR/$$folderName/pwg-stat.dat
 fi
 
 FULLGRIDRM=`ls $${WORKDIR}/$${folderName} | grep fullgrid-rm`

--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -13,11 +13,6 @@ rm -f $$WORKDIR/$$folderName'_'$$process'.tgz'
 
 cp -p $$WORKDIR/run_pwg.py $$WORKDIR/$$folderName
 
-if [ -e $$WORKDIR/$$folderName/pwggrid-0001.dat ]; then
-  cp -p $$WORKDIR/$$folderName/pwggrid-0001.dat $$WORKDIR/$$folderName/pwggrid.dat
-  cp -p $$WORKDIR/$$folderName/pwg-0001-stat.dat $$WORKDIR/$$folderName/pwg-stat.dat
-fi
-
 
 FULLGRIDRM=`ls $${WORKDIR}/$${folderName} | grep fullgrid-rm`
 FULLGRIDBTL=`ls $${WORKDIR}/$${folderName} | grep fullgrid-btl`


### PR DESCRIPTION
Hi, I noticed during the ZjMiNNLO validation that these lines have an unwanted consequence when used with more complicated samples that require parallelstages.
They prevent powheg to read all the stage2 grid files during event generation, using only `pwggrid.dat = pwggrid-0001.dat` instead.

This leads to a poor estimate of the total cross section used for generation and a higher number of upper bound violations, that are also visible as non-unit weights when using `ubexcess_correct 1`.

Illustrating plot, compare with and without "stage2fix":
![image](https://user-images.githubusercontent.com/1311783/79847211-ad6fd100-83bf-11ea-83a3-e3355b3bc954.png)
