### PR TITLE
Florida Tech Request (Reupload)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_customizecards.dat
@@ -1,0 +1,7 @@
+set param_card mass 1023 MASS # mZD
+set param_card mass 500521 5.000000e+00 # mfD1
+set param_card mass 500523 2.000000e+00 # mfD2
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500521 Auto # WfD1
+set param_card decay 500523 0.000000+e+00 # WfD2

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Fermionic_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Fermionic_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > FD11 FD11, (FD11 > FD21 mu+ mu-))
+output MASS -nojpeg #name of the directory

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/ZDfD/ZDfD_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfD_ZDM80toM700/createCards.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(80 91.11876 100 125 200 300 400 500 600 700)
+base_dir="2017/13TeV/"
+template_dir="ZDfD/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDfD_M${mp}/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDfD_extramodels.dat" "${dir}ZDfD_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDfD_proc_card.dat" "${dir}ZDfD_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDfD_run_card.dat" "${dir}ZDfD_M${mp}_run_card.dat"
+    cp "${template_dir}ZDfD_customizecards.dat" "${dir}ZDfD_M${mp}_customizecards.dat"
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDfD_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDfD_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/ZDfD_M${mp}/g" "ZDfD_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_customizecards.dat
@@ -1,0 +1,8 @@
+set param_card mass 1023 MASS # mZD
+set param_card mass 500521 5.000000e+00 # mfD1
+set param_card mass 500523 2.000000e+00 # mfD2
+#set param_card mass 500512 5.000000e+00 # msD
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500521 Auto # WfD1
+set param_card decay 500523 0.000000+e+00 # WfD2

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > SD SD~, SD > mu+ mu-, SD~ > mu+ mu-)
+output MASS -nojpeg #name of the directory

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/ZDfDsD_sDdecay/ZDfDsD_sDdecay_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM60toM200_sDdecay/createCards.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(60 91.11876 100 125 200)
+base_dir="2017/13TeV/"
+template_dir="ZDfDsD_sDdecay/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDfDsD_M${mp}_sDdecay/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDfDsD_sDdecay_extramodels.dat" "${dir}ZDfDsD_sDdecay_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDfDsD_sDdecay_proc_card.dat" "${dir}ZDfDsD_sDdecay_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDfDsD_sDdecay_run_card.dat" "${dir}ZDfDsD_sDdecay_M${mp}_run_card.dat"
+    cp "${template_dir}ZDfDsD_sDdecay_customizecards.dat" "${dir}ZDfDsD_sDdecay_M${mp}_customizecards.dat"
+    
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDfDsD_sDdecay_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDfDsD_sDdecay_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/M${mp}/g" "ZDfDsD_sDdecay_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_customizecards.dat
@@ -1,0 +1,7 @@
+set param_card mass 1023 MASS # mZD
+set param_card mass 500521 5.000000e+00 # mfD1
+set param_card mass 500523 2.000000e+00 # mfD2
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500521 Auto # WfD1
+set param_card decay 500523 0.000000+e+00 # WfD2

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > FD11 FD11, (FD11 > FD21 mu+ mu-))
+output MASS -nojpeg #name of the directory 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/ZDfDsD_ZDscan_fDdecay/ZDfDsD_ZDscan_fDdecay_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_ZDM80toM700_fDdecay/createCards.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(80 91.11876 100 125 200 300 400 500 600 700)
+base_dir="2017/13TeV/"
+template_dir="ZDfDsD_ZDscan_fDdecay/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDfDsD_ZDscan_fDdecay_M${mp}/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDfDsD_ZDscan_fDdecay_extramodels.dat" "${dir}ZDfDsD_ZDscan_fDdecay_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDfDsD_ZDscan_fDdecay_proc_card.dat" "${dir}ZDfDsD_ZDscan_fDdecay_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDfDsD_ZDscan_fDdecay_run_card.dat" "${dir}ZDfDsD_ZDscan_fDdecay_M${mp}_run_card.dat"
+    cp "${template_dir}ZDfDsD_ZDscan_fDdecay_customizecards.dat" "${dir}ZDfDsD_ZDscan_fDdecay_M${mp}_customizecards.dat"
+    
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDfDsD_ZDscan_fDdecay_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDfDsD_ZDscan_fDdecay_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/M${mp}/g" "ZDfDsD_ZDscan_fDdecay_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_customizecards.dat
@@ -1,0 +1,7 @@
+set param_card mass 1023 500 # mZD
+set param_card mass 500521 MASS # mfD1
+set param_card mass 500523 2.000000e+00 # mfD2
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500521 Auto # WfD1
+set param_card decay 500523 0.000000+e+00 # WfD2

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > FD11 FD11, (FD11 > FD21 mu+ mu-))
+output MASS -nojpeg #name of the directory 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/ZDfDsD_fD1scan_fDdecay/ZDfDsD_fD1scan_fDdecay_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD1M5toM245_fDdecay/createCards.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(80 91.11876 100 125 200 300 400 500 600 700)
+base_dir="2017/13TeV/"
+template_dir="ZDfDsD_fD1scan_fDdecay/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDfDsD_fD1scan_fDdecay_M${mp}/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDfDsD_fD1scan_fDdecay_extramodels.dat" "${dir}ZDfDsD_fD1scan_fDdecay_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDfDsD_fD1scan_fDdecay_proc_card.dat" "${dir}ZDfDsD_fD1scan_fDdecay_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDfDsD_fD1scan_fDdecay_run_card.dat" "${dir}ZDfDsD_fD1scan_fDdecay_M${mp}_run_card.dat"
+    cp "${template_dir}ZDfDsD_fD1scan_fDdecay_customizecards.dat" "${dir}ZDfDsD_fD1scan_fDdecay_M${mp}_customizecards.dat"
+    
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDfDsD_fD1scan_fDdecay_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDfDsD_fD1scan_fDdecay_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/M${mp}/g" "ZDfDsD_fD1scan_fDdecay_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_customizecards.dat
@@ -1,0 +1,7 @@
+set param_card mass 1023 5.000000e+02 # mZD
+set param_card mass 500521 1.000000e+02 # mfD1
+set param_card mass 500523 MASS # mfD2
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500521 Auto # WfD1
+set param_card decay 500523 0.000000+e+00 # WfD2

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Fermionic_Scalar_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > FD11 FD11, (FD11 > FD21 mu+ mu-))
+output MASS -nojpeg #name of the directory 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/ZDfDsD_fD2scan_fDdecay/ZDfDsD_fD2scan_fDdecay_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDfDsD_fD2M2toM50_fDdecay/createCards.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(2 10 20 30 40 50)
+base_dir="2017/13TeV/"
+template_dir="ZDfDsD_fD2scan_fDdecay/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDfDsD_fD2scan_fDdecay_M${mp}/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDfDsD_fD2scan_fDdecay_extramodels.dat" "${dir}ZDfDsD_fD2scan_fDdecay_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDfDsD_fD2scan_fDdecay_proc_card.dat" "${dir}ZDfDsD_fD2scan_fDdecay_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDfDsD_fD2scan_fDdecay_run_card.dat" "${dir}ZDfDsD_fD2scan_fDdecay_M${mp}_run_card.dat"
+    cp "${template_dir}ZDfDsD_fD2scan_fDdecay_customizecards.dat" "${dir}ZDfDsD_fD2scan_fDdecay_M${mp}_customizecards.dat"
+    
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDfDsD_fD2scan_fDdecay_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDfDsD_fD2scan_fDdecay_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/M${mp}/g" "ZDfDsD_fD2scan_fDdecay_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_customizecards.dat
@@ -1,0 +1,5 @@
+set param_card mass 1023 MASS # mZD
+set param_card mass 500512 5.000000e+00 # mSD
+set param_card hidden 1 1.000000e-02 # eta
+set param_card decay 1023 Auto # WZD
+set param_card decay 500512 Auto # WsD

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_extramodels.dat
@@ -1,0 +1,1 @@
+DM_KinMix_Med_Spin1_Scalar_Prds.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_proc_card.dat
@@ -1,0 +1,4 @@
+import model DM_KinMix_Med_Spin1_Scalar_Prds
+define p = g u c d s u~ c~ d~ s~
+generate p p > ZD, (ZD > SD SD~, SD > mu+ mu-, SD~ > mu+ mu-)
+output MASS -nojpeg #name of the directory

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
@@ -1,0 +1,167 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  1000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     nn23lo1    = pdlabel     ! PDF set
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+  set small_width_treatment default
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+ #*********************************************************************
+ # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+ # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+ #*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 5.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}    = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ -1 = drll    ! min distance between leptons
+ -1.0  = drllmax ! max distance between leptons
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+ # WARNING: for four lepton final state mmll cut require to have      *
+ #          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons                *
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
@@ -23,7 +23,7 @@
 # Number of events and rnd seed                                      *
 # Warning: Do not generate more than 1M events in a single run       *
 #*********************************************************************
