### PR TITLE
Updated Cards for RunII

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_Za/ggh01_M125_ToZa01_Tomumubb_M91M/ggh01_M125_ToZa01_Tomumubb_M91M_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_Za/ggh01_M125_ToZa01_Tomumubb_M91M/ggh01_M125_ToZa01_Tomumubb_M91M_run_card.dat
@@ -87,10 +87,10 @@
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
- 20  = ptj       ! minimum pt for the jets 
+ 10  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
+  5  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_Za/h_Za_2b2mu_ggF.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_Za/h_Za_2b2mu_ggF.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-masses=(12 15 20 25 30 33)
+masses=(12 15 18 21 24 27 30 33)
 sample=ggh01_M125_ToZa01_Tomumubb_M91M
 
 postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_aa/ggh01_M125_Toa01a01_Tomumubb_M/ggh01_M125_Toa01a01_Tomumubb_M_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_aa/ggh01_M125_Toa01a01_Tomumubb_M/ggh01_M125_Toa01a01_Tomumubb_M_run_card.dat
@@ -87,10 +87,10 @@
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
- 20  = ptj       ! minimum pt for the jets 
+ 10  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
-  0  = ptl       ! minimum pt for the charged leptons 
+  5  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_aa/h_aa_2b2mu_ggF.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/ggF_aa/h_aa_2b2mu_ggF.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-masses=(20 25 30 35 40 45 50 55  60)
+masses=(10 15 20 25 30 35 40 45 50 55 60)
 sample=ggh01_M125_Toa01a01_Tomumubb_M
 
 postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/vbf_aa/h_aa_2b2mu_vbf.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/vbf_aa/h_aa_2b2mu_vbf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-masses=(20 30 40 50 60)
+masses=(10 20 30 40 50 60)
 sample=vbfh01_M125_Toa01a01_Tomumubb_M
 
 postfix=(_run_card.dat _customizecards.dat _proc_card.dat _extramodels.dat)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/vbf_aa/vbfh01_M125_Toa01a01_Tomumubb_M/vbfh01_M125_Toa01a01_Tomumubb_M_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/mumubb_final_state/vbf_aa/vbfh01_M125_Toa01a01_Tomumubb_M/vbfh01_M125_Toa01a01_Tomumubb_M_run_card.dat
@@ -87,10 +87,10 @@
 #*********************************************************************
 # Minimum and maximum pt's (for max, -1 means no cut)                *
 #*********************************************************************
- 20  = ptj       ! minimum pt for the jets 
+ 10  = ptj       ! minimum pt for the jets 
   0  = ptb       ! minimum pt for the b 
  10  = pta       ! minimum pt for the photons 
- 10  = ptl       ! minimum pt for the charged leptons 
+ 5  = ptl       ! minimum pt for the charged leptons 
   0  = misset    ! minimum missing Et (sum of neutrino's momenta)
   0  = ptheavy   ! minimum pt for one heavy final state
  1.0 = ptonium   ! minimum pt for the quarkonium states

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -144,14 +144,16 @@ CARDSDIR=${PRODHOME}/${carddir}
 
 MGBASEDIR=mgbasedir
 
-MG=MG5_aMC_v2.4.2.tar.gz
+MG=MG5_aMC_v2.6.5.tar.gz
+#MG=MG5_aMC_v2.4.2.tar.gz
 MGSOURCE=https://cms-project-generators.web.cern.ch/cms-project-generators/$MG
 
 #syscalc is a helper tool for madgraph to add scale and pdf variation weights for LO processes
 SYSCALC=SysCalc_V1.1.6.tar.gz
 SYSCALCSOURCE=https://cms-project-generators.web.cern.ch/cms-project-generators/$SYSCALC
 
-MGBASEDIRORIG=MG5_aMC_v2_4_2
+MGBASEDIRORIG=MG5_aMC_v2_6_5
+#MGBASEDIRORIG=MG5_aMC_v2_4_2
 
 isscratchspace=0
 


### PR DESCRIPTION
Hello, 
Please merge the pull request. We have updated run cards (lower cuts have been used for muons and jets) as per the discussions within the Exo group for the signature h->aa->bbmm. Since the samples haven't been simulated yet, we hope it is quite acceptable. 
Presetation have been made in the Exo-group and paths to gridpacks are:
h->aa->mmbb (ggF): /afs/cern.ch/user/a/aashah/public/GridPacks/h_aa/ggH
h->aa->mmbb (vbf): /afs/cern.ch/user/a/aashah/public/GridPacks/h_aa/vbf
h->Za->mmbb (ggF): /afs/cern.ch/user/a/aashah/public/GridPacks/h_Za

Thank you.


Best,
-Aashaq
On behalf of the mmbb group