### PR TITLE
fix typo in submit_cmsconnect_gridpack_generation, CLUSTERID -> CLUSTER_ID

### DIFF
--- a/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/submit_cmsconnect_gridpack_generation.sh
@@ -256,7 +256,7 @@ condor_wait "$LOG_FILE" "$CLUSTER_ID"
 # If querying job exitcode fails, retry
 status_n_retries=10
 for ((i=0; i<=$status_n_retries; ++i)); do
-    condor_exitcode=$(condor_history ${CLUSTERID} -limit 1 -format "%s" ExitCode)
+    condor_exitcode=$(condor_history ${CLUSTER_ID} -limit 1 -format "%s" ExitCode)
     if [ "x$condor_exitcode" != "x" ]; then
         break
     fi


### PR DESCRIPTION
I found a typo in *submit_cmsconnect_gridpack_generation.sh*.
This makes the script retrieve the exit code of most recently finished job (including all other users' jobs) instead of the its own CODEGEN job.