### PR TITLE
fix bug for is5FlavorScheme in gridpack_generation.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -348,7 +348,7 @@ make_gridpack () {
       echo "WARNING: If you changed the process card you need to clean the folder and run from scratch"
     
       if [ "$is5FlavorScheme" -eq -1 ]; then
-        if cat $LOGFILE_NAME*.log | grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~"; then 
+        if grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~" $LOGFILE_NAME*.log; then 
             is5FlavorScheme=1
         else
             is5FlavorScheme=0


### PR DESCRIPTION
With *set -o pipefail*, the pipe method *cat ...|grep -q ...* can return unexpected exit code, which results in wrong *is5FlavorScheme* value. Avoid this problem by not using pipe.

More discussion at below link.
https://cms-talk.web.cern.ch/t/clustermanagmenterror-during-gridpack-generation/4669/6