### PR TITLE
Set bornonly to be 0 for ggHZ samples

### DIFF
--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic.input
@@ -58,7 +58,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vinclusive.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vinclusive.input
@@ -60,7 +60,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vleptonic.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vleptonic.input
@@ -60,7 +60,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vneutrinos.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vneutrinos.input
@@ -60,6 +60,4 @@ doublefsr 1
 
 nohad   1
 
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vhadronic_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vhadronic_template.input
@@ -61,4 +61,4 @@ nohad   1
 
 LOevents 1
 # with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vhadronic_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vhadronic_template.input
@@ -58,7 +58,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
 bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vinclusive_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vinclusive_template.input
@@ -60,7 +60,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
 bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vinclusive_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vinclusive_template.input
@@ -63,4 +63,4 @@ nohad   1
 
 LOevents 1
 # with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vleptonic_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vleptonic_template.input
@@ -60,7 +60,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
 bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vleptonic_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vleptonic_template.input
@@ -63,4 +63,4 @@ nohad   1
 
 LOevents 1
 # with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vneutrinos_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vneutrinos_template.input
@@ -62,4 +62,4 @@ nohad   1
 
 LOevents 1
 # with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vneutrinos_template.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_Vneutrinos_template.input
@@ -60,6 +60,4 @@ doublefsr 1
 
 nohad   1
 
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
 bornonly 0 

--- a/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_M125_Vhadronic.input
+++ b/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_M125_Vhadronic.input
@@ -58,7 +58,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_Vhadronic_template.input
+++ b/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_Vhadronic_template.input
@@ -61,4 +61,4 @@ nohad   1
 
 LOevents 1
 # with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 

--- a/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_Vhadronic_template.input
+++ b/bin/Powheg/production/pre2017/13TeV/ggHZ_HanythingJ_NNPDF30_13TeV/ggHZ_HanythingJ_NNPDF30_13TeV_Vhadronic_template.input
@@ -58,7 +58,4 @@ doublefsr 1
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
 bornonly 0 


### PR DESCRIPTION
For the cards included with PR #2675 , change bornonly option in the ggHZ cards to be 0.