### PR TITLE
Add higgsino case, PSweights to Disappearing Tracks AMSB fragments

### DIFF
--- a/genfragments/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -21,6 +21,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
             'SUSY:all = off',
             'SUSY:qqbar2chi+chi- = on',
@@ -33,6 +34,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
         parameterSets = cms.vstring(
             'pythia8CommonSettings',
             'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
             'processParameters')
     ),
     # The following parameters are required by Exotica_HSCP_SIM_cfi:

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/Higgsino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/Higgsino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py
@@ -1,0 +1,55 @@
+COM_ENERGY = 13000.
+MCHI = XXX  # GeV
+CTAU = YYY  # mm
+CROSS_SECTION = ZZZ # pb
+SLHA_TABLE="""
+""" % (1.97326979e-13 / CTAU)
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    filterEfficiency = cms.untracked.double(-1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    SLHATableForPythia8 = cms.string('%s' % SLHA_TABLE),
+    comEnergy = cms.double(COM_ENERGY),
+    crossSection = cms.untracked.double(CROSS_SECTION),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SUSY:all = off',
+            'SUSY:qqbar2chi+chi- = on',
+            'SUSY:qqbar2chi+-chi0 = on',
+            '1000024:isResonance = false',
+            '1000024:oneChannel = 1 0.4775 100 1000022 211',
+            '1000024:addChannel = 1 0.4775 100 1000023 211',
+            '1000024:addChannel = 1 0.0150 100 1000022 -11 12',
+            '1000024:addChannel = 1 0.0150 100 1000023 -11 12',
+            '1000024:addChannel = 1 0.0075 100 1000022 -13 14',
+            '1000024:addChannel = 1 0.0075 100 1000023 -13 14',
+            '1000024:tau0 = %.1f' % CTAU,
+            '1000023:mayDecay = false',
+            'ParticleDecays:tau0Max = %.1f' % (CTAU * 10),
+       ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PSweightsSettings',
+            'processParameters')
+    ),
+    # The following parameters are required by Exotica_HSCP_SIM_cfi:
+    slhaFile = cms.untracked.string(''),   # value not used
+    processFile = cms.untracked.string('SimG4Core/CustomPhysics/data/RhadronProcessList.txt'),
+    useregge = cms.bool(False),
+    hscpFlavor = cms.untracked.string('stau'),
+    massPoint = cms.untracked.int32(MCHI),  # value not used
+    particleFile = cms.untracked.string('Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSB/test/geant4_higgsinoAMSB_chargino_%sGeV_ctau%scm.slha' % (MCHI, CTAU/10))
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/README.md
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/README.md
@@ -1,7 +1,6 @@
 # Disappearing Tracks AMSB
 https://indico.cern.ch/event/725187/contributions/3018385/attachments/1656960/2652924/disappTrksMCRequest.pdf
 
-    cd $CMSSW_BASE/src/Configuration/GenProduction/python/ThirteenTeV/DisappTrksAMSB/
     ./createPoints.py
     cd $CMSSW_BASE/src
     scramv1 b -j 9

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/createPoints.py
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/createPoints.py
@@ -18,36 +18,59 @@ def findMassValue(fileName, particleName):
 		if particleName in line:
 			return line.split()[1]
 
-baseConfigFile = 'AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_13TeV_pythia8_cff.py'
-baseParticleFile = 'geant4_AMSB_chargino.slha'
+baseConfigFile_wino = 'AMSB_chargino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py'
+baseParticleFile_wino = 'geant4_AMSB_chargino.slha'
+
+baseConfigFile_higgsino = 'Higgsino_M-XXXGeV_CTau-YYYcm_TuneCP5_PSweights_13TeV_pythia8_cff.py'
+baseParticleFile_higgsino = 'geant4_higgsinoAMSB_chargino.slha'
 
 c = 299792458.0 * 100.0 # cm/s
 
-# xsecs[mass in GeV] = xsec (pb)
-xsecs = {
-	100 : 34.282,
-	200 : 2.709959,
-	300 : 0.577095,
-	400 : 0.179644,
-	500 : 0.06848,
-	600 : 0.029636,
-	700 : 0.013949,
-	800 : 0.0069704,
-	900 : 0.00364968,
+ctaus = [1, 10, 100, 1000, 10000] # cm
+
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SUSYCrossSections13TeVn2x1wino
+# plus
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SUSYCrossSections13TeVx1x1wino
+xsecs_wino = { # [mass in GeV] : xsec (pb)
+	100  : 34.282,
+	200  : 2.709959,
+	300  : 0.577095,
+	400  : 0.179644,
+	500  : 0.06848,
+	600  : 0.029636,
+	700  : 0.013949,
+	800  : 0.0069704,
+	900  : 0.00364968,
 	1000 : 0.001965386,
 	1100 : 0.001082998
 }
 
-ctaus = [10, 100, 1000, 10000] # cm
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SUSYCrossSections13TeVn2x1hino (times 2 for degenerate N1/N2)
+# plus
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SUSYCrossSections13TeVx1x1hino
+xsecs_higgsino = { # [mass in GeV] : xsec (pb)
+	100  : 13.53557,
+	200  : 1.092653,
+	300  : 0.2342024,
+	400  : 0.0731865,
+	500  : 0.02798925,
+	600  : 0.0121587,
+	700  : 0.00572751,
+	800  : 0.002878806,
+	900  : 0.001502429
+}
 
-for mass in xsecs:
+if not os.path.exists('test'):
+	os.mkdir('test')
+
+for mass in xsecs_wino:
 	for ctau in ctaus:
-		outputConfigFile = 'test/AMSB_chargino_M-%dGeV_CTau-%dcm_TuneCP5_13TeV_pythia8_cff.py' % (mass, ctau)
+		outputConfigFile = 'test/AMSB_chargino_M-%dGeV_CTau-%dcm_TuneCP5_PSweights_13TeV_pythia8_cff.py' % (mass, ctau)
 		outputParticleFile = 'test/geant4_AMSB_chargino_%dGeV_ctau%dcm.slha' % (mass, ctau)
 
-		os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile + ' > ' + outputConfigFile)
+		os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile_wino + ' > ' + outputConfigFile)
 		os.system('sed -i "s/YYY/' + str(int(ctau * 10.0)) + '/g" ' + outputConfigFile) # mm
-		os.system('sed -i "s/ZZZ/' + str(xsecs[mass]) + '/g" ' + outputConfigFile)
+		os.system('sed -i "s/ZZZ/' + str(xsecs_wino[mass]) + '/g" ' + outputConfigFile)
 		insertSLHA(outputConfigFile, mass)
 
 		mW1ss = findMassValue(outputConfigFile, 'w1ss')
@@ -56,8 +79,32 @@ for mass in xsecs:
 		tau = ctau / c * 1.e9 # ns
 		width = (1.97326979e-14 / ctau) # GeV
 
-		os.system('sed "s/_MW1SS/' + str(mW1ss) + '/g" ' + baseParticleFile + ' > ' + outputParticleFile)
+		os.system('sed "s/_MW1SS/' + str(mW1ss) + '/g" ' + baseParticleFile_wino + ' > ' + outputParticleFile)
 		os.system('sed -i "s/_MZ1SS/' + str(mZ1ss) + '/g" ' + outputParticleFile)
