### PR TITLE
Fix f2py version used in the NLO reweighting mode

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -106,6 +106,12 @@ prepare_reweight () {
         export LIBRARY_PATH=$LD_LIBRARY_PATH
     fi
 
+    # Use f2py2 instead of f2py to install a py2 version of "rwgt2py"
+    # (occurs in CMSSW_10_6_19 where default f2py points to a py3 version)
+    if [ -e $(readlink -f `which f2py`)2 ]; then
+        echo "f2py_compiler="$(readlink -f `which f2py`)2 >> $config
+    fi
+
     if [ "$isnlo" -gt "0" ]; then
         # Needed to get around python import errors
         rwgt_dir="$WORKDIR/process/rwgt"


### PR DESCRIPTION
**Description**: 
 In CMSSW_10_6_19, the default `f2py` points to the python3 version. During the reweight routine in NLO mode, the package `rwgt2py` will be installed under python3, therefore an error
`ImportError : No module named rwgt2py`
will occur from the python2 instance launched by MG2.6.5.

the error is described in https://answers.launchpad.net/mg5amcnlo/+question/686780

**Solution**: 
Manually point `f2py_compiler` to `f2py2` instead of using the default `f2py`, if `f2py2` exists in the same installation directory.

To reproduce the issue out of the box:
`./gridpack_generation.sh GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia8 cards/production/13TeV/ggHCPjets_v2/GluGluToPseudoscalarHToTauTau_M125_13TeV_amcatnloFXFX_pythia`