### PR TITLE
Update EWK W proc cards to account for non-resonant l+jets final states

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ewkwmlvjj_5f_LO/ewkwmlvjj_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ewkwmlvjj_5f_LO/ewkwmlvjj_5f_LO_proc_card.dat
@@ -3,7 +3,7 @@ import model sm-ckm_no_b_mass
 define l- = e- mu- ta-
 define vl~ = ve~ vm~ vt~
 
-generate p p > w- j j / t t~ h QED=4 QCD=0, w- > l- vl~
+generate p p > l- vl~ j j / t t~ h QCD=0
 
 output ewkwmlvjj_5f_LO -nojpeg
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ewkwplvjj_5f_LO/ewkwplvjj_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ewkwplvjj_5f_LO/ewkwplvjj_5f_LO_proc_card.dat
@@ -3,7 +3,7 @@ import model sm-ckm_no_b_mass
 define l+ = e+ mu+ ta+
 define vl = ve vm vt
 
-generate p p > w+ j j / t t~ h QED=4 QCD=0, w+ > l+ vl 
+generate p p > l+ vl j j / t t~ h QCD=0
 
 output ewkwplvjj_5f_LO -nojpeg
 


### PR DESCRIPTION
Hello, for the EWK W cards merged in #2834, we received some comments saying that we're not taking non-resonant lepton+jets final states into account, one such contributing diagram is shown in [1]. Looking at XS before and after, this seems to be a small impact, around 1% or so, but we were advised to update the proc cards as in this PR. We wanted to make this PR and ask for your opinion, if you think these look good, is it possible to merge these cards? Thanks a lot!  

[1]: http://cms-results.web.cern.ch/cms-results/public-results/publications/SMP-17-011/CMS-SMP-17-011_Figure_001-c.png