+		os.system('sed -i "s/_CTAU/' + str(ctau) + '/g" ' + outputParticleFile)
+		os.system('sed -i "s/_TAU/' + str(tau) + '/g" ' + outputParticleFile)
+		os.system('sed -i "s/_WIDTH/' + str(width) + '/g" ' + outputParticleFile)
+
+for mass in xsecs_higgsino:
+	for ctau in ctaus:
+		outputConfigFile = 'test/Higgsino_M-%dGeV_CTau-%dcm_TuneCP5_PSweights_13TeV_pythia8_cff.py' % (mass, ctau)
+		outputParticleFile = 'test/geant4_higgsinoAMSB_chargino_%dGeV_ctau%dcm.slha' % (mass, ctau)
+
+		os.system('sed "s/XXX/' + str(mass) + '/g" ' + baseConfigFile_higgsino + ' > ' + outputConfigFile)
+		os.system('sed -i "s/YYY/' + str(int(ctau * 10.0)) + '/g" ' + outputConfigFile) # mm
+		os.system('sed -i "s/ZZZ/' + str(xsecs_higgsino[mass]) + '/g" ' + outputConfigFile)
+		insertSLHA(outputConfigFile, mass)
+
+		mW1ss = findMassValue(outputConfigFile, 'w1ss')
+		mZ1ss = findMassValue(outputConfigFile, 'z1ss')
+		mZ2ss = findMassValue(outputConfigFile, 'z2ss')
+
+		tau = ctau / c * 1.e9 # ns
+		width = (1.97326979e-14 / ctau) # GeV
+
+		os.system('sed "s/_MW1SS/' + str(mW1ss) + '/g" ' + baseParticleFile_higgsino + ' > ' + outputParticleFile)
+		os.system('sed -i "s/_MZ1SS/' + str(mZ1ss) + '/g" ' + outputParticleFile)
+		os.system('sed -i "s/_MZ2SS/' + str(mZ2ss) + '/g" ' + outputParticleFile)
 		os.system('sed -i "s/_CTAU/' + str(ctau) + '/g" ' + outputParticleFile)
 		os.system('sed -i "s/_TAU/' + str(tau) + '/g" ' + outputParticleFile)
 		os.system('sed -i "s/_WIDTH/' + str(width) + '/g" ' + outputParticleFile)

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/geant4_higgsinoAMSB_chargino.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/geant4_higgsinoAMSB_chargino.slha
@@ -1,0 +1,41 @@
+# This file is read by SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+# The strings "decay", "pdg code", and "block", with correct capitalization, are used
+# to control the data input, so do not use these in any comments.
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000022   _MZ1SS   # ~neutralino(1)
+   1000023   _MZ2SS   # ~neutralino(2)
+  -1000023   _MZ2SS   # ~anti_neutralino(2)
+   1000024   _MW1SS   # ~chargino(1)+
+  -1000024   _MW1SS   # ~chargino(1)-
+Block
+
+# Set chargino lifetime
+# and decay:  chargino -> neutralino + pion
+# chargino ctau  = _CTAU cm
+# chargino  tau  = _TAU ns
+# chargino width = _WIDTH GeV
+#       PDG       Width               #
+DECAY  1000024  _WIDTH # +chargino decay
+#   BR       NDA      ID1      ID2
+   0.4775    2     1000022    211
+   0.4775    2     1000023    211
+   0.0150    3     1000022    -11    12
+   0.0150    3     1000023    -11    12
+   0.0075    3     1000022    -13    14
+   0.0075    3     1000023    -13    14
+Block
+
+#       PDG       Width               #
+DECAY  -1000024  _WIDTH # -chargino decay
+#   BR       NDA      ID1      ID2
+   0.4775    2     1000022    -211
+   0.4775    2     1000023    -211
+   0.0150    3     1000022    11    -12
+   0.0150    3     1000023    11    -12
+   0.0075    3     1000022    13    -14
+   0.0075    3     1000023    13    -14
+Block
+
+EOF

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_100GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_100GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27843697E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     3.50800000E+04   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.26820216E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.09165016E+02   #  h^0
+        35     1.69811304E+03   #  H^0
+        36     1.68658362E+03   #  A^0
+        37     1.69844373E+03   #  H^+
+   1000001     1.64875269E+03   #  dnl
+   1000002     1.64692371E+03   #  upl
+   1000003     1.64875269E+03   #  stl
+   1000004     1.64692432E+03   #  chl
+   1000005     1.36096313E+03   #  b1
+   1000006     1.00422571E+03   #  t1
+   1000011     1.49030664E+03   #  el-
+   1000012     1.48858191E+03   #  nuel
+   1000013     1.49030664E+03   #  mul-
+   1000014     1.48858191E+03   #  numl
+   1000015     1.48539880E+03   #  tau1
+   1000016     1.48676428E+03   #  nutl
+   1000021     8.64298706E+02   #  glss
+   1000022     9.98443985E+01   #  z1ss
+   1000023     9.98443985E+01   #  z2ss
+   1000024     1.00032974E+02   #  w1ss
+   1000025    -7.42030518E+02   #  z3ss
+   1000035     7.49072571E+02   #  z4ss
+   1000037     7.49086609E+02   #  w2ss
+   2000001     1.65904858E+03   #  dnr
+   2000002     1.65516052E+03   #  upr
+   2000003     1.65904858E+03   #  str
+   2000004     1.65516113E+03   #  chr
+   2000005     1.65050024E+03   #  b2
+   2000006     1.37387744E+03   #  t2
+   2000011     1.49084143E+03   #  er-
+   2000013     1.49084143E+03   #  mur-
+   2000015     1.48991235E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.98805586E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     6.12325780E-02   # O_{11}
+  1  2    -9.98123527E-01   # O_{12}
+  2  1     9.98123527E-01   # O_{21}
+  2  2     6.12325780E-02   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99970913E-01   # O_{11}
+  1  2     7.62549881E-03   # O_{12}
+  2  1    -7.62549881E-03   # O_{21}
+  2  2     9.99970913E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     5.97260058E-01   # O_{11}
+  1  2     8.02047670E-01   # O_{12}
+  2  1    -8.02047670E-01   # O_{21}
+  2  2     5.97260058E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  1.13725037E+03   #
+     1     3.57492119E-01   # g`
+     2     6.52496159E-01   # g_2
+     3     1.22099471E+00   # g_3
+Block YU Q=  1.13725037E+03   #
+  3  3     8.78648043E-01   # y_t
+Block YD Q=  1.13725037E+03   #
+  3  3     6.93556666E-02   # y_b
+Block YE Q=  1.13725037E+03   #
+  3  3     5.13891652E-02   # y_tau
+Block HMIX Q=  1.13725037E+03   # Higgs mixing parameters
+     1     7.33976440E+02   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51144409E+02   # Higgs vev at Q
+     4     2.84456425E+06   # m_A^2(Q)
+Block MSOFT Q=  1.13725037E+03   # DRbar SUSY breaking parameters
+     1     3.23079498E+02   # M_1(Q)
+     2     9.78689346E+01   # M_2(Q)
+     3    -7.54845886E+02   # M_3(Q)
+    31     1.48517932E+03   # MeL(Q)
+    32     1.48517932E+03   # MmuL(Q)
+    33     1.48340161E+03   # MtauL(Q)
+    34     1.48875891E+03   # MeR(Q)
+    35     1.48875891E+03   # MmuR(Q)
+    36     1.48529724E+03   # MtauR(Q)
+    41     1.61164856E+03   # MqL1(Q)
+    42     1.61164856E+03   # MqL2(Q)
+    43     1.33004492E+03   # MqL3(Q)
+    44     1.61942517E+03   # MuR(Q)
+    45     1.61942517E+03   # McR(Q)
+    46     9.72402039E+02   # MtR(Q)
+    47     1.62276147E+03   # MdR(Q)
+    48     1.62276147E+03   # MsR(Q)
+    49     1.62246484E+03   # MbR(Q)
+Block AU Q=  1.13725037E+03   #
+  1  1     6.08556396E+02   # A_u
+  2  2     6.08556396E+02   # A_c
+  3  3     6.08556396E+02   # A_t
+Block AD Q=  1.13725037E+03   #
+  1  1     1.45460706E+03   # A_d
+  2  2     1.45460706E+03   # A_s
+  3  3     1.45460706E+03   # A_b
+Block AE Q=  1.13725037E+03   #
+  1  1     3.71930389E+02   # A_e
+  2  2     3.71930389E+02   # A_mu
+  3  3     3.71930389E+02   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_200GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_200GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27843697E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     6.89400000E+04   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.26820216E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.11363144E+02   #  h^0
+        35     1.95587000E+03   #  H^0
+        36     1.94270361E+03   #  A^0
+        37     1.95422314E+03   #  H^+
+   1000001     2.01900940E+03   #  dnl
+   1000002     2.01751855E+03   #  upl
+   1000003     2.01900940E+03   #  stl
+   1000004     2.01751904E+03   #  chl
+   1000005     1.71646375E+03   #  b1
+   1000006     1.34441077E+03   #  t1
+   1000011     1.47130884E+03   #  el-
+   1000012     1.46899902E+03   #  nuel
+   1000013     1.47130884E+03   #  mul-
+   1000014     1.46899902E+03   #  numl
+   1000015     1.46202637E+03   #  tau1
+   1000016     1.46698926E+03   #  nutl
+   1000021     1.53593469E+03   #  glss
+   1000022     1.99839157E+02   #  z1ss
+   1000023     1.99839157E+02   #  z2ss
+   1000024     2.00013046E+02   #  w1ss
+   1000025    -1.22576782E+03   #  z3ss
+   1000035     1.23021887E+03   #  z4ss
+   1000037     1.23092566E+03   #  w2ss
+   2000001     2.03759778E+03   #  dnr
+   2000002     2.02848047E+03   #  upr
+   2000003     2.03759778E+03   #  str
+   2000004     2.02848083E+03   #  chr
+   2000005     2.02415881E+03   #  b2
+   2000006     1.73585388E+03   #  t2
+   2000011     1.46771460E+03   #  er-
+   2000013     1.46771460E+03   #  mur-
+   2000015     1.47096094E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.98512524E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     1.05499819E-01   # O_{11}
+  1  2    -9.94419336E-01   # O_{12}
+  2  1     9.94419336E-01   # O_{21}
+  2  2     1.05499819E-01   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99964714E-01   # O_{11}
+  1  2     8.40252452E-03   # O_{12}
+  2  1    -8.40252452E-03   # O_{21}
+  2  2     9.99964714E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     4.30086315E-01   # O_{11}
+  1  2     9.02787745E-01   # O_{12}
+  2  1    -9.02787745E-01   # O_{21}
+  2  2     4.30086315E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  1.46022791E+03   #
+     1     3.57492119E-01   # g`
+     2     6.52496159E-01   # g_2
+     3     1.22099471E+00   # g_3
+Block YU Q=  1.46022791E+03   #
+  3  3     8.65803540E-01   # y_t
+Block YD Q=  1.46022791E+03   #
+  3  3     6.84231147E-02   # y_b
+Block YE Q=  1.46022791E+03   #
+  3  3     5.14152572E-02   # y_tau
+Block HMIX Q=  1.46022791E+03   # Higgs mixing parameters
+     1     1.21942151E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51206696E+02   # Higgs vev at Q
+     4     3.77409725E+06   # m_A^2(Q)
+Block MSOFT Q=  1.46022791E+03   # DRbar SUSY breaking parameters
+     1     6.36427734E+02   # M_1(Q)
+     2     1.90158478E+02   # M_2(Q)
+     3    -1.39936938E+03   # M_3(Q)
+    31     1.46589587E+03   # MeL(Q)
+    32     1.46589587E+03   # MmuL(Q)
+    33     1.46393054E+03   # MtauL(Q)
+    34     1.46522168E+03   # MeR(Q)
+    35     1.46522168E+03   # MmuR(Q)
+    36     1.46127014E+03   # MtauR(Q)
+    41     1.94845117E+03   # MqL1(Q)
+    42     1.94845117E+03   # MqL2(Q)
+    43     1.65248535E+03   # MqL3(Q)
+    44     1.95919067E+03   # MuR(Q)
+    45     1.95919067E+03   # McR(Q)
+    46     1.29033850E+03   # MtR(Q)
+    47     1.96798145E+03   # MdR(Q)
+    48     1.96798145E+03   # MsR(Q)
+    49     1.97202722E+03   # MbR(Q)
+Block AU Q=  1.46022791E+03   #
+  1  1     1.16652148E+03   # A_u
+  2  2     1.16652148E+03   # A_c
+  3  3     1.16652148E+03   # A_t
+Block AD Q=  1.46022791E+03   #
+  1  1     2.77925708E+03   # A_d
+  2  2     2.77925708E+03   # A_s
+  3  3     2.77925708E+03   # A_b
+Block AE Q=  1.46022791E+03   #
+  1  1     7.27510864E+02   # A_e
+  2  2     7.27510864E+02   # A_mu
+  3  3     7.27510864E+02   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_300GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_300GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27843719E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     1.03650000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.21940317E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.13281731E+02   #  h^0
+        35     2.31703979E+03   #  H^0
+        36     2.30156934E+03   #  A^0
+        37     2.31312744E+03   #  H^+
+   1000001     2.49383179E+03   #  dnl
+   1000002     2.49261523E+03   #  upl
+   1000003     2.49383179E+03   #  stl
+   1000004     2.49261548E+03   #  chl
+   1000005     2.15123779E+03   #  b1
+   1000006     1.73482275E+03   #  t1
+   1000011     1.43890710E+03   #  el-
+   1000012     1.43549438E+03   #  nuel
+   1000013     1.43890710E+03   #  mul-
+   1000014     1.43549438E+03   #  numl
+   1000015     1.42184009E+03   #  tau1
+   1000016     1.43293103E+03   #  nutl
+   1000021     2.18962207E+03   #  glss
+   1000022     2.99864838E+02   #  z1ss
+   1000023     2.99864838E+02   #  z2ss
+   1000024     3.00037323E+02   #  w1ss
+   1000025    -1.74983081E+03   #  z3ss
+   1000035     1.75280737E+03   #  z4ss
+   1000037     1.75418726E+03   #  w2ss
+   2000001     2.52172412E+03   #  dnr
+   2000002     2.50711743E+03   #  upr
+   2000003     2.52172412E+03   #  str
+   2000004     2.50711792E+03   #  chr
+   2000005     2.50527832E+03   #  b2
+   2000006     2.17448901E+03   #  t2
+   2000011     1.42790625E+03   #  er-
+   2000013     1.42790625E+03   #  mur-
+   2000015     1.43795154E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.98217750E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     1.15278468E-01   # O_{11}
+  1  2    -9.93333220E-01   # O_{12}
+  2  1     9.93333220E-01   # O_{21}
+  2  2     1.15278468E-01   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99966919E-01   # O_{11}
+  1  2     8.13260302E-03   # O_{12}
+  2  1    -8.13260302E-03   # O_{21}
+  2  2     9.99966919E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     3.27634096E-01   # O_{11}
+  1  2     9.44804668E-01   # O_{12}
+  2  1    -9.44804668E-01   # O_{21}
+  2  2     3.27634096E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  1.85234131E+03   #
+     1     3.57492119E-01   # g`
+     2     6.52495980E-01   # g_2
+     3     1.22099257E+00   # g_3
+Block YU Q=  1.85234131E+03   #
+  3  3     8.58246148E-01   # y_t
+Block YD Q=  1.85234131E+03   #
+  3  3     6.76042885E-02   # y_b
+Block YE Q=  1.85234131E+03   #
+  3  3     5.14520593E-02   # y_tau
+Block HMIX Q=  1.85234131E+03   # Higgs mixing parameters
+     1     1.74554053E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51296097E+02   # Higgs vev at Q
+     4     5.29722150E+06   # m_A^2(Q)
+Block MSOFT Q=  1.85234131E+03   # DRbar SUSY breaking parameters
+     1     9.59482605E+02   # M_1(Q)
+     2     2.83875336E+02   # M_2(Q)
+     3    -2.03255798E+03   # M_3(Q)
+    31     1.43290662E+03   # MeL(Q)
+    32     1.43290662E+03   # MmuL(Q)
+    33     1.43040063E+03   # MtauL(Q)
+    34     1.42463135E+03   # MeR(Q)
+    35     1.42463135E+03   # MmuR(Q)
+    36     1.41936206E+03   # MtauR(Q)
+    41     2.38789746E+03   # MqL1(Q)
+    42     2.38789746E+03   # MqL2(Q)
+    43     2.05947778E+03   # MqL3(Q)
+    44     2.40229883E+03   # MuR(Q)
+    45     2.40229883E+03   # McR(Q)
+    46     1.66603821E+03   # MtR(Q)
+    47     2.41674878E+03   # MdR(Q)
+    48     2.41674878E+03   # MsR(Q)
+    49     2.42613452E+03   # MbR(Q)
+Block AU Q=  1.85234131E+03   #
+  1  1     1.71933716E+03   # A_u
+  2  2     1.71933716E+03   # A_c
+  3  3     1.71933716E+03   # A_t
+Block AD Q=  1.85234131E+03   #
+  1  1     4.09207031E+03   # A_d
+  2  2     4.09207031E+03   # A_s
+  3  3     4.09207031E+03   # A_b
+Block AE Q=  1.85234131E+03   #
+  1  1     1.09036902E+03   # A_e
+  2  2     1.09036902E+03   # A_mu
+  3  3     1.09036902E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_400GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_400GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27836258E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     1.38900000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.17248989E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.14519646E+02   #  h^0
+        35     2.73490747E+03   #  H^0
+        36     2.71675513E+03   #  A^0
+        37     2.72878003E+03   #  H^+
+   1000001     3.01710205E+03   #  dnl
+   1000002     3.01608276E+03   #  upl
+   1000003     3.01710205E+03   #  stl
+   1000004     3.01608325E+03   #  chl
+   1000005     2.61766577E+03   #  b1
+   1000006     2.14433862E+03   #  t1
+   1000011     1.39210693E+03   #  el-
+   1000012     1.38680359E+03   #  nuel
+   1000013     1.39210693E+03   #  mul-
+   1000014     1.38680359E+03   #  numl
+   1000015     1.36285266E+03   #  tau1
+   1000016     1.38311682E+03   #  nutl
+   1000021     2.83484521E+03   #  glss
+   1000022     3.99869446E+02   #  z1ss
+   1000023     3.99869446E+02   #  z2ss
+   1000024     4.00042084E+02   #  w1ss
+   1000025    -2.27931201E+03   #  z3ss
+   1000035     2.28139746E+03   #  z4ss
+   1000037     2.28401465E+03   #  w2ss
+   2000001     3.05592041E+03   #  dnr
+   2000002     3.03452344E+03   #  upr
+   2000003     3.05592041E+03   #  str
+   2000004     3.03452393E+03   #  chr
+   2000005     3.03357007E+03   #  b2
+   2000006     2.64484961E+03   #  t2
+   2000011     1.36942285E+03   #  er-
+   2000013     1.36942285E+03   #  mur-
+   2000015     1.38940100E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97996110E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     1.10778496E-01   # O_{11}
+  1  2    -9.93845105E-01   # O_{12}
+  2  1     9.93845105E-01   # O_{21}
+  2  2     1.10778496E-01   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99971330E-01   # O_{11}
+  1  2     7.57318595E-03   # O_{12}
+  2  1    -7.57318595E-03   # O_{21}
+  2  2     9.99971330E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     2.59617299E-01   # O_{11}
+  1  2     9.65711594E-01   # O_{12}
+  2  1    -9.65711594E-01   # O_{21}
+  2  2     2.59617299E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  2.27118091E+03   #
+     1     3.57524991E-01   # g`
+     2     6.52378619E-01   # g_2
+     3     1.21928012E+00   # g_3
+Block YU Q=  2.27118091E+03   #
+  3  3     8.51342678E-01   # y_t
+Block YD Q=  2.27118091E+03   #
+  3  3     6.68446645E-02   # y_b
+Block YE Q=  2.27118091E+03   #
+  3  3     5.15245311E-02   # y_tau
+Block HMIX Q=  2.27118091E+03   # Higgs mixing parameters
+     1     2.27753613E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51399094E+02   # Higgs vev at Q
+     4     7.38075850E+06   # m_A^2(Q)
+Block MSOFT Q=  2.27118091E+03   # DRbar SUSY breaking parameters
+     1     1.28960913E+03   # M_1(Q)
+     2     3.78281647E+02   # M_2(Q)
+     3    -2.65677417E+03   # M_3(Q)
+    31     1.38500964E+03   # MeL(Q)
+    32     1.38500964E+03   # MmuL(Q)
+    33     1.38140698E+03   # MtauL(Q)
+    34     1.36513391E+03   # MeR(Q)
+    35     1.36513391E+03   # MmuR(Q)
+    36     1.35705725E+03   # MtauR(Q)
+    41     2.87804614E+03   # MqL1(Q)
+    42     2.87804614E+03   # MqL2(Q)
+    43     2.50271753E+03   # MqL3(Q)
+    44     2.89632764E+03   # MuR(Q)
+    45     2.89632764E+03   # McR(Q)
+    46     2.06106445E+03   # MtR(Q)
+    47     2.91756348E+03   # MdR(Q)
+    48     2.91756348E+03   # MsR(Q)
+    49     2.92883350E+03   # MbR(Q)
+Block AU Q=  2.27118091E+03   #
+  1  1     2.26492847E+03   # A_u
+  2  2     2.26492847E+03   # A_c
+  3  3     2.26492847E+03   # A_t
+Block AD Q=  2.27118091E+03   #
+  1  1     5.38747949E+03   # A_d
+  2  2     5.38747949E+03   # A_s
+  3  3     5.38747949E+03   # A_b
+Block AE Q=  2.27118091E+03   #
+  1  1     1.45806897E+03   # A_e
+  2  2     1.45806897E+03   # A_mu
+  3  3     1.45806897E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_500GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_500GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27836266E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     1.74430000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.12737372E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.15511902E+02   #  h^0
+        35     3.18671997E+03   #  H^0
+        36     3.16565356E+03   #  A^0
+        37     3.17845288E+03   #  H^+
+   1000001     3.56121729E+03   #  dnl
+   1000002     3.56034009E+03   #  upl
+   1000003     3.56121729E+03   #  stl
+   1000004     3.56034033E+03   #  chl
+   1000005     3.10211743E+03   #  b1
+   1000006     2.56294897E+03   #  t1
+   1000011     1.32959814E+03   #  el-
+   1000012     1.32121753E+03   #  nuel
+   1000013     1.32959814E+03   #  mul-
+   1000014     1.32121753E+03   #  numl
+   1000015     1.28115686E+03   #  tau1
+   1000016     1.31567761E+03   #  nutl
+   1000021     3.47622827E+03   #  glss
+   1000022     4.99829254E+02   #  z1ss
+   1000023     4.99829254E+02   #  z2ss
+   1000024     5.00002502E+02   #  w1ss
+   1000025    -2.81133667E+03   #  z3ss
+   1000035     2.81305249E+03   #  z4ss
+   1000037     2.81642407E+03   #  w2ss
+   2000001     3.61366235E+03   #  dnr
+   2000002     3.58297388E+03   #  upr
+   2000003     3.61366235E+03   #  str
+   2000004     3.58297412E+03   #  chr
+   2000005     3.58649536E+03   #  b2
+   2000006     3.13307568E+03   #  t2
+   2000011     1.28796350E+03   #  er-
+   2000013     1.28796350E+03   #  mur-
+   2000015     1.32356653E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97843567E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     1.02065332E-01   # O_{11}
+  1  2    -9.94777679E-01   # O_{12}
+  2  1     9.94777679E-01   # O_{21}
+  2  2     1.02065332E-01   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99975383E-01   # O_{11}
+  1  2     7.02077523E-03   # O_{12}
+  2  1    -7.02077523E-03   # O_{21}
+  2  2     9.99975383E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     2.05478176E-01   # O_{11}
+  1  2     9.78661716E-01   # O_{12}
+  2  1    -9.78661716E-01   # O_{21}
+  2  2     2.05478176E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  2.70318530E+03   #
+     1     3.57524961E-01   # g`
+     2     6.52378559E-01   # g_2
+     3     1.21927977E+00   # g_3
+Block YU Q=  2.70318530E+03   #
+  3  3     8.46211851E-01   # y_t
+Block YD Q=  2.70318530E+03   #
+  3  3     6.63219020E-02   # y_b
+Block YE Q=  2.70318530E+03   #
+  3  3     5.15569262E-02   # y_tau
+Block HMIX Q=  2.70318530E+03   # Higgs mixing parameters
+     1     2.81156128E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51505371E+02   # Higgs vev at Q
+     4     1.00213620E+07   # m_A^2(Q)
+Block MSOFT Q=  2.70318530E+03   # DRbar SUSY breaking parameters
+     1     1.62324744E+03   # M_1(Q)
+     2     4.73120422E+02   # M_2(Q)
+     3    -3.27709692E+03   # M_3(Q)
+    31     1.32059900E+03   # MeL(Q)
+    32     1.32059900E+03   # MmuL(Q)
+    33     1.31518896E+03   # MtauL(Q)
+    34     1.28408386E+03   # MeR(Q)
+    35     1.28408386E+03   # MmuR(Q)
+    36     1.27127039E+03   # MtauR(Q)
+    41     3.39131226E+03   # MqL1(Q)
+    42     3.39131226E+03   # MqL2(Q)
+    43     2.96472168E+03   # MqL3(Q)
+    44     3.41352490E+03   # MuR(Q)
+    45     3.41352490E+03   # McR(Q)
+    46     2.46472070E+03   # MtR(Q)
+    47     3.44374805E+03   # MdR(Q)
+    48     3.44374805E+03   # MsR(Q)
+    49     3.45781030E+03   # MbR(Q)
+Block AU Q=  2.70318530E+03   #
+  1  1     2.80809619E+03   # A_u
+  2  2     2.80809619E+03   # A_c
+  3  3     2.80809619E+03   # A_t
+Block AD Q=  2.70318530E+03   #
+  1  1     6.67355664E+03   # A_d
+  2  2     6.67355664E+03   # A_s
+  3  3     6.67355664E+03   # A_b
+Block AE Q=  2.70318530E+03   #
+  1  1     1.82787415E+03   # A_e
+  2  2     1.82787415E+03   # A_mu
+  3  3     1.82787415E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_600GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_600GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27836258E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     2.10300000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.08399992E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.16262634E+02   #  h^0
+        35     3.65780957E+03   #  H^0
+        36     3.63369482E+03   #  A^0
+        37     3.64751147E+03   #  H^+
+   1000001     4.12058105E+03   #  dnl
+   1000002     4.11981787E+03   #  upl
+   1000003     4.12058105E+03   #  stl
+   1000004     4.11981787E+03   #  chl
+   1000005     3.59533765E+03   #  b1
+   1000006     2.98517871E+03   #  t1
+   1000011     1.24901599E+03   #  el-
+   1000012     1.23573743E+03   #  nuel
+   1000013     1.24901599E+03   #  mul-
+   1000014     1.23573743E+03   #  numl
+   1000015     1.17080225E+03   #  tau1
+   1000016     1.22719019E+03   #  nutl
+   1000021     4.10994922E+03   #  glss
+   1000022     5.99874023E+02   #  z1ss
+   1000023     5.99874023E+02   #  z2ss
+   1000024     6.00047424E+02   #  w1ss
+   1000025    -3.34248657E+03   #  z3ss
+   1000035     3.34395361E+03   #  z4ss
+   1000037     3.34808301E+03   #  w2ss
+   2000001     4.18315088E+03   #  dnr
+   2000002     4.14656396E+03   #  upr
+   2000003     4.18315088E+03   #  str
+   2000004     4.14656445E+03   #  chr
+   2000005     4.15172412E+03   #  b2
+   2000006     3.63008374E+03   #  t2
+   2000011     1.17744092E+03   #  er-
+   2000013     1.17744092E+03   #  mur-
+   2000015     1.23730310E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97738439E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     9.25537199E-02   # O_{11}
+  1  2    -9.95707691E-01   # O_{12}
+  2  1     9.95707691E-01   # O_{21}
+  2  2     9.25537199E-02   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99980092E-01   # O_{11}
+  1  2     6.31465809E-03   # O_{12}
+  2  1    -6.31465809E-03   # O_{21}
+  2  2     9.99980092E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     1.63745880E-01   # O_{11}
+  1  2     9.86502528E-01   # O_{12}
+  2  1    -9.86502528E-01   # O_{21}
+  2  2     1.63745880E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  3.14105103E+03   #
+     1     3.57524991E-01   # g`
+     2     6.52378619E-01   # g_2
+     3     1.21927989E+00   # g_3
+Block YU Q=  3.14105103E+03   #
+  3  3     8.41931880E-01   # y_t
+Block YD Q=  3.14105103E+03   #
+  3  3     6.57430291E-02   # y_b
+Block YE Q=  3.14105103E+03   #
+  3  3     5.15759252E-02   # y_tau
+Block HMIX Q=  3.14105103E+03   # Higgs mixing parameters
+     1     3.34447510E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51609634E+02   # Higgs vev at Q
+     4     1.32037380E+07   # m_A^2(Q)
+Block MSOFT Q=  3.14105103E+03   # DRbar SUSY breaking parameters
+     1     1.96140686E+03   # M_1(Q)
+     2     5.68461975E+02   # M_2(Q)
+     3    -3.88895142E+03   # M_3(Q)
+    31     1.23681946E+03   # MeL(Q)
+    32     1.23681946E+03   # MmuL(Q)
+    33     1.22848254E+03   # MtauL(Q)
+    34     1.17675854E+03   # MeR(Q)
+    35     1.17675854E+03   # MmuR(Q)
+    36     1.15583582E+03   # MtauR(Q)
+    41     3.92100171E+03   # MqL1(Q)
+    42     3.92100171E+03   # MqL2(Q)
+    43     3.43584668E+03   # MqL3(Q)
+    44     3.94716504E+03   # MuR(Q)
+    45     3.94716504E+03   # McR(Q)
+    46     2.87154858E+03   # MtR(Q)
+    47     3.98305713E+03   # MdR(Q)
+    48     3.98305713E+03   # MsR(Q)
+    49     4.00040381E+03   # MbR(Q)
+Block AU Q=  3.14105103E+03   #
+  1  1     3.34236670E+03   # A_u
+  2  2     3.34236670E+03   # A_c
+  3  3     3.34236670E+03   # A_t
+Block AD Q=  3.14105103E+03   #
+  1  1     7.95083057E+03   # A_d
+  2  2     7.95083057E+03   # A_s
+  3  3     7.95083057E+03   # A_b
+Block AE Q=  3.14105103E+03   #
+  1  1     2.20090503E+03   # A_e
+  2  2     2.20090503E+03   # A_mu
+  3  3     2.20090503E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_700GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_700GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27842453E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     2.46440000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.04228903E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.16918777E+02   #  h^0
+        35     4.13995459E+03   #  H^0
+        36     4.11271240E+03   #  A^0
+        37     4.12772119E+03   #  H^+
+   1000001     4.68634814E+03   #  dnl
+   1000002     4.68567432E+03   #  upl
+   1000003     4.68634814E+03   #  stl
+   1000004     4.68567480E+03   #  chl
+   1000005     4.09400562E+03   #  b1
+   1000006     3.40991528E+03   #  t1
+   1000011     1.14678894E+03   #  el-
+   1000012     1.12562231E+03   #  nuel
+   1000013     1.14678894E+03   #  mul-
+   1000014     1.12562231E+03   #  numl
+   1000015     1.02227649E+03   #  tau1
+   1000016     1.11225781E+03   #  nutl
+   1000021     4.74673096E+03   #  glss
+   1000022     6.99874146E+02   #  z1ss
+   1000023     6.99874146E+02   #  z2ss
+   1000024     7.00047607E+02   #  w1ss
+   1000025    -3.87153369E+03   #  z3ss
+   1000035     3.87282349E+03   #  z4ss
+   1000037     3.87772314E+03   #  w2ss
+   2000001     4.76078076E+03   #  dnr
+   2000002     4.71648975E+03   #  upr
+   2000003     4.76078076E+03   #  str
+   2000004     4.71649023E+03   #  chr
+   2000005     4.72474414E+03   #  b2
+   2000006     4.13260303E+03   #  t2
+   2000011     1.02800623E+03   #  er-
+   2000013     1.02800623E+03   #  mur-
+   2000015     1.12574829E+03   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97664991E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     8.36024433E-02   # O_{11}
+  1  2    -9.96499181E-01   # O_{12}
+  2  1     9.96499181E-01   # O_{21}
+  2  2     8.36024433E-02   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99983907E-01   # O_{11}
+  1  2     5.66892792E-03   # O_{12}
+  2  1    -5.66892792E-03   # O_{21}
+  2  2     9.99983907E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     1.32659495E-01   # O_{11}
+  1  2     9.91161644E-01   # O_{12}
+  2  1    -9.91161644E-01   # O_{21}
+  2  2     1.32659495E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  3.58269727E+03   #
+     1     3.57497722E-01   # g`
+     2     6.52475953E-01   # g_2
+     3     1.22070026E+00   # g_3
+Block YU Q=  3.58269727E+03   #
+  3  3     8.38887691E-01   # y_t
+Block YD Q=  3.58269727E+03   #
+  3  3     6.52210116E-02   # y_b
+Block YE Q=  3.58269727E+03   #
+  3  3     5.15824445E-02   # y_tau
+Block HMIX Q=  3.58269727E+03   # Higgs mixing parameters
+     1     3.87514209E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51709106E+02   # Higgs vev at Q
+     4     1.69144040E+07   # m_A^2(Q)
+Block MSOFT Q=  3.58269727E+03   # DRbar SUSY breaking parameters
+     1     2.30335156E+03   # M_1(Q)
+     2     6.64254944E+02   # M_2(Q)
+     3    -4.50376855E+03   # M_3(Q)
+    31     1.12926123E+03   # MeL(Q)
+    32     1.12926123E+03   # MmuL(Q)
+    33     1.11625525E+03   # MtauL(Q)
+    34     1.03541077E+03   # MeR(Q)
+    35     1.03541077E+03   # MmuR(Q)
+    36     9.99967957E+02   # MtauR(Q)
+    41     4.45722266E+03   # MqL1(Q)
+    42     4.45722266E+03   # MqL2(Q)
+    43     3.91252832E+03   # MqL3(Q)
+    44     4.48730469E+03   # MuR(Q)
+    45     4.48730469E+03   # McR(Q)
+    46     3.28067163E+03   # MtR(Q)
+    47     4.53066406E+03   # MdR(Q)
+    48     4.53066406E+03   # MsR(Q)
+    49     4.55108252E+03   # MbR(Q)
+Block AU Q=  3.58269727E+03   #
+  1  1     3.86256177E+03   # A_u
+  2  2     3.86256177E+03   # A_c
+  3  3     3.86256177E+03   # A_t
+Block AD Q=  3.58269727E+03   #
+  1  1     9.22079785E+03   # A_d
+  2  2     9.22079785E+03   # A_s
+  3  3     9.22079785E+03   # A_b
+Block AE Q=  3.58269727E+03   #
+  1  1     2.57661255E+03   # A_e
+  2  2     2.57661255E+03   # A_mu
+  3  3     2.57661255E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_800GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_800GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27836266E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     2.82870000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     1.00218262E+16   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.17473404E+02   #  h^0
+        35     4.63466455E+03   #  H^0
+        36     4.60420850E+03   #  A^0
+        37     4.62050830E+03   #  H^+
+   1000001     5.26110645E+03   #  dnl
+   1000002     5.26050488E+03   #  upl
+   1000003     5.26110645E+03   #  stl
+   1000004     5.26050488E+03   #  chl
+   1000005     4.59925488E+03   #  b1
+   1000006     3.83768652E+03   #  t1
+   1000011     1.01695599E+03   #  el-
+   1000012     9.82228577E+02   #  nuel
+   1000013     1.01695599E+03   #  mul-
+   1000014     9.82228577E+02   #  numl
+   1000015     8.14143616E+02   #  tau1
+   1000016     9.60563965E+02   #  nutl
+   1000021     5.37773779E+03   #  glss
+   1000022     7.99861450E+02   #  z1ss
+   1000023     7.99861450E+02   #  z2ss
+   1000024     8.00035156E+02   #  w1ss
+   1000025    -4.40436084E+03   #  z3ss
+   1000035     4.40551318E+03   #  z4ss
+   1000037     4.41120557E+03   #  w2ss
+   2000001     5.34743115E+03   #  dnr
+   2000002     5.29265430E+03   #  upr
+   2000003     5.34743115E+03   #  str
+   2000004     5.29265430E+03   #  chr
+   2000005     5.30680615E+03   #  b2
+   2000006     4.64177100E+03   #  t2
+   2000011     8.16208069E+02   #  er-
+   2000013     8.16208069E+02   #  mur-
+   2000015     9.79908020E+02   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97611898E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     7.59116933E-02   # O_{11}
+  1  2    -9.97114539E-01   # O_{12}
+  2  1     9.97114539E-01   # O_{21}
+  2  2     7.59116933E-02   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99985218E-01   # O_{11}
+  1  2     5.43311611E-03   # O_{12}
+  2  1    -5.43311611E-03   # O_{21}
+  2  2     9.99985218E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     1.09243631E-01   # O_{11}
+  1  2     9.94014978E-01   # O_{12}
+  2  1    -9.94014978E-01   # O_{21}
+  2  2     1.09243631E-01   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  4.02882178E+03   #
+     1     3.57524961E-01   # g`
+     2     6.52378559E-01   # g_2
+     3     1.21928000E+00   # g_3
+Block YU Q=  4.02882178E+03   #
+  3  3     8.36005747E-01   # y_t
+Block YD Q=  4.02882178E+03   #
+  3  3     6.48209378E-02   # y_b
+Block YE Q=  4.02882178E+03   #
+  3  3     5.15556112E-02   # y_tau
+Block HMIX Q=  4.02882178E+03   # Higgs mixing parameters
+     1     4.40950830E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51802856E+02   # Higgs vev at Q
+     4     2.11987360E+07   # m_A^2(Q)
+Block MSOFT Q=  4.02882178E+03   # DRbar SUSY breaking parameters
+     1     2.64877222E+03   # M_1(Q)
+     2     7.60767517E+02   # M_2(Q)
+     3    -5.11175781E+03   # M_3(Q)
+    31     9.90100281E+02   # MeL(Q)
+    32     9.90100281E+02   # MmuL(Q)
+    33     9.69131042E+02   # MtauL(Q)
+    34     8.43792542E+02   # MeR(Q)
+    35     8.43792542E+02   # MmuR(Q)
+    36     7.78837646E+02   # MtauR(Q)
+    41     5.00258447E+03   # MqL1(Q)
+    42     5.00258447E+03   # MqL2(Q)
+    43     4.39563135E+03   # MqL3(Q)
+    44     5.03392529E+03   # MuR(Q)
+    45     5.03392529E+03   # McR(Q)
+    46     3.69262158E+03   # MtR(Q)
+    47     5.08750146E+03   # MdR(Q)
+    48     5.08750146E+03   # MsR(Q)
+    49     5.11095166E+03   # MbR(Q)
+Block AU Q=  4.02882178E+03   #
+  1  1     4.39446729E+03   # A_u
+  2  2     4.39446729E+03   # A_c
+  3  3     4.39446729E+03   # A_t
+Block AD Q=  4.02882178E+03   #
+  1  1     1.04963750E+04   # A_d
+  2  2     1.04963750E+04   # A_s
+  3  3     1.04963750E+04   # A_b
+Block AE Q=  4.02882178E+03   #
+  1  1     2.95507666E+03   # A_e
+  2  2     2.95507666E+03   # A_mu
+  3  3     2.95507666E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#

