### PR TITLE
Minor fixes for running gridpack generation on CMS Connect 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -83,10 +83,12 @@ make_gridpack () {
     # CMS Connect runs git status inside its own script.
     if [ $iscmsconnect -eq 0 ]; then
       cd $PRODHOME
-      git status
-      echo "Current git revision is:"
-      git rev-parse HEAD
-      git diff | cat
+      if [ -x "$(command -v git)" ]; then
+        git status
+        echo "Current git revision is:"
+        git rev-parse HEAD
+        git diff | cat
+      fi
       cd -
     fi
     
@@ -398,7 +400,11 @@ make_gridpack () {
     #################################
     script_dir="${PRODHOME}/Utilities/scripts"
     if [ ! -d "$script_dir" ]; then
-      script_dir=$(git rev-parse --show-toplevel)/Utilities/scripts
+      if ! [ -x "$(command -v git)" ]; then
+        script_dir=${PRODHOME%genproductions*}/genproductions/Utilities/scripts
+      else
+        script_dir=$(git rev-parse --show-toplevel)/Utilities/scripts
+      fi
     fi
     
     prepare_run_card $name $CARDSDIR $is5FlavorScheme $script_dir $isnlo
@@ -661,8 +667,12 @@ fi
 helpers_dir=${PRODHOME%genproductions*}/genproductions/Utilities
 helpers_file=${helpers_dir}/gridpack_helpers.sh
 if [ ! -f "$helpers_file" ]; then
+  if ! [ -x "$(command -v git)" ]; then
+    helpers_dir=${PRODHOME}/Utilities
+  else
     helpers_dir=$(git rev-parse --show-toplevel)/bin/MadGraph5_aMCatNLO/Utilities
-    helpers_file=${helpers_dir}/gridpack_helpers.sh
+  fi
+  helpers_file=${helpers_dir}/gridpack_helpers.sh
 fi
 source ${helpers_file}
 

--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
@@ -20,7 +20,7 @@ cat<<-EOF
         +IsGridpack=true
         +GridpackCard = "${card_name}"
 	
-	+REQUIRED_OS = "rhel6"
+	+REQUIRED_OS = "${rhel_ver}"
 	request_cpus = $cores
 	request_memory = $memory
 	Queue 1
@@ -167,6 +167,28 @@ cores="${3:-1}"
 memory="${4:-2 Gb}"
 scram_arch="${5:-}"
 cmssw_version="${6:-}"
+
+export SYSTEM_RELEASE=`cat /etc/redhat-release`
+
+if [ -n "$5" ]; then
+  if [[ $scram_arch == *"slc6"* ]]; then
+    rhel_ver="rhel6"
+  elif [[ $scram_arch == *"slc7"* ]]; then
+    rhel_ver="rhel7"
+  else
+    echo "Invalid scram_arch is specified!"
+    if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
+  fi
+else
+  if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+    rhel_ver="rhel6"
+  elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+    rhel_ver="rhel7"
+  else 
+    echo "No default CMSSW for current OS!"
+      if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi        
+  fi
+fi
 
 parent_dir=$PWD
 

--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation_singlejob.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation_singlejob.sh
@@ -21,7 +21,7 @@ cat<<-EOF
 	+WantIOProxy=true
 	periodic_release = (JobStatus == 5) && StringListMember(HoldReasonCode,"26,13,256,12,6") && (NumJobStarts < 11)
 	
-	+REQUIRED_OS = "rhel6"
+	+REQUIRED_OS = ${rhel_ver}
 	request_cpus = $cores
 	request_memory = $memory
 	+MaxWallTimeMins = $condor_maxwalltime
@@ -129,6 +129,28 @@ memory="${4:-16 Gb}"
 condor_maxwalltime="${5:-2400}"
 scram_arch="${6:-}"
 cmssw_version="${7:-}"
+
+export SYSTEM_RELEASE=`cat /etc/redhat-release`
+
+if [ -n "$6" ]; then
+  if [[ $scram_arch == *"slc6"* ]]; then
+    rhel_ver="rhel6"
+  elif [[ $scram_arch == *"slc7"* ]]; then
+    rhel_ver="rhel7"
+  else
+    echo "Invalid scram_arch is specified!"
+    if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
+  fi
+else
+  if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+    rhel_ver="rhel6"
+  elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+    rhel_ver="rhel7"
+  else
+    echo "No default CMSSW for current OS!"
+      if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 1; else exit 1; fi
+  fi
+fi
 
 parent_dir=$PWD
 ##############################################


### PR DESCRIPTION
Now running gridpack generation on CMS Connect is almost compatible for both `slc6` (by the help of command `cmssw-slc6-condor`) and `slc7` (native), this PR attempts to fix two minor issues:

1. Fix hard-coded OS version in the `condor` submit card, detect either OS or user-specified `scram_arch` automatically
2. Command `git` does not exist occasionally when using singularity container inside `condor` sandbox environment. Try to check whether `git` exists first, and add a backup solution for locating directories when `git` does not exist.

Tested it by generating several simple gridpacks (e.g. `dy01jMLM`) on CMS Connect