### PR TITLE
Change ggWW MCFM+JHUGen PDF for UL gridpacks

### DIFF
--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENEN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENEN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENMN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENMN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENTN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoENTN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNEN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNEN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNMN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNMN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNTN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoMNTN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNEN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNEN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNMN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNMN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNTN_BKG_NNPDF31.DAT
+++ b/bin/MCFM/cards/MCFM_JHUGen_ggWW/MCFM_JHUGen_13TeV_ggWWtoTNTN_BKG_NNPDF31.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_lo_as_0131'			[LHAPDF group]
+'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'			[LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]


### PR DESCRIPTION
While redoing the MCFM+JHUGen gg->WW gridpacks for UL production, we also change the PDF set to NNPDF31_nnlo_as_0118_mc_hessian_pdfas.

Except for the PDF set, the cards are identical to the ones in the previous gridpacks.