### PR TITLE
Added "WriteFailedEvents=2" to ZZ4l_withtaus cards

### DIFF
--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2AA_1.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2AA_1.input
@@ -1,1 +1,1 @@
-ghz1=0,0 ghgsgs2=0.0530640,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=0,0 ghgsgs2=0.0530640,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2AA_dec_05.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2AA_dec_05.input
@@ -1,1 +1,1 @@
-ghz1=1,0 ghgsgs2=0.0530640,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=1,0 ghgsgs2=0.0530640,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2ZA_1.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2ZA_1.input
@@ -1,1 +1,1 @@
-ghz1=0,0 ghzgs2=0.0477547,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=0,0 ghzgs2=0.0477547,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2ZA_dec_05.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa2ZA_dec_05.input
@@ -1,1 +1,1 @@
-ghz1=1,0 ghzgs2=0.0477547,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=1,0 ghzgs2=0.0477547,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3AA_1.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3AA_1.input
@@ -1,1 +1,1 @@
-ghz1=0,0 ghgsgs4=0.0536022,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=0,0 ghgsgs4=0.0536022,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3AA_dec_05.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3AA_dec_05.input
@@ -1,1 +1,1 @@
-ghz1=1,0 ghgsgs4=0.0536022,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=1,0 ghgsgs4=0.0536022,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3ZA_1.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3ZA_1.input
@@ -1,1 +1,1 @@
-ghz1=0,0 ghzgs4=0.0529487,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=0,0 ghzgs4=0.0529487,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2

--- a/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3ZA_dec_05.input
+++ b/bin/JHUGen/cards/decay/anomalouscouplings/ZZ4l_withtaus_fa3ZA_dec_05.input
@@ -1,1 +1,1 @@
-ghz1=1,0 ghzgs4=0.0529487,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info
+ghz1=1,0 ghzgs4=0.0529487,0 DecayMode1=8 DecayMode2=8 MPhotonCutoff=4 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info WriteFailedEvents=2


### PR DESCRIPTION
Some of the gammaH gridpacks only returned 99% of the number of events requested, so "WriteFailedEvents=2" was added to fix this.