### PR TITLE
dummy decay patch for mg33x

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0077-fix_madspin_dummy_decay.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0077-fix_madspin_dummy_decay.patch
@@ -1,0 +1,29 @@
+--- a/MadSpin/decay.py
++++ b/MadSpin/decay.py
+@@ -2469,7 +2469,11 @@ class decay_all_events(object):
+         #no decays for this production mode, run in passthrough mode, only adding the helicities to the events
+         nb_mc_masses=0
+         p, p_str=self.curr_event.give_momenta(event_map)
+-        stdin_text=' %s %s %s %s \n' % ('2', self.options['BW_cut'], self.Ecollider, 1.0, self.options['frame_id'])
++        try:
++            frameid = self.options['frame_id']
++        except KeyError:
++            frameid = 6
++        stdin_text=' %s %s %s %s %s\n' % ('2', self.options['BW_cut'], self.Ecollider, 1.0, frameid)
+         stdin_text+=p_str
+         # here I also need to specify the Monte Carlo Masses
+         stdin_text+=" %s \n" % nb_mc_masses
+--- a/MadSpin/interface_madspin.py
++++ b/MadSpin/interface_madspin.py
+@@ -633,8 +633,9 @@ class MadSpinInterface(extended_cmd.Cmd):
+                 if pid in self.final_state:
+                     break
+         else:
+-            logger.info("Nothing to decay ...")
+-            return
++            if not self.options['onlyhelicity']:
++                logger.info("Nothing to decay ...")
++                return
+         
+ 
+         model_line = self.banner.get('proc_card', 'full_model_line')


### PR DESCRIPTION
This patch fixes the problem of using a dummy decay madspin card, details are in this discussion:
 
https://answers.launchpad.net/mg5amcnlo/+question/699822