### PR TITLE
fix osWW in VVjj_hadronic EWK+QCD

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/VBS/VVjj_hadronic/EWK_QCD/WPJJWMJJjj_EWK_QCD_LO/WPJJWMJJjj_EWK_QCD_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/VBS/VVjj_hadronic/EWK_QCD/WPJJWMJJjj_EWK_QCD_LO/WPJJWMJJjj_EWK_QCD_LO_proc_card.dat
@@ -3,5 +3,6 @@ set ignore_six_quark_processes False
 set loop_optimized_output True
 set complex_mass_scheme False
 import model sm-ckm_no_b_mass
-generate p p > w+ w- j j $ t t~ QED=4 QCD=99
+generate p p > w+ w- j j QED=4 QCD=0
+add process p p > w+ w- j j $ t t~ QED=2 QCD=99 @2
 output WPJJWMJJjj_EWK_QCD_LO -nojpeg


### PR DESCRIPTION
In osWW EWK cards tops are not excluded, while in QCD they are (with `$ t t~` in generate line).

To be consistent in EWK_QCD this adds a process in the proc card to exclude tops in QCD but not in EWK.