### PR TITLE
Request EL7 workers for codegen step in CMS Connect

### DIFF
--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
@@ -20,7 +20,7 @@ cat<<-EOF
         +IsGridpack=true
         +GridpackCard = "${card_name}"
 	
-	+REQUIRED_OS = "rhel6"
+	+REQUIRED_OS = "rhel7"
 	request_cpus = $cores
 	request_memory = $memory
 	Queue 1


### PR DESCRIPTION
Since `UL2019` branch works with EL7, this CMS Connect script needs to be updated in order to request the proper OS in the codestep step. Thank to @agrohsje for noticing this.