### PR TITLE
Add WWAToLNuLNuA_4f_NLO Process Cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_madspin_card.dat
@@ -1,0 +1,14 @@
+set ms_dir ./madspingrid
+
+set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+set max_running_process 1
+
+define w = w+ w-
+define lep = e+ mu+ ta+ e- mu- ta-
+define nu = ve vm vt ve~ vm~ vt~
+
+decay w > lep nu
+
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_madspin_card.dat
@@ -5,10 +5,6 @@ set max_weight_ps_point 400  # number of PS to estimate the maximum for each eve
 
 set max_running_process 1
 
-define w = w+ w-
-define lep = e+ mu+ ta+ e- mu- ta-
-define nu = ve vm vt ve~ vm~ vt~
-
 decay w > lep nu
 
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_proc_card.dat
@@ -1,0 +1,15 @@
+import model loop_sm
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set gauge unitary
+set complex_mass_scheme False
+
+define p = g u c d s u~ c~ d~ s~
+define w = w+ w-
+define lep = e+ mu+ ta+ e- mu- ta-
+define nu = ve vm vt ve~ vm~ vt~
+
+generate p p > w a lep nu [QCD]  @0
+
+output WWAToLNuLNuA_4f_NLO_1 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
@@ -28,7 +28,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
- 300 = nevents ! Number of unweighted events requested 
+ 3000 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
  20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
@@ -30,7 +30,7 @@
 #***********************************************************************
  3000 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
- 20 = nevt_job! Max number of events per job in event generation. 
+ -1 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).
 #***********************************************************************
 # Normalize the weights of LHE events such that they sum or average to *
@@ -123,7 +123,7 @@
 # BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
 # written in the LHE event file                                        ***********************************************************************
 #***********************************************************************
- 25.0  = bwcutoff
+ 30.0  = bwcutoff
 #***********************************************************************
 # Cuts on the jets. Jet clustering is performed by FastJet.            *
 #  - When matching to a parton shower, these generation cuts should be *
@@ -156,7 +156,6 @@
   1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
   1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
  True  = isoEM  ! isolate photons from EM energy (photons and leptons)
-  #0.1 = dral    ! min distance between gamma *************************
 #***********************************************************************
 # For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)***********************************************************************
  0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_1/WWAToLNuLNuA_4f_NLO_1_run_card.dat
@@ -1,0 +1,164 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 300 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ 20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ $DEFAULT_PDF_SETS = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0 = rw_rscale ! muR factors to be included by reweighting
+ 1.0 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 0        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        ***********************************************************************
+#***********************************************************************
+ 25.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  0.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+ 
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  10  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.1  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+  #0.1 = dral    ! min distance between gamma *************************
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+
+#********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_proc_card.dat
@@ -1,0 +1,8 @@
+import model loop_sm
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+
+generate p p >  ell+ vl ell- vl~ a [QCD]  $z  @0
+
+output WWAToLNuLNuA_4f_NLO_2 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
@@ -28,7 +28,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
- 300 = nevents ! Number of unweighted events requested 
+ 3000 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
  20 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
@@ -1,0 +1,162 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 300 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ 20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm      ! average or sum
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6500.0   = ebeam1  ! beam 1 energy in GeV
+ 6500.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ $DEFAULT_PDF_SETS = lhaid ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1.0       = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0 = rw_rscale ! muR factors to be included by reweighting
+ 1.0 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ False = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 0        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15000  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  0.7  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  1.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  10  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.1  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToLNuLNuA_4f_NLO_2/WWAToLNuLNuA_4f_NLO_2_run_card.dat
@@ -30,7 +30,7 @@
 #***********************************************************************
  3000 = nevents ! Number of unweighted events requested 
  0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
- 20 = nevt_job! Max number of events per job in event generation. 
+ -1 = nevt_job! Max number of events per job in event generation. 
                  !  (-1= no split).
 #***********************************************************************
 # Normalize the weights of LHE events such that they sum or average to *


### PR DESCRIPTION
There are two sets of cards for WWAToLNuLNuA_4f_NLO process.
The first one is p p > w a lep nu [QCD] : w combined w+ and  w-, we also take the offshell/onshell w and fsr photons into account.
The Second one is p p >  ell+ vl ell- vl~ a [QCD]  $z : all w are offshell but this will include zza process, so we use $z to depress it. 