### PR TITLE
update BW-Cutoff for wwa_emu process

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToEMuA_4f_NLO/WWAToEMuA_4f_NLO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/WWAToLNuLNuA_4f_NLO/WWAToEMuA_4f_NLO/WWAToEMuA_4f_NLO_run_card.dat
@@ -123,7 +123,7 @@
 # BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
 # written in the LHE event file                                        *
 #***********************************************************************
- 30  = bwcutoff
+ 15  = bwcutoff
 #***********************************************************************
 # Cuts on the jets. Jet clustering is performed by FastJet.            *
 #  - When matching to a parton shower, these generation cuts should be *


### PR DESCRIPTION
Because final states in this process have been defined, we can use a smaller BW-Cutoff in run_card.