--- a/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_900GeV_Isajet780.slha
+++ b/genfragments/ThirteenTeV/DisappTrksAMSB/slha/Higgsino_900GeV_Isajet780.slha
@@ -1,0 +1,158 @@
+#  ISAJET SUSY parameters in SUSY Les Houches Accord 2 format
+#  Created by ISALHA 2.0 Last revision: C. Balazs 21 Apr 2009
+Block SPINFO   # Program information
+     1   ISASUGRA from ISAJET          # Spectrum Calculator
+     2   7.80   29-OCT-2009 12:50:36   # Version number
+Block MODSEL   # Model selection
+     1     3   # Minimal anomaly mediated (AMSB) model
+Block SMINPUTS   # Standard Model inputs
+     1     1.27836258E+02   # alpha_em^(-1)
+     2     1.16570000E-05   # G_Fermi
+     3     1.17200002E-01   # alpha_s(M_Z)
+     4     9.11699982E+01   # m_{Z}(pole)
+     5     4.19999981E+00   # m_{b}(m_{b})
+     6     1.73070007E+02   # m_{top}(pole)
+     7     1.77699995E+00   # m_{tau}(pole)
+Block MINPAR   # SUSY breaking input parameters
+     1     1.50000000E+03   # m_0
+     2     3.20160000E+05   # m_{3/2}
+     3     5.00000000E+00   # tan(beta)
+     4     1.00000000E+00   # sign(mu)
+Block EXTPAR   # Non-universal SUSY breaking parameters
+     0     9.63624875E+15   # Input scale
+Block MASS   # Scalar and gaugino mass spectrum
+#  PDG code   mass                 particle
+        24     8.04229965E+01   #  W^+
+        25     1.17885536E+02   #  h^0
+        35     5.14209375E+03   #  H^0
+        36     5.10833789E+03   #  A^0
+        37     5.12604248E+03   #  H^+
+   1000001     5.84499561E+03   #  dnl
+   1000002     5.84445264E+03   #  upl
+   1000003     5.84499561E+03   #  stl
+   1000004     5.84445264E+03   #  chl
+   1000005     5.11084131E+03   #  b1
+   1000006     4.26797754E+03   #  t1
+   1000011     8.44497009E+02   #  el-
+   1000012     7.82294617E+02   #  nuel
+   1000013     8.44497009E+02   #  mul-
+   1000014     7.82294617E+02   #  numl
+   1000015     4.59390961E+02   #  tau1
+   1000016     7.43124634E+02   #  nutl
+   1000021     6.02264111E+03   #  glss
+   1000022     8.99857849E+02   #  z1ss
+   1000023     8.99857849E+02   #  z2ss
+   1000024     9.00032288E+02   #  w1ss
+   1000025    -4.94443994E+03   #  z3ss
+   1000035     4.94548633E+03   #  z4ss
+   1000037     4.95200684E+03   #  w2ss
+   2000001     5.94409229E+03   #  dnr
+   2000002     5.88074072E+03   #  upr
+   2000003     5.94409229E+03   #  str
+   2000004     5.88074072E+03   #  chr
+   2000005     5.89824365E+03   #  b2
+   2000006     5.15734326E+03   #  t2
+   2000011     4.41901886E+02   #  er-
+   2000013     4.41901886E+02   #  mur-
+   2000015     7.75092834E+02   #  tau2
+Block ALPHA   # Effective Higgs mixing parameter
+         -1.97571859E-01   # alpha
+Block STOPMIX   # stop mixing matrix
+  1  1     6.91948459E-02   # O_{11}
+  1  2    -9.97603178E-01   # O_{12}
+  2  1     9.97603178E-01   # O_{21}
+  2  2     6.91948459E-02   # O_{22}
+Block SBOTMIX   # sbottom mixing matrix
+  1  1     9.99987841E-01   # O_{11}
+  1  2     4.92899446E-03   # O_{12}
+  2  1    -4.92899446E-03   # O_{21}
+  2  2     9.99987841E-01   # O_{22}
+Block STAUMIX   # stau mixing matrix
+  1  1     9.16852951E-02   # O_{11}
+  1  2     9.95788038E-01   # O_{12}
+  2  1    -9.95788038E-01   # O_{21}
+  2  2     9.16852951E-02   # O_{22}
+Block NMIX   # neutralino mixing matrix
+  1  1     0.00000000E+00   #
+  1  2     0.00000000E+00   #
+  1  3     0.70710678E+00   #
+  1  4     0.70710678E+00   #
+  2  1     0.00000000E+00   #
+  2  2     0.00000000E+00   #
+  2  3     0.70710678E+00   #
+  2  4    -0.70710678E+00   #
+  3  1     0.70710678E+00   #
+  3  2     0.70710678E+00   #
+  3  3     0.00000000E+00   #
+  3  4     0.00000000E+00   #
+  4  1     0.70710678E+00   #
+  4  2    -0.70710678E+00   #
+  4  3     0.00000000E+00   #
+  4  4     0.00000000E+00   #
+Block UMIX   # chargino U mixing matrix
+  1  1     0.00000000E+00   # U_{11}
+  1  2     1.00000000E+00   # U_{12}
+  2  1     1.00000000E+00   # U_{21}
+  2  2     0.00000000E+00   # U_{22}
+Block VMIX   # chargino V mixing matrix
+  1  1     0.00000000E+00   # V_{11}
+  1  2     1.00000000E+00   # V_{12}
+  2  1     1.00000000E+00   # V_{21}
+  2  2     0.00000000E+00   # V_{22}
+Block GAUGE Q=  4.47923682E+03   #
+     1     3.57524991E-01   # g`
+     2     6.52378619E-01   # g_2
+     3     1.21928000E+00   # g_3
+Block YU Q=  4.47923682E+03   #
+  3  3     8.32892656E-01   # y_t
+Block YD Q=  4.47923682E+03   #
+  3  3     6.45801947E-02   # y_b
+Block YE Q=  4.47923682E+03   #
+  3  3     5.14558963E-02   # y_tau
+Block HMIX Q=  4.47923682E+03   # Higgs mixing parameters
+     1     4.95111182E+03   # mu(Q)
+     2     5.00000000E+00   # tan(beta)(M_GUT)
+     3     2.51892105E+02   # Higgs vev at Q
+     4     2.60951160E+07   # m_A^2(Q)
+Block MSOFT Q=  4.47923682E+03   # DRbar SUSY breaking parameters
+     1     3.00553760E+03   # M_1(Q)
+     2     8.59459534E+02   # M_2(Q)
+     3    -5.73397852E+03   # M_3(Q)
+    31     7.99010315E+02   # MeL(Q)
+    32     7.99010315E+02   # MmuL(Q)
+    33     7.61961365E+02   # MtauL(Q)
+    34     5.51579651E+02   # MeR(Q)
+    35     5.51579651E+02   # MmuR(Q)
+    36     3.78081726E+02   # MtauR(Q)
+    41     5.55658252E+03   # MqL1(Q)
+    42     5.55658252E+03   # MqL2(Q)
+    43     4.88496289E+03   # MqL3(Q)
+    44     5.59192773E+03   # MuR(Q)
+    45     5.59192773E+03   # McR(Q)
+    46     4.10720898E+03   # MtR(Q)
+    47     5.65382471E+03   # MdR(Q)
+    48     5.65382471E+03   # MsR(Q)
+    49     5.68008496E+03   # MbR(Q)
+Block AU Q=  4.47923682E+03   #
+  1  1     4.93593066E+03   # A_u
+  2  2     4.93593066E+03   # A_c
+  3  3     4.93593066E+03   # A_t
+Block AD Q=  4.47923682E+03   #
+  1  1     1.17858047E+04   # A_d
+  2  2     1.17858047E+04   # A_s
+  3  3     1.17858047E+04   # A_b
+Block AE Q=  4.47923682E+03   #
+  1  1     3.34377515E+03   # A_e
+  2  2     3.34377515E+03   # A_mu
+  3  3     3.34377515E+03   # A_tau
+#
+#
+#
+#                             =================
+#                             |The decay table|
+#                             =================
+#
+#         PDG            Width
+DECAY   1000024     %.9g # chargino decay
+#
+#


### PR DESCRIPTION
This adds a few things to the 13 TeV disappearing tracks AMSB fragments. The Higgsino-like LSP case is introduced (same as the private generation for EXO-19-010), PSweights is added, and the card creation script is slightly cleaned up.