### PR TITLE
Remove fakevirt for parallel stages 2 and 3

### DIFF
--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -321,10 +321,6 @@ def runEvents(parstage, folderName, EOSfolder, njobs, powInputName, jobtag, proc
         if not 'manyseeds' in open(inputName).read() :
             runCommand("echo \'manyseeds 1\' >> "+ inputName)
 
-        if not 'fakevirt' in open(inputName).read() :
-            if process != 'b_bbar_4l':
-                runCommand("echo \'fakevirt 1\' >> "+inputName)
-    
     runCommand('cp -p ' + folderName + '/powheg.input ' + folderName + '/powheg.input.' + parstage)
 
     with open(os.path.join(folderName, "pwgseeds.dat"), "w") as f:


### PR DESCRIPTION
Shouldn't fakevirt be used in parallel stage 1 but not the later parallel stages? That is my understand from reading the POWHEG manual for several processes. For example: [manual-BOX-VBF_Wp_Wp.pdf](https://github.com/cms-sw/genproductions/files/4709336/manual-BOX-VBF_Wp_Wp.pdf)
