### PR TITLE
Fix aMCatNLO Wpt FxFx cuts.f template fortran error

### DIFF
--- a/bin/GenValidation/updated_validation_cards/wjets_fxfx/w012jfxfx_ptbinned/wpt-0to50_cuts_template.f
+++ b/bin/GenValidation/updated_validation_cards/wjets_fxfx/w012jfxfx_ptbinned/wpt-0to50_cuts_template.f
@@ -418,8 +418,7 @@ C
      &        ((abs(ipdg(i)).eq.11.or.abs(ipdg(i)).eq.13.or.
      &        abs(ipdg(i)).eq.15).and.
      &        (ipdg(j).eq.-sign(abs(ipdg(i))+1,ipdg(i))))) then
-              ptw=dsqrt((p(1,i)+p(1,j))**2 + (p(2,i)+p(2,j))**2)
-              if (ptw.gt.50) then
+              if ( (p(1,i)+p(1,j))**2 + (p(2,i)+p(2,j))**2 .gt.50d0**2 ) then
                 passcuts_user=.false.
                 return
               endif


### PR DESCRIPTION
Fix the following error while doing `gfortran -O -fno-automatic -ffixed-line-length-300 -c -I. -I../../lib/ cuts.f`:
```
cuts.f:421:17:

               ptw=dsqrt((p(1,i)+p(1,j))**2 + (p(2,i)+p(2,j))**2)
                 1
Error: Symbol 'ptw' at (1) has no IMPLICIT type
make: *** [makefile:73: cuts.o] Error 1
```