### PR TITLE
add_min_mjj_invariant_mass

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/VBF_gammaH_HTobb_LO/VBF_gammaH_HTobb_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/VBF_gammaH_HTobb_LO/VBF_gammaH_HTobb_LO_run_card.dat
@@ -167,7 +167,7 @@
 # WARNING: for four lepton final state mmll cut require to have      *
 #          different lepton masses for each flavor!                  *           
 #*********************************************************************
- 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 200.0   = mmjj    ! min invariant mass of a jet pair 
  0.0   = mmbb    ! min invariant mass of a b pair 
  0.0   = mmaa    ! min invariant mass of gamma gamma pair
  0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair


### PR DESCRIPTION
@agrohsje I missed the minimum invariant mass cut for the light quark jets in our signal sample can you please check once. Extremely sorry for this mistake and please merge if you think. 