### PR TITLE
tW 5F NLO DR inclusive MadGraph5 sample cards for gridpack generation

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card decay  6 auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_madspin_card.dat
@@ -1,0 +1,28 @@
+#************************************************************
+#*                        MadSpin                           *
+#*                                                          *
+#*    P. Artoisenet, R. Frederix, R. Rietkerk, O. Mattelaer * 
+#*                                                          *
+#*    Part of the MadGraph5_aMC@NLO Framework:              *
+#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#*    Manual:                                               *
+#*    cp3.irmp.ucl.ac.be/projects/madgraph/wiki/MadSpin     *
+#*                                                          *
+#************************************************************
+# directory for gridpack mode
+set ms_dir ./madspingrid
+
+# Some options (uncomment to apply)
+set Nevents_for_max_weigth 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+
+# Decays
+decay t > w+ b, w+ > all all
+decay t~ > w- b~, w- > all all
+decay w+ > all all
+decay w- > all all
+
+# running the actual code
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_proc_card.dat
@@ -1,0 +1,5 @@
+import model loop_sm-no_b_mass
+define p = p b b~
+generate p p > t W- [QCD]
+add process p p > t~ W+ [QCD]
+output ST_tW_5f_NLO_inclusive_DR -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_run_card.dat
@@ -1,0 +1,188 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#                                                                      *
+#   To display additional parameter, you can use the command:          *
+#      update to_full                                                  *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+    tag_1   = run_tag ! name of the run
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+    10000   = nevents   ! Number of unweighted events requested
+    -1.0    = req_acc   ! Required accuracy (-1=auto determined from nevents)
+    -1      = nevt_job  ! Max number of events per job in event generation.
+                        !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+    average = event_norm ! valid settings: average, sum, bias
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+    0.01    = req_acc_fo    ! Required accuracy (-1=ignored, and use the
+                            ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+    5000    = npoints_fo_grid   ! number of points to setup grids
+    4       = niters_fo_grid    ! number of iter. to setup grids
+    10000   = npoints_fo        ! number of points to compute Xsec
+    6       = niters_fo         ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+  0    = iseed ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1       = lpp1      ! beam 1 type (0 = no PDF)
+    1       = lpp2      ! beam 2 type (0 = no PDF)
+    6500.0  = ebeam1    ! beam 1 energy in GeV
+    6500.0  = ebeam2    ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+    lhapdf              = pdlabel ! PDF set
+    $DEFAULT_PDF_SETS   = lhaid
+
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+    PYTHIA8    = parton_shower
+    1.0        = shower_scale_factor    ! multiply default shower starting
+                                        ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+    False   = fixed_ren_scale   ! if .true. use fixed ren scale
+    False   = fixed_fac_scale   ! if .true. use fixed fac scale
+    91.118  = mur_ref_fixed     ! fixed ren reference scale
+    91.118  = muf_ref_fixed     ! fixed fact reference scale
+    -1      = dynamical_scale_choice    ! Choose one (or more) of the predefined
+                                        ! dynamical choices. Can be a list; scale choices beyond the
+                                        ! first are included via reweighting
+    1.0       = mur_over_ref    ! ratio of current muR over reference muR
+    1.0       = muf_over_ref    ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+    .true.  = reweight_scale   ! reweight to get scale dependence
+    0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+    2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+    0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+    2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+    $DEFAULT_PDF_MEMBERS = reweight_PDF ! reweight to get PDF uncertainty
+                                        ! First of the error PDF sets
+                                        ! Last of the error PDF sets
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+    True    = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# Parameters relevant for the MasSTR plugin:                           *
+# iSTR controls the strategy for the resonance treatment               *
+#  istr = 1 -> DR without interferece                                  *
+#  istr = 2 -> DR with interferece                                     *
+#  istr = 3 -> DS with reshuffling on initial state, standard BW       *
+#  istr = 4 -> DS with reshuffling on initial state, running BW        *
+#  istr = 5 -> DS with reshuffling on all FS particles, standard BW    *
+#  istr = 6 -> DS with reshuffling on all FS particles, running BW     *
+#***********************************************************************
+    1    = istr             ! strategy to be used to remove resonances
+                            ! appearing in real emissions
+    True = str_include_pdf  ! compensate for PDFs when doing reshuffling
+    True = str_include_flux ! compensate for flux when doing reshuffling
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+    0    = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+    15.0    = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+    1.0    = jetalgo    ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+    0.7    = jetradius  ! The radius parameter for the jet algorithm
+    10.0   = ptj        ! Min jet transverse momentum
+    -1.0   = etaj       ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+    0.0    = ptl        ! Min lepton transverse momentum
+    -1.0   = etal       ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+    0.0    = drll       ! Min distance between opposite sign lepton pairs
+    0.0    = drll_sf    ! Min distance between opp. sign same-flavor lepton pairs
+    0.0    = mll        ! Min inv. mass of all opposite sign lepton pairs
+    30.0   = mll_sf     ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+    20.0   = ptgmin     ! Min photon transverse momentum
+    -1.0   = etagamma   ! Max photon abs(pseudo-rap)
+    0.4    = r0gamma    ! Radius of isolation code
+    1.0    = xn         ! n parameter of eq.(3.4) in hep-ph/9801442
+    1.0    = epsgamma   ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+    True   = isoem      ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Cuts associated to MASSIVE particles identified by their PDG codes.  *
+# All cuts are applied to both particles and anti-particles, so use    *
+# POSITIVE PDG CODES only. Example of the syntax is {6 : 100} or       *
+# {6:100, 25:200} for multiple particles                               *
+#***********************************************************************
+    {}    = pt_min_pdg  ! Min pT for a massive particle
+    {}    = pt_max_pdg  ! Max pT for a massive particle
+    {}    = mxx_min_pdg ! inv. mass for any pair of (anti)particles
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+    0    = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ST_tW_5f_NLO_inclusive_DR/ST_tW_5f_NLO_inclusive_DR_run_card.dat
@@ -31,7 +31,7 @@
 # (relative) accuracy on the Xsec.                                     *
 # These values are ignored for fixed order runs                        *
 #***********************************************************************
-    10000   = nevents   ! Number of unweighted events requested
+    3000    = nevents   ! Number of unweighted events requested
     -1.0    = req_acc   ! Required accuracy (-1=auto determined from nevents)
     -1      = nevt_job  ! Max number of events per job in event generation.
                         !  (-1= no split).


### PR DESCRIPTION
In this PR I add cards for generate tW 5F NLO inclusive sample gridpack with the diagram removal (DR) scheme for MadGraph5, following @agrohsje suggestion on Mattermost.

The cards are based on the analogous for the tWZ already present in the same folder. The only modifications are to the process themselves, the name in the process card, and the madspin decay information. They have been tested locally and a gridpack has been successfully produced.

We have, nevertheless, a question on whether the way we generalised the cards for all decay channels is the best one (changing in the madspin file the decays to "all" in all cases): is it really? Should we forget about using madspin?

@epalencia 