### PR TITLE
[Backport] Fix file missing: scale_pdf_dependence.dat error

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0035-fix_condor_scale_pdf_dependence.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0035-fix_condor_scale_pdf_dependence.patch
@@ -1,0 +1,13 @@
+--- a/madgraph/various/cluster.py
++++ b/madgraph/various/cluster.py
+@@ -392,8 +392,8 @@ Press ctrl-C to force the update.''' % self.options['cluster_status_update'][0])
+         for path in args['required_output']:
+             if args['cwd']:
+                 path = pjoin(args['cwd'], path)
+-# check that file exists and is not empty.
+-            if not (os.path.exists(path) and os.stat(path).st_size != 0) :
++# check that file exists - allow empty file, scale_pdf_dependence.dat is often empty
++            if not os.path.exists(path) :
+                 break
+         else:
+             # all requested output are present


### PR DESCRIPTION
Backport of #2875 to fix condor error at mg27x (The [reweighting patch](https://github.com/cms-sw/genproductions/blob/79b6c26f1769338b37eed631a3ed403b7b0adae6/bin/MadGraph5_aMCatNLO/patches/0029-correct_sys_rwgt_steering.patch) is now officially merged to the Madgraph's source)