### PR TITLE
change dark higgs decay width from auto to a fixed value

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/darkphotonDimuon/darkphotonDimuon_DPMass5e-1MeV_DF1e-2/darkphotonDimuon_DPMass5e-1MeV_DF1e-2_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/darkphotonDimuon/darkphotonDimuon_DPMass5e-1MeV_DF1e-2/darkphotonDimuon_DPMass5e-1MeV_DF1e-2_customizecards.dat
@@ -2,5 +2,5 @@ set param_card HIDDEN 1 5e-4
 set param_card HIDDEN 2 1e4
 set param_card HIDDEN 3 1e-1
 set param_card HIDDEN 4 1e-10
-set param_card DECAY 35 auto
+set param_card DECAY 35 5.237950
 set param_card DECAY 1023 0


### PR DESCRIPTION
This value was set to auto, but I realized that it might cause some unstable in calculation, so I set it to a fixed value. It happens when I ran the gridpack, the decay width of dark higgs to Z Z might be some tiny negative value, and madgraph quits. Since our signal process has nothing to do with dark higgs,  I set it to be a fixed value and it is solved. 