### PR TITLE
madspin patch for mg27x branch

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
@@ -1,0 +1,42 @@
+diff --git a/MadSpin/interface_madspin.py b/MadSpin/interface_madspin.py
+index dd2be33..6796e51 100755
+--- a/MadSpin/interface_madspin.py
++++ b/MadSpin/interface_madspin.py
+@@ -1264,8 +1264,20 @@ class MadSpinInterface(extended_cmd.Cmd):
+                 me5_cmd.exec_cmd("exit")
+                 out[i] = lhe_parser.EventFile(pjoin(decay_dir, "Events", 'run_01', 'unweighted_events.lhe.gz'))            
+             else:
+-                misc.call(['run.sh', str(int(1.2*nb_event)), str(self.seed)], cwd=decay_dir)     
+-                out[i] = lhe_parser.EventFile(pjoin(decay_dir, 'events.lhe.gz'))            
++                if not self.seed:
++                    if hasattr(self, 'mother'):
++                        try:
++                            self.seed = 100 + self.mother.run_card['iseed']
++                        except:
++                            self.seed = random.randint(0, int(30081*30081))
++                if self.seed > 30081*30081:
++                    self.seed -= 30081*30081
++
++                logger.info("Will use seed %s" %(self.seed))
++                misc.call(['run.sh', str(int(1.2*nb_event)), str(self.seed)], cwd=decay_dir)
++
++                out[i] = lhe_parser.EventFile(pjoin(decay_dir, 'events.lhe.gz'))
++
+             if cumul:
+                 break
+         
+diff --git a/madgraph/interface/common_run_interface.py b/madgraph/interface/common_run_interface.py
+index 4265aea..da84476 100755
+--- a/madgraph/interface/common_run_interface.py
++++ b/madgraph/interface/common_run_interface.py
+@@ -3678,8 +3678,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
+         for key, value in self.options.items():
+             if isinstance(value, str):
+                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s' %(key,value), errorhandling=False, printcmd=False, precmd=False, postcmd=True)
++
+         madspin_cmd.cluster = self.cluster
+-        
++        madspin_cmd.mother = self
+         madspin_cmd.update_status = lambda *x,**opt: self.update_status(*x, level='madspin',**opt)
+ 
+         path = pjoin(self.me_dir, 'Cards', 'madspin_card.dat')


### PR DESCRIPTION
- we don't need patch for madgraph versions below 265, the crash caused when madgraph was updated to 265.
- we further compared distributions between branches mg261 and master using gridpack based LHE files
- Is it okay to number them as 0031 and 0032 for patch 1 and patch 2?
- patch 1 not need for mg27x

patch 1 : to accommodate the madspin changes mg265 -> mg273
patch 2 : to fix randomseed delivery issue in mg273
https://indico.cern.ch/event/951404/contributions/4012583/attachments/2105591/3542606/gen_sep_21_2020_madspin_patch_validation_followup.pdf