-  1000 = nevents ! Number of unweighted events requested
+  EVENTS = nevents ! Number of unweighted events requested
   0   = iseed   ! rnd seed (0=assigned automatically=default))
 #*********************************************************************
 # Collider type and energy                                           *
@@ -136,7 +136,6 @@
 #*********************************************************************
 # Inclusive cuts                                                     *
 #*********************************************************************
- 0.0  = ptheavy   ! minimum pt for at least one heavy final state
  0.0  = xptl ! minimum pt for at least one charged lepton
  #*********************************************************************
  # Control the pt's of leptons sorted by pt                           *
@@ -162,6 +161,4 @@
 #*********************************************************************
    True  = use_syst      ! Enable systematics studies
 #
-systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
-['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
 # Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/ZDsD/ZDsD_run_card.dat
@@ -39,8 +39,8 @@
 #*********************************************************************
 # PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
 #*********************************************************************
-     nn23lo1    = pdlabel     ! PDF set
-     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
 # To see heavy ion options: type "update ion_pdf"
 #*********************************************************************
 # Renormalization and factorization scales                           *

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/createCards.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZDsD_ZDM60toM1400/createCards.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#  customizecards.sh
+#  For fD Models, scan over ZD
+#
+#  Created by Jacob Chesslo on 6/30/20.
+#
+masspoints=(60 91.11876 100 125 200 300 400 500 600 700 800 900 1000 1100 1200 1300 1400)
+base_dir="2017/13TeV/"
+template_dir="ZDsD/"
+
+for mp in "${masspoints[@]}"
+do
+    dir="ZDsD_M${mp}/"
+    mkdir -p "$dir"
+    
+    cp "${template_dir}ZDsD_extramodels.dat" "${dir}ZDsD_M${mp}_extramodels.dat"
+    cp "${template_dir}ZDsD_proc_card.dat" "${dir}ZDsD_M${mp}_proc_card.dat"
+    cp "${template_dir}ZDsD_run_card.dat" "${dir}ZDsD_M${mp}_run_card.dat"
+    cp "${template_dir}ZDsD_customizecards.dat" "${dir}ZDsD_M${mp}_customizecards.dat"
+    
+    
+    cd ${dir}
+        #customizecard.dat
+        sed -i '' "s/MASS/${mp}/g" "ZDsD_M${mp}_customizecards.dat"
+
+        #run_card.dat
+        sed -i '' "s/EVENTS/5000/g" "ZDsD_M${mp}_run_card.dat"
+        
+        #param_card.dat
+        
+        #proc_card.dat
+        sed -i '' "s/MASS/M${mp}/g" "ZDsD_M${mp}_proc_card.dat"
+        
+        #extramodels.dat
+        
+    cd ../
+    
+done
+


### PR DESCRIPTION
For the request we have three prompt Dark Matter models, where they can decay into SM particles or first into DM matter particles and then into SM particles such as muons, through a spin 1 mediator, a dark Z-like boson ZD, which can interact with the Standard Model sector as well as the dark matter sector.

**FD model: DM_KM_Med_Spin1_Fermioic_Prds.:**
pp collisions produce our ZD through kinetic mixing, which then eventually decays into ordinary matter and stable dark matter (fD2)

**SD model: DM_KM_Med_Spin1_Scalar_Prds.**
pp collisions produce our ZD through kinetic mixing then decaying into dark scalar matter (sD), which then decays into ordinary matter

**Combination of the two models: DM_KM_Med_Spin1_Fermionic_Scalar_Prds**
A combination of the above two, where the dark Z can decay into either fermionic or scalar matter.

**Mass Scans**

MZD scan- fD model
MZD scan- sD model
MZD scan- combination of two models - fD decays
MZD scan- combination of two models - sD decays
MfD1 scan- combination of two models - fD decays
MfD2 scan- combination of two models - fD decays
Note: MsD scan- combination of two models - sD decays: we are not doing mass scan for MsD because they dont seem to have enough sensitivity for higher masses

This is a 2018 Request, and we would also like to clarify that **our sample campaign should be produced in consistency with ALP/Dark Susy 2018 samples**, such as in Wei's campaign: https://cms-pdmv.cern.ch/mcm/requests?dataset_name=ALP_mH_*_mALP_*_PSWeights_TuneCP5_13TeV-madgraph-pythia8&page=-1&shown=275146342527

_This is a Reupload of the original (Request #2666) where we were told to remove the "-pythia8" naming convention, as well as alteration to run_card with correct cuts._