### PR TITLE
Set EW parameter for V+jets samples in validation

### DIFF
--- a/bin/GenValidation/updated_validation_cards/dy01234mlm/dyellell01234j_5f_LO_MLM_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy01234mlm/dyellell01234j_5f_LO_MLM_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx/dyellell012j_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx/dyellell012j_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663786999999999e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt0_50/DYJetsToLL_012j_Zpt-0To50_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt0_50/DYJetsToLL_012j_Zpt-0To50_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt100_250/DYJetsToLL_012j_Zpt-100To250_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt100_250/DYJetsToLL_012j_Zpt-100To250_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt250_400/DYJetsToLL_012j_Zpt-250To400_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt250_400/DYJetsToLL_012j_Zpt-250To400_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt400_650/DYJetsToLL_012j_Zpt-400To650_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt400_650/DYJetsToLL_012j_Zpt-400To650_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt50_100/DYJetsToLL_012j_Zpt-50To100_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt50_100/DYJetsToLL_012j_Zpt-50To100_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt650_inf/DYJetsToLL_012j_Zpt-650Toinf_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012jfxfx_ptbinned/pt650_inf/DYJetsToLL_012j_Zpt-650Toinf_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy012mlm/dyellell012j_5f_LO_MLM_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy012mlm/dyellell012j_5f_LO_MLM_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663786999999999e-05

--- a/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy0jfxfx/dyellell0j_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy0jfxfx/dyellell0j_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy1jfxfx/dyellell1j_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy1jfxfx/dyellell1j_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy2jfxfx/dyellell2j_5f_NLO_FXFX_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/dy_jetbinned_fxfx/dy2jfxfx/dyellell2j_5f_NLO_FXFX_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, sinthetaW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 79.906828021009360
+set param_card DECAY 24 2.085
+set param_card SMINPUTS 1 128.82539822180297
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/GenValidation/updated_validation_cards/w01234mlm/lv_bwcutoff_WJetsToLNu_HT-incl_customizecards.dat
+++ b/bin/GenValidation/updated_validation_cards/w01234mlm/lv_bwcutoff_WJetsToLNu_HT-incl_customizecards.dat
@@ -1,0 +1,10 @@
+# These inputs are based on fixing the PDG vlaues of mZ, mW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s)
+# dependent. We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+set param_card mass 23 91.153480619182758
+set param_card DECAY 23 2.4942663787728243
+# The value of mW is significantly differnt from the PDG in this input scheme
+set param_card mass 24 80.351971594490678
+set param_card DECAY 24 2.0842988936726390
+set param_card SMINPUTS 1 132.30808052535320
+set param_card SMINPUTS 2 1.1663787e-05

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -636,11 +636,13 @@ if [ -z "$PRODHOME" ]; then
 fi 
 
 # Folder structure is different on CMSConnect
-helpers_dir=${PRODHOME}/Utilities
-if [ ! -d "$helpers_dir" ]; then
+helpers_dir=${PRODHOME%genproductions*}/genproductions/Utilities
+helpers_file=${helpers_dir}/gridpack_helpers.sh
+if [ ! -f "$helpers_file" ]; then
     helpers_dir=$(git rev-parse --show-toplevel)/bin/MadGraph5_aMCatNLO/Utilities
+    helpers_file=${helpers_dir}/gridpack_helpers.sh
 fi
-source ${helpers_dir}/gridpack_helpers.sh 
+source ${helpers_file}
 
 
 if [ ! -z ${CMSSW_BASE} ]; then


### PR DESCRIPTION
Explicitly set the EW parameters for V+jets, following the setup used for the W mass samples. The values are set to the best PDG values, using the input scheme with G_fermi and either mW,mZ for W production and mZ, sinthetaW for Z production. MadGraph uses a fixed width scheme, so we account for the fact that the PDG values are sqrt(s) dependent using https://arxiv.org/pdf/1606.02330.pdf

I checked that this is technically working for DY MLM, but can someone make additional checks to be sure that it is always read properly and set, and that the cross sections are changed with or without the customization?