### PR TITLE
Update HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.py

### DIFF
--- a/genfragments/ThirteenTeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.py
+++ b/genfragments/ThirteenTeV/Higgs/HZJ_HanythingJ_NNPDF31_13TeV_M125_Vhadronic_filterB.py
@@ -50,4 +50,4 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                                                      )
                          )
 
-ProductionFilterSequence = cms.Sequence(generator)
+ProductionFilterSequence = cms.Sequence(lheGenericFilter*generator)


### PR DESCRIPTION
b filter was not actually included in the production sequence. Fixed this by adding lheGenericFilter* in the last line.