### PR TITLE
Fix file missing: scale_pdf_dependence.dat error

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0035-fix_condor_scale_pdf_dependence.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0035-fix_condor_scale_pdf_dependence.patch
@@ -1,0 +1,13 @@
+--- a/madgraph/various/cluster.py
++++ b/madgraph/various/cluster.py
+@@ -392,8 +392,8 @@ Press ctrl-C to force the update.''' % self.options['cluster_status_update'][0])
+         for path in args['required_output']:
+             if args['cwd']:
+                 path = pjoin(args['cwd'], path)
+-# check that file exists and is not empty.
+-            if not (os.path.exists(path) and os.stat(path).st_size != 0) :
++# check that file exists - allow empty file, scale_pdf_dependence.dat is often empty
++            if not os.path.exists(path) :
+                 break
+         else:
+             # all requested output are present


### PR DESCRIPTION
Fix `file missing: scale_pdf_dependence.dat` error when generating NLO gridpacks on `condor` cluster by adding a patch. `scale_pdf_dependence.dat` can be empty due to CMS patches [[1]](https://github.com/cms-sw/genproductions/blob/79b6c26f1769338b37eed631a3ed403b7b0adae6/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh#L65-L66)[[2]](https://github.com/cms-sw/genproductions/blob/79b6c26f1769338b37eed631a3ed403b7b0adae6/bin/MadGraph5_aMCatNLO/patches/0029-correct_sys_rwgt_steering.patch), however Madgraph's `condor` interface (in `cluster.py`) does not collect the file with size 0 - hence it ends up with the error even if the (empty) `scale_pdf_dependence.dat` exists. This patch makes Madgraph collect any file regardless of the file size.