### PR TITLE
bug fix for cut card Mll selection and fix to proc card tag name

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dyee012j_5f_NLO_FXFX_M100to160/dyee012j_5f_NLO_FXFX_M100to160_cuts.f
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dyee012j_5f_NLO_FXFX_M100to160/dyee012j_5f_NLO_FXFX_M100to160_cuts.f
@@ -140,13 +140,6 @@ c DeltaR and invariant mass cuts
                            endif
                         endif
                         if (mll_sf.gt.0d0) then
-                           if (invm2_04(p(0,i),p(0,j),1d0).gt.10**2)
-     $                          then
-                              passcuts_user=.false.
-                              return
-                           endif
-                        endif
-                        if (mll_sf.gt.0d0) then
                            if (invm2_04(p(0,i),p(0,j),1d0).lt.mll_sf**2)
      $                          then
                               passcuts_user=.false.
@@ -433,22 +426,21 @@ c$$$         endif
 c$$$      enddo
 c
 
-!      mZ of opposite sign, same flavour lepton pairs
-      do i=0,nexternal
-         do j=i+1,nexternal
-            if (abs(ipdg(i)).eq.11.and.(ipdg(i).eq.-ipdg(j))) then
-              if (invm2_04(p(0,i),p(0,j),1d0).lt.100**2) then
-                passcuts_user=.false.
-                return
-              endif
-              if (invm2_04(p(0,i),p(0,j),1d0).gt.160**2) then
-                passcuts_user=.false.
-                return
-              endif
-            endif
-         enddo
-      enddo
-
+c$$$  mZ of opposite sign, same flavour lepton pairs
+          do i=0,nexternal
+             do j=i+1,nexternal
+                if (abs(ipdg(i)).eq.11.and.(ipdg(i).eq.-ipdg(j))) then
+                  if (invm2_04(p(0,i),p(0,j),1d0).lt.100**2) then
+                    passcuts_user=.false.
+                    return
+                  endif
+                  if (invm2_04(p(0,i),p(0,j),1d0).gt.160**2) then
+                    passcuts_user=.false.
+                    return
+                  endif
+                endif
+             enddo
+          enddo
 
       return
       end

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dyee012j_5f_NLO_FXFX_M100to160/dyee012j_5f_NLO_FXFX_M100to160_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/dyee012j_5f_NLO_FXFX_M100to160/dyee012j_5f_NLO_FXFX_M100to160_proc_card.dat
@@ -7,5 +7,4 @@ generate p p > e+ e- [QCD] @0
 add process p p > e+ e- j [QCD] @1
 add process p p > e+ e- j j [QCD] @2
 
-output dyee012j_5f_NLO_FXFX_M105to160 -nojpeg
-
+output dyee012j_5f_NLO_FXFX_M100to160 -nojpeg


### PR DESCRIPTION
Following email discussion with Alexander, I am making a PR with a bug fix for a proc card and cut card that were merged previously. The cards are for Drell-Yan (Z->ee) UL samples for the H->ee search with full Run 2 dataset. They were intended for producing two DY samples with selection on the dilepton invariant mass (105 < MLL < 160), one of which has enhanced VBF topology (VBFFilter). 

The original PR with the bugs was merged in this thread: https://github.com/cms-sw/genproductions/pull/2835

Please let me know if the new cards look sensible.

Thanks,
Joe