### PR TITLE
ggHZ card - PDF updated for UL gridpack

### DIFF
--- a/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vleptonic.input
+++ b/bin/Powheg/production/2017/13TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13TeV/ggHZ_HanythingJ_NNPDF31_13TeV_M125_Vleptonic.input
@@ -2,10 +2,10 @@ vdecaymode   11   ! 1: e, 2: mu, 3: tau, 4:nu_e, 5: nu_mu, 6: nu_tau, 11: inclus
 hdecaymode  -1  ! undecayed Higgs boson (for PYTHIA and HERWIG)
 
 hmass  125d0        ! Higgs boson mass 
-hwidth 0.403d-2     ! Higgs boson width 
+hwidth 0.00407d0     ! Higgs boson width
 
-min_h_mass    10d0      
-max_h_mass 1000d0 
+min_h_mass  12d0      
+max_h_mass  1250d0 
 
 min_z_mass     10d0
 max_z_mass     1000d0
@@ -19,10 +19,9 @@ ebeam2 6500d0     ! energy of beam 2
 
 bornktmin 0d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
 bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
-pdfreweight 0
 
-lhans1  306000         ! pdf set for hadron 1 (LHA numbering)
-lhans2  306000         ! pdf set for hadron 2 (LHA numbering)	
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)	
 
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
@@ -52,16 +51,13 @@ nubound 2000000 ! number of calls to set up the upper bounding norms for radiati
 testplots  1      ! (default 0, do not) do NLO and PWHG distributions
 
 iseed    SEED         !  Start the random number generator with seed iseed
+
 fastbtlbound 1
 
-storeinfo_rwgt 0   ! store info to allow for reweighting
 withnegweights 1
 
 doublefsr 1 
 
 nohad   1
 
-
-LOevents 1
-# with LOevents equal 1, bornonly must be set equal to 1
-bornonly 1 
+bornonly 0 


### PR DESCRIPTION
PDF set updated to 325300 in order to use the card for the production of ggZH gridpack for the UL campaign. Other than that, no changes have been implemented