### PR TITLE
fix reweighting for lo and nlo when using madspin

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -41,10 +41,15 @@ EOF
 # and copy to correct directory
 # Args: <process_name> <cards directory> <is5FlavorScheme> 
 prepare_run_card () {
-    set_run_card_pdf $1 $2 $3 $4
+    name=$1
+    CARDSDIR=$2
+    is5FlavorScheme=$3
+    script_dir=$4
+    isnlo=$5
+
+    set_run_card_pdf $name $CARDSDIR $is5FlavorScheme $script_dir
 
     # Set maxjetflavor according to PDF scheme
-    is5FlavorScheme=$3
     nFlavorScheme=5
     if [ $is5FlavorScheme -ne 1 ]; then
         nFlavorScheme=4
@@ -55,6 +60,16 @@ prepare_run_card () {
     else
         echo "${nFlavorScheme} = maxjetflavor" >> ./Cards/run_card.dat 
     fi
+
+    if [ "$isnlo" -gt "0" ]; then # nlo mode
+	echo "False = reweight_scale" >> ./Cards/run_card.dat 
+	echo "False = reweight_PDF" >> ./Cards/run_card.dat 
+	echo "True = store_rwgt_info" >> ./Cards/run_card.dat 
+    else # lo mode 
+	echo "None = systematics_program" >> ./Cards/run_card.dat 
+	echo "True = use_syst" >> ./Cards/run_card.dat 
+    fi
+    
 }
 
 # Run reweight step, explicitly compiling subprocesses

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -382,6 +382,12 @@ make_gridpack () {
     
     cd processtmp
     
+    #automatically detect NLO mode or LO mode from output directory
+    isnlo=0
+    if [ -e ./MCatNLO ]; then
+      isnlo=1
+    fi
+    
     #################################
     #Add PDF info and copy run card #
     #################################
@@ -390,7 +396,7 @@ make_gridpack () {
       script_dir=$(git rev-parse --show-toplevel)/Utilities/scripts
     fi
     
-    prepare_run_card $name $CARDSDIR $is5FlavorScheme $script_dir
+    prepare_run_card $name $CARDSDIR $is5FlavorScheme $script_dir $isnlo
     
     #copy provided custom fks params or cuts
     if [ -e $CARDSDIR/${name}_cuts.f ]; then
@@ -423,12 +429,6 @@ make_gridpack () {
       cp $CARDSDIR/${name}_param_card.dat ./Cards/param_card.dat
     fi
      
-    #automatically detect NLO mode or LO mode from output directory
-    isnlo=0
-    if [ -e ./MCatNLO ]; then
-      isnlo=1
-    fi
-    
     if [ "$isnlo" -gt "0" ]; then
     #NLO mode  
       #######################

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -41,9 +41,7 @@ if [ "$use_gridpack_env" = true ]
     cd ${cmssw_version}/src
     eval `scramv1 runtime -sh`
 fi
-cd $LHEWORKDIR
-
-cd process
+cd $LHEWORKDIR/process
 
 #make sure lhapdf points to local cmssw installation area
 LHAPDFCONFIG=`echo "$LHAPDF_DATA_PATH/../../bin/lhapdf-config"`
@@ -141,14 +139,31 @@ if [ -e ./madevent/Cards/reweight_card.dat ]; then
     mv $LHEWORKDIR/process/madevent/Events/GridRun_${rnum}/unweighted_events.lhe.gz $LHEWORKDIR/process/events.lhe.gz
 fi
 
+gzip -d $LHEWORKDIR/process/events.lhe.gz
+
 domadspin=0
 if [ -f ./madspin_card.dat ] ;then
     domadspin=1
-    echo "import events.lhe.gz" > madspinrun.dat
+    # extract header as overwritten by madspin 
+    if grep -R "<initrwgt>" events.lhe ; then
+	sed -n '/<initrwgt>/,/<\/initrwgt>/p' events.lhe >  initrwgt.txt
+    fi
+    echo "import events.lhe" > madspinrun.dat
     rnum2=$(($rnum+1000000))
     echo `echo "set seed $rnum2"` >> madspinrun.dat
     cat ./madspin_card.dat >> madspinrun.dat
     $LHEWORKDIR/mgbasedir/MadSpin/madspin madspinrun.dat 
+    # add header back 
+    gzip -d events_decayed.lhe.gz  
+    if [ -e initrwgt.txt ]; then
+	sed -i "/<\/header>/ {
+             h
+             r initrwgt.txt
+             g
+             N
+        }" events_decayed.lhe
+	rm initrwgt.txt
+    fi
 fi
 
 cd $LHEWORKDIR
@@ -156,28 +171,21 @@ cd $LHEWORKDIR
 runlabel=GridRun_PostProc_${rnum}
 mkdir process/madevent/Events/${runlabel}
 
-event_file=events.lhe.gz
+event_file=events.lhe
 if [ "$domadspin" -gt "0" ] ; then 
-    event_file=events_decayed.lhe.gz
+    event_file=events_decayed.lhe
 fi
-mv process/$event_file process/madevent/Events/${runlabel}/events.lhe.gz
+mv process/$event_file process/madevent/Events/${runlabel}/events.lhe
 
 # Add scale and PDF weights using systematics module
 #
 pushd process/madevent
 pdfsets="PDF_SETS_REPLACE"
 scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur,dyn --dyn=-1,1,2,3,4 --alps=0.5,1,2"
-
-if [ "$doreweighting" -gt "0" ] ; then 
-    echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent
-else
-    echo "systematics $runlabel --remove_wgts=all --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent
-fi
-
+echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent
 popd
 
-mv process/madevent/Events/${runlabel}/events.lhe.gz cmsgrid_final.lhe.gz
-gzip -d cmsgrid_final.lhe.gz
+mv ${LHEWORKDIR}/process/madevent/Events/${runlabel}/events.lhe ${LHEWORKDIR}/cmsgrid_final.lhe
 
 ls -l
 echo

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -20,17 +20,17 @@ fi
 if [ "$use_gridpack_env" = true ]
   then
     if [ -n "$5" ]
-      then
+    then
         scram_arch_version=${5}
-      else
+    else
         scram_arch_version=SCRAM_ARCH_VERSION_REPLACE
     fi
     echo "%MSG-MG5 SCRAM_ARCH version = $scram_arch_version"
-
+    
     if [ -n "$6" ]
-      then
+    then
         cmssw_version=${6}
-      else
+    else
         cmssw_version=CMSSW_VERSION_REPLACE
     fi
     echo "%MSG-MG5 CMSSW version = $cmssw_version"
@@ -41,9 +41,8 @@ if [ "$use_gridpack_env" = true ]
     cd ${cmssw_version}/src
     eval `scramv1 runtime -sh`
 fi
-cd $LHEWORKDIR
 
-cd process
+cd $LHEWORKDIR/process
 
 #make sure lhapdf points to local cmssw installation area
 LHAPDFCONFIG=`echo "$LHAPDF_DATA_PATH/../../bin/lhapdf-config"`
@@ -53,9 +52,10 @@ echo "lhapdf = $LHAPDFCONFIG" >> ./Cards/amcatnlo_configuration.txt
 
 echo "run_mode = 2" >> ./Cards/amcatnlo_configuration.txt
 echo "nb_core = $ncpu" >> ./Cards/amcatnlo_configuration.txt
-
-echo "reweight=OFF" > runscript.dat
+echo "madspin=OFF" > runscript.dat 
+echo "reweight=OFF" >> runscript.dat
 echo "done" >> runscript.dat
+
 echo "set nevents $nevt" >> runscript.dat
 echo "set iseed $rnum" >> runscript.dat
 
@@ -66,7 +66,6 @@ if [ "$nevtjob" -lt "10" ]; then
 fi
 
 echo "set nevt_job ${nevtjob}" >> runscript.dat
-
 echo "done" >> runscript.dat
 
 domadspin=0
@@ -91,25 +90,51 @@ runname=cmsgrid
 if [ ! -e $LHEWORKDIR/header_for_madspin.txt ]; then
   
     cat runscript.dat | ./bin/generate_events -ox -n $runname
-
     runlabel=$runname
-    if [ "$domadspin" -gt "0" ] ; then 
-      runlabel=${runname}_decayed_1
-    fi
 
-    if [ "$doreweighting" -gt "0" ] ; then 
+    if [ "$doreweighting" -gt "0" ] ; then
         #when REWEIGHT=OFF is applied, mg5_aMC moves reweight_card.dat to .reweight_card.dat
         mv ./Cards/.reweight_card.dat ./Cards/reweight_card.dat
         rwgt_dir="$LHEWORKDIR/process/rwgt"
         export PYTHONPATH=$rwgt_dir:$PYTHONPATH
         echo "0" | ./bin/aMCatNLO --debug reweight $runname
     fi
+    gzip -d $LHEWORKDIR/process/Events/${runlabel}/events.lhe 
+
+    if [ "$domadspin" -gt "0" ] ; then
+	mv $LHEWORKDIR/process/Events/${runlabel}/events.lhe events.lhe
+        # extract header as overwritten by madspin 
+	if grep -R "<initrwgt>" events.lhe ; then
+	    sed -n '/<initrwgt>/,/<\/initrwgt>/p' events.lhe >  initrwgt.txt
+	fi        
+        #when MADSPIN=OFF is applied, mg5_aMC moves reweight_card.dat to .reweight_card.dat
+        mv ./Cards/.madspin_card.dat ./Cards/madspin_card.dat
+        echo "import events.lhe" > madspinrun.dat
+        cat ./Cards/madspin_card.dat >> madspinrun.dat
+        $LHEWORKDIR/mgbasedir/MadSpin/madspin madspinrun.dat 
+        # add header back 
+	gzip -d events_decayed.lhe.gz  
+	if [ -e initrwgt.txt ]; then
+	    sed -i "/<\/header>/ {
+             h
+             r initrwgt.txt
+             g
+             N
+        }" events_decayed.lhe
+	    rm initrwgt.txt
+	fi
+	runlabel=${runname}_decayed_1
+	mkdir -p ./Events/${runlabel}
+        
+	mv $LHEWORKDIR/process/events_decayed.lhe $LHEWORKDIR/process/Events/${runlabel}/events.lhe
+    fi
 
     pdfsets="PDF_SETS_REPLACE"
     scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur --dyn=-1"
 
-    echo "systematics $runlabel --remove_wgts=all --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/aMCatNLO
-	cp ./Events/${runlabel}/events.lhe.gz $LHEWORKDIR/${runname}_final.lhe.gz
+    echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/aMCatNLO
+
+    cp $LHEWORKDIR/process/Events/${runlabel}/events.lhe $LHEWORKDIR/${runname}_final.lhe
 
 #else handle external tarball
 else
@@ -140,24 +165,21 @@ else
     rm madspinrun.dat
     rm cmsgrid_predecay.lhe.gz
     mv cmsgrid_predecay_decayed.lhe.gz cmsgrid_final.lhe.gz
-    
+    gzip -d cmsgrid_final.lhe.gz
+
     if [ -e initrwgt.txt ];then
-    	gzip -d cmsgrid_final.lhe.gz
-    	sed -i "/<\/header>/ {
+	sed -i "/<\/header>/ {
              h
              r initrwgt.txt
              g
              N
         }" cmsgrid_final.lhe
         rm initrwgt.txt
-        gzip cmsgrid_final.lhe
     fi
-
     
 fi
 
 cd $LHEWORKDIR
-gzip -d ${runname}_final.lhe.gz
 sed -i -e '/<mgrwgt/,/mgrwgt>/d' ${runname}_final.lhe 
 ls -l
 echo


### PR DESCRIPTION
changed order of madspin and rwgt as done in pr2170, can be closed 
madspin removed header for me weights -> added back
systematic evaluated only once -> modified run_card in gridpack helpers
compared output w and w/o madspin, w and w/o rwgt, lo and nlo at lhe level: no problems observed  
