### PR TITLE
darkHiggs to WWjjlnu: proc datacard redefine multiparticle to be safe

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DarkHiggs_WWjjlnu/DarkHiggs_WWjjlnu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/DarkHiggs_WWjjlnu/DarkHiggs_WWjjlnu_proc_card.dat
@@ -1,8 +1,8 @@
 import model ZpHiggs_UFO
 
-define l = e+ e- mu+ mu- ta+ ta-
-define vl = ve ve~ vm vm~ vt vt~
+define myl = e+ e- mu+ mu- ta+ ta-
+define myvl = ve ve~ vm vm~ vt vt~
 
-generate p p > zp > dm dm hs, (hs > w+ w- > j j l vl)
+generate p p > zp > dm dm hs, (hs > w+ w- > j j myl myvl)
 
 output DarkHiggs_WWjjlnu -nojpeg 


### PR DESCRIPTION
The name of the lepton multiparticles was changed:
l => myl
vl => myvl
To be sure nothing preexisting is overwritten, carrying unwanted changes.

The gridpack's where created with these datacards.