### PR TITLE
Template MG cards for XToYYprime, and script to generate actual cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_customizecards.dat
@@ -1,0 +1,9 @@
+set param_card mass 9000001 1000
+set param_card mass 9000002 1000
+set param_card rhoinputs 2 1000
+set param_card DECAY 9000001 1.000000e-03
+set param_card DECAY 9000002 1.000000e-03
+set param_card mass 25 60
+set param_card mass 23 30
+set param_card DECAY 25 1.000000e-03
+set param_card DECAY 23 1.000000e-03

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_extramodels.dat
@@ -1,0 +1,2 @@
+#from https://github.com/syuvivida/DibosonBSMSignal_13TeV/tree/master/Models/Vector_Triplet_free_Width_UFO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_proc_card.dat
@@ -1,0 +1,9 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set gauge unitary
+set complex_mass_scheme False
+import model Vector_Triplet_free_Width_UFO
+define p = g u c d s b u~ c~ d~ s~ b~
+define q = u c d s b u~ c~ d~ s~ b~
+generate p p > vz, (vz > h z)
+output XToYYprime_MX1000_MY30_MYprime60_narrow -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_proc_card.dat
@@ -1,9 +1,4 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
 import model Vector_Triplet_free_Width_UFO
-define p = g u c d s b u~ c~ d~ s~ b~
-define q = u c d s b u~ c~ d~ s~ b~
+define p = g u c d s u~ c~ d~ s~
 generate p p > vz, (vz > h z)
 output XToYYprime_MX1000_MY30_MYprime60_narrow -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/XToYYprime_MX1000_MY30_MYprime60_narrow/XToYYprime_MX1000_MY30_MYprime60_narrow_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+     1000     = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'  = pdlabel     ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf number              
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 10  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  -1  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0001 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/gen_card.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/gen_card.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#based on script bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/BulkGraviton_hh_granular/gen_card.sh
+
+sample=XToYYprime_MX
+
+postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)
+
+mYprime_l=30
+mYprime_r_1=250
+mYprime_r_2=500
+mYprime_step1=30
+mYprime_step2=50
+mYprime_step3=100
+
+mY_l=30
+mY_step1=30
+mY_step2=50
+mY_step3=100
+
+mX_l=1000
+mX_r=6000
+mX_step1=500
+mX_step2=1000
+mX_tmp=$mX_l
+
+number_of_points=0
+
+mX_step_tmp=$mX_step1
+mYprime_r_tmp=$mYprime_r_1
+while [ ${mX_tmp} -le ${mX_r} ]
+do
+    echo generating cards for MX = ${mX_tmp} GeV
+    mYprime_tmp=$mYprime_l
+    mYprime_step_tmp=$mYprime_step1
+
+    while [ ${mYprime_tmp} -le ${mYprime_r_tmp} ]
+    do
+        mY_tmp=$mY_l
+        mY_step_tmp=$mY_step1
+        echo "   "MYprime = ${mYprime_tmp} GeV
+        while [ ${mY_tmp} -le ${mYprime_tmp} ]
+        do
+            echo "      "MY = ${mY_tmp} GeV
+            mkdir ${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow
+            for i in {0..3}; do
+                sed "s/<MASS_X>/${mX_tmp}/g" template_cards/${sample}_MY_MYprime_narrow${postfix[$i]} > ${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow/${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow${postfix[$i]}
+                sed -i "s/<MASS_Yprime>/${mYprime_tmp}/g" ${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow/${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow${postfix[$i]}
+                sed -i "s/<MASS_Y>/${mY_tmp}/g" ${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow/${sample}${mX_tmp}_MY${mY_tmp}_MYprime${mYprime_tmp}_narrow${postfix[$i]}
+            done
+        
+            if [ ${mY_tmp} -eq 150 ]
+            then
+                mY_step_tmp=$mY_step2
+            elif [ ${mY_tmp} -eq 300 ]
+            then
+                mY_step_tmp=$mY_step3
+            fi
+
+            let "mY_tmp+=mY_step_tmp"
+            let "number_of_points=number_of_points+1"
+        done
+    
+        if [ ${mYprime_tmp} -eq 150 ]
+        then
+            mYprime_step_tmp=$mYprime_step2
+        elif [ ${mYprime_tmp} -eq 300 ]
+        then
+            mYprime_step_tmp=$mYprime_step3
+        fi       
+
+        let "mYprime_tmp+=mYprime_step_tmp"
+    done
+
+    if [ ${mX_tmp} -eq 2000 ]
+    then
+        mX_step_tmp=$mX_step2
+        mYprime_r_tmp=$mYprime_r_2
+    fi
+
+    let "mX_tmp+=mX_step_tmp"
+done
+
+echo "Number of mass points: "$number_of_points

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_customizecards.dat
@@ -1,0 +1,9 @@
+set param_card mass 9000001 <MASS_X>
+set param_card mass 9000002 <MASS_X>
+set param_card rhoinputs 2 <MASS_X>
+set param_card DECAY 9000001 1.000000e-03
+set param_card DECAY 9000002 1.000000e-03
+set param_card mass 25 <MASS_Yprime>
+set param_card mass 23 <MASS_Y>
+set param_card DECAY 25 1.000000e-03
+set param_card DECAY 23 1.000000e-03

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_extramodels.dat
@@ -1,0 +1,2 @@
+#from https://github.com/syuvivida/DibosonBSMSignal_13TeV/tree/master/Models/Vector_Triplet_free_Width_UFO
+dibosonResonanceModel.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_proc_card.dat
@@ -1,9 +1,4 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set gauge unitary
-set complex_mass_scheme False
 import model Vector_Triplet_free_Width_UFO
-define p = g u c d s b u~ c~ d~ s~ b~
-define q = u c d s b u~ c~ d~ s~ b~
+define p = g u c d s u~ c~ d~ s~
 generate p p > vz, (vz > h z)
 output XToYYprime_MX<MASS_X>_MY<MASS_Y>_MYprime<MASS_Yprime>_narrow -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_proc_card.dat
@@ -1,0 +1,9 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set gauge unitary
+set complex_mass_scheme False
+import model Vector_Triplet_free_Width_UFO
+define p = g u c d s b u~ c~ d~ s~ b~
+define q = u c d s b u~ c~ d~ s~ b~
+generate p p > vz, (vz > h z)
+output XToYYprime_MX<MASS_X>_MY<MASS_Y>_MYprime<MASS_Yprime>_narrow -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/XToYYprime/template_cards/XToYYprime_MX_MY_MYprime_narrow_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+     1000     = nevents ! Number of unweighted events requested 
+      0       = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'  = pdlabel     ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf number              
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   F  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 10  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  -1  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+  -1  = etaa    ! max rap for the photons 
+  -1  = etal    ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0001 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1    =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies
+#
+#**************************************


### PR DESCRIPTION
This PR contains template MG cards for XToYYprime (resonance X decaying to two non-SM bosons Y and Y'), and a script to generate the actual cards. 

- The cards are based on a Z' -> ZH model (see [these cards](https://github.com/cms-sw/genproductions/tree/339ced1cc4be2a73b701f0b750155d70b38010ba/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/exo_diboson/Spin-1/Zprime_Zh_Zhadhbb)), changing the Z', Z, and H masses. The widths of the Y (= modified Z) and Y' (= modified H) bosons are set to narrow widths. The decays of the Y and Y' are to be done in Pythia.

- The script to generate the actual cards from the template cards is based on the script in the [BulkGraviton_hh_granular](https://github.com/cms-sw/genproductions/tree/22d4141/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/BulkGraviton_hh_granular) model.