### PR TITLE
Add powheg cards for two more t-chan. 4FS single-top top width variation points

### DIFF
--- a/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop0p55/st_tch_4f_ckm_antitop_13TeV_wtop0p55_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop0p55/st_tch_4f_ckm_antitop_13TeV_wtop0p55_UL.input
@@ -1,0 +1,86 @@
+! ST-tchannel inputs
+
+#smartsig       1 
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop
+
+withnegweights 0   ! will generate also events with negative-weight 
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+#bornonly   1     ! (default 0) if 1 do Born only
+#testplots  1     ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     0      ! initialize random number sequence 
+#rand2     0      ! initialize random number sequence 
+#manyseeds 1   
+
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 6500
+ebeam2 6500
+
+
+! To be set only if using LHA pdfs
+lhans1 320900
+lhans2 320900
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PROCESS SPECIFIC PARAMETERS
+
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 0.55
+
+ttype        -1
+topmass      172.5
+wmass        80.4
+wwidth       2.141
+sthw2        0.231295
+alphaem_inv  137.0360098
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.18
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.18
+bottomthrpdf 4.18
+charmthr     1.27
+charmthrpdf  1.27
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97420
+CKM_Vus   0.2243
+CKM_Vub   0.00394
+CKM_Vcd   0.218
+CKM_Vcs   0.997
+CKM_Vcb   0.0422
+CKM_Vtd   0.0081
+CKM_Vts   0.0394
+CKM_Vtb   1.0

--- a/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop0p55/st_tch_4f_ckm_top_13TeV_wtop0p55_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop0p55/st_tch_4f_ckm_top_13TeV_wtop0p55_UL.input
@@ -1,0 +1,87 @@
+! ST-tchannel inputs
+
+#smartsig       1 
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop
+
+withnegweights 0   ! will generate also events with negative-weight 
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+#bornonly   1     ! (default 0) if 1 do Born only
+#testplots  1     ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     0      ! initialize random number sequence 
+#rand2     0      ! initialize random number sequence 
+#manyseeds 1   
+
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 6500
+ebeam2 6500
+
+
+! To be set only if using LHA pdfs
+lhans1 320900
+lhans2 320900
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PROCESS SPECIFIC PARAMETERS
+
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 0.55
+
+ttype        1
+topmass      172.5
+wmass        80.4
+wwidth       2.141
+sthw2        0.231295
+alphaem_inv  137.0360098
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.18
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.18
+bottomthrpdf 4.18
+charmthr     1.27
+charmthrpdf  1.27
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97420
+CKM_Vus   0.2243
+CKM_Vub   0.00394
+CKM_Vcd   0.218
+CKM_Vcs   0.997
+CKM_Vcb   0.0422
+CKM_Vtd   0.0081
+CKM_Vts   0.0394
+CKM_Vtb   1.0
+

--- a/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop1p45/st_tch_4f_ckm_antitop_13TeV_wtop1p45_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop1p45/st_tch_4f_ckm_antitop_13TeV_wtop1p45_UL.input
@@ -1,0 +1,86 @@
+! ST-tchannel inputs
+
+#smartsig       1 
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop
+
+withnegweights 0   ! will generate also events with negative-weight 
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+#bornonly   1     ! (default 0) if 1 do Born only
+#testplots  1     ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     0      ! initialize random number sequence 
+#rand2     0      ! initialize random number sequence 
+#manyseeds 1   
+
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 6500
+ebeam2 6500
+
+
+! To be set only if using LHA pdfs
+lhans1 320900
+lhans2 320900
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PROCESS SPECIFIC PARAMETERS
+
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 1.45
+
+ttype        -1
+topmass      172.5
+wmass        80.4
+wwidth       2.141
+sthw2        0.231295
+alphaem_inv  137.0360098
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.18
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.18
+bottomthrpdf 4.18
+charmthr     1.27
+charmthrpdf  1.27
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97420
+CKM_Vus   0.2243
+CKM_Vub   0.00394
+CKM_Vcd   0.218
+CKM_Vcs   0.997
+CKM_Vcb   0.0422
+CKM_Vtd   0.0081
+CKM_Vts   0.0394
+CKM_Vtb   1.0

--- a/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop1p45/st_tch_4f_ckm_top_13TeV_wtop1p45_UL.input
+++ b/bin/Powheg/production/2017/13TeV/st_tch_4f_ckm_13TeV_wtop1p45/st_tch_4f_ckm_top_13TeV_wtop1p45_UL.input
@@ -1,0 +1,87 @@
+! ST-tchannel inputs
+
+#smartsig       1 
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop
+
+withnegweights 0   ! will generate also events with negative-weight 
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+#bornonly   1     ! (default 0) if 1 do Born only
+#testplots  1     ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     0      ! initialize random number sequence 
+#rand2     0      ! initialize random number sequence 
+#manyseeds 1   
+
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 6500
+ebeam2 6500
+
+
+! To be set only if using LHA pdfs
+lhans1 320900
+lhans2 320900
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! PROCESS SPECIFIC PARAMETERS
+
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 1.45
+
+ttype        1
+topmass      172.5
+wmass        80.4
+wwidth       2.141
+sthw2        0.231295
+alphaem_inv  137.0360098
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.18
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.18
+bottomthrpdf 4.18
+charmthr     1.27
+charmthrpdf  1.27
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97420
+CKM_Vus   0.2243
+CKM_Vub   0.00394
+CKM_Vcd   0.218
+CKM_Vcs   0.997
+CKM_Vcb   0.0422
+CKM_Vtd   0.0081
+CKM_Vts   0.0394
+CKM_Vtb   1.0
+


### PR DESCRIPTION
Two more points have been requested for UL. Cards for top and anti-top processes are copied from existing width variations with only the top width parameter changed.