### PR TITLE
Update ZZTo2L2Q cards for UL

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_madspin_card.dat
@@ -1,21 +1,8 @@
-#************************************************************
-#*                        MadSpin                           *
-#*                                                          *
-#*    P. Artoisenet, R. Frederix, R. Rietkerk, O. Mattelaer * 
-#*                                                          *
-#*    Part of the MadGraph5_aMC@NLO Framework:              *
-#*    The MadGraph5_aMC@NLO Development Team - Find us at   *
-#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
-#*                                                          *
-#************************************************************
-#Some options (uncomment to apply)
 set ms_dir ./madspingrid
 set Nevents_for_max_weigth 250 
 set max_weight_ps_point 400  
-set BW_cut 40                
- 
+set BW_cut 15 
 set max_running_process 1
-
 define q = u c d s b u~ c~ d~ s~ b~
 decay z > q q
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_proc_card.dat
@@ -1,12 +1,9 @@
 import model loop_sm-ckm_no_b_mass
 define p = p b b~
 define j = j b b~
-
 define V = z
 define ell+ = e+ mu+ ta+
 define ell- = e- mu- ta-
-
 generate p p > V ell+ ell- [QCD] @0
 add process p p > V ell+ ell- j [QCD] @1
-
 output ZZTo2L2Q01j_5f_NLO_FXFX -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ZZTo2L2Q01j_5f_NLO_FXFX/ZZTo2L2Q01j_5f_NLO_FXFX_run_card.dat
@@ -83,7 +83,12 @@ average = event_norm ! Normalize events to sum or average to the X sect.
  1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
  1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
  1        = QES_over_ref     ! ratio of current QES over reference QES
-#*********************************************************************** 
+#************************************************************************
+## Store reweight information in the LHE file for off-line model-       *
+## parameter reweighting at NLO+PS accuracy                             *
+##***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
 # Reweight flags to get scale dependence and PDF uncertainty           *
 # For scale dependence: factor rw_scale_up/down around central scale   *
 # For PDF uncertainty: use LHAPDF with supported set                   *
@@ -93,8 +98,6 @@ average = event_norm ! Normalize events to sum or average to the X sect.
   2.0     = rw_Rscale_up     ! upper bound for ren scale variations
   0.5     = rw_Fscale_down   ! lower bound for fact scale variations
   2.0     = rw_Fscale_up     ! upper bound for fact scale variations
- 292201   = PDF_set_min      ! First of the error PDF sets 
- 292302   = PDF_set_max      ! Last of the error PDF sets
 #***********************************************************************
 # Merging - WARNING! Applies merging only at the hard-event level.     *
 # After showering an MLM-type merging should be applied as well.       *


### PR DESCRIPTION
Dear GEN,

Can you please review these card for UL production?
BW cut in madspin from the WZTo2L2Q https://github.com/cms-sw/genproductions/pull/2955 discussion is also implemented here.

P.S. The one difference is the redefinition of `p`, and `j` here to include `b` , which I am not sure why this is needed for ZZ vs WZ case.

Regards,
Ramanpreet