### PR TITLE
EOS unstability

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -723,6 +723,10 @@ fi
 
 #For correct running you should place at least the run and proc card in a folder under the name "cards" in the same folder where you are going to run the script
 RUNHOME=`pwd`
+if grep -F "/eos/home-" $RUNHOME ; then
+    echo "Running this in /eos/home-X/~ which is not really stable. Run this in /eos/user/X/ instead."
+    exit 1;
+fi
 LOGFILE=${RUNHOME}/${name}.log
 LOGFILE_NAME=${LOGFILE/.log/}
 

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -723,10 +723,15 @@ fi
 
 #For correct running you should place at least the run and proc card in a folder under the name "cards" in the same folder where you are going to run the script
 RUNHOME=`pwd`
-if grep -F "/eos/home-" $RUNHOME ; then
-    echo "Running this in /eos/home-X/~ which is not really stable. Run this in /eos/user/X/ instead."
-    exit 1;
+
+if [[ `uname -a` == *"lxplus"* ]]; then
+  if [[ $RUNHOME == *"/eos/home-"* ]]; then
+      echo "Running in /eos/home-X/~ which is not really stable. Use /eos/user/X/ instead."
+      exit 1;
+      #Preventing the use of /eos/home-X/ solely based on experience! Might not be a REAL problem.
+  fi
 fi
+
 LOGFILE=${RUNHOME}/${name}.log
 LOGFILE_NAME=${LOGFILE/.log/}
 


### PR DESCRIPTION
Based on experience only, /eos/home-X/~ is not really stable while /eos/user/X/ didn't show any issues for gridpack generations.

Until /eos/user/X/ is found to be problematic as well, prevent /eos/home-X/ area and advise to use /eos/user/X/ instead.