### PR TITLE
mg27x branch Madgraph5_aMCatNLO 0032*.patch fix

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
@@ -24,19 +24,18 @@ index dd2be33..6796e51 100755
 +
              if cumul:
                  break
-         
+
 diff --git a/madgraph/interface/common_run_interface.py b/madgraph/interface/common_run_interface.py
-index 4265aea..da84476 100755
+index 49ae661..1dfcaaa 100755
 --- a/madgraph/interface/common_run_interface.py
 +++ b/madgraph/interface/common_run_interface.py
-@@ -3678,8 +3678,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
-         for key, value in self.options.items():
+@@ -3697,7 +3697,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
              if isinstance(value, str):
-                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s' %(key,value), errorhandling=False, printcmd=False, precmd=False, postcmd=True)
-+
+                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s --no_save' %(key,value), errorhandling=False, p
          madspin_cmd.cluster = self.cluster
 -        
-+        madspin_cmd.mother = self
++
++        madspin_cmd.mother = self.mother
          madspin_cmd.update_status = lambda *x,**opt: self.update_status(*x, level='madspin',**opt)
  
          path = pjoin(self.me_dir, 'Cards', 'madspin_card.dat')

--- a/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0032-fix_madspin_seed_delivery.patch
@@ -31,7 +31,7 @@ index 49ae661..1dfcaaa 100755
 +++ b/madgraph/interface/common_run_interface.py
 @@ -3697,7 +3697,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
              if isinstance(value, str):
-                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s --no_save' %(key,value), errorhandling=False, p
+                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s --no_save' %(key,value), errorhandling=False, printcmd=False, precmd=False, postcmd=True)
          madspin_cmd.cluster = self.cluster
 -        
 +


### PR DESCRIPTION
There was a mix of the patches between the master branch and the mg27x branch result in the failure of the patch. Fix for the mg27x branch.