### PR TITLE
Changing location of madspin_card.dat in Madgraph LO gridpack

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -583,7 +583,6 @@ make_gridpack () {
         $WORKDIR/$MGBASEDIRORIG/MadSpin/madspin madspinrun.dat 
         rm madspinrun.dat
         rm -rf tmp*
-        cp $CARDSDIR/${name}_madspin_card.dat $WORKDIR/process/madspin_card.dat
       fi
     
       echo "preparing final gridpack"

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -143,7 +143,10 @@ fi
 gzip -d $LHEWORKDIR/process/events.lhe.gz
 
 domadspin=0
-if [ -f ./madspin_card.dat ] ;then
+#checking for a madspin_card in the InputCards directory,
+#rather than checking for it in the process directory, since run.sh will remove *.dat from that directory,
+#if it fails to generate any event in the first iteration 
+if [ -f $LHEWORKDIR/InputCards/*madspin_card.dat ] ;then
     domadspin=1
     # extract header as overwritten by madspin 
     if grep -R "<initrwgt>" events.lhe ; then
@@ -152,7 +155,7 @@ if [ -f ./madspin_card.dat ] ;then
     echo "import events.lhe" > madspinrun.dat
     rnum2=$(($rnum+1000000))
     echo `echo "set seed $rnum2"` >> madspinrun.dat
-    cat ./madspin_card.dat >> madspinrun.dat
+    cat $LHEWORKDIR/InputCards/*madspin_card.dat >> madspinrun.dat
     $LHEWORKDIR/mgbasedir/MadSpin/madspin madspinrun.dat 
     # add header back 
     gzip -d events_decayed.lhe.gz  


### PR DESCRIPTION
Hi,

this changes the location of the `madspin_card.dat` in the LO Madgraph gridpacks.
I changed the respective paths in `gridpack_generation.sh` as well as `runcmsgrid_LO.sh` from
`$WORKDIR/process/madspin_card.dat` to `$WORKDIR/process/madevent/Cards/madspin_card.dat`.

This helps avoid problems when any of the runs in `runcmsgrid_LO.sh` fail to generate any events.
This would lead to the removal of `madspin_card.dat` in the `process` dir and consequently the skipping of madspin.
The card is removed from the `process` dir in those cases, since this is where madgraphs `run.sh` is called and this script is removing any `*.dat` cards from the current directory if `./madevent/Events/GridRun_${seed}/unweighted_events.lhe.gz` does not exists (see [Template/LO/bin/internal/Gridpack/run.sh#L60](https://bazaar.launchpad.net/~madteam/mg5amcnlo/3.x/view/head:/Template/LO/bin/internal/Gridpack/run.sh#L60) ).

I'm not sure if this is the preferred way of 'fixing' this - so let me know if I should change anyhting. 
(I'm not sure if the madspin_card is expected in the `process` dir by other scripts.)

Cheers
Steffen