### PR TITLE
Updated JHUGen version in gridpack scripts to 7.5.1

### DIFF
--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import textwrap
 
-JHUGenversion = "v7.2.7"
+JHUGenversion = "v7.5.1"
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Make JHUGen gridpack")
@@ -59,7 +59,7 @@ def main(args):
         errortext += "  To check the status of the jobs, use the --check-jobs option."
       raise OSError(errortext)
   if args.link_mela:
-    os.environ["LD_LIBRARY_PATH"] = (os.path.join(JHUbasedir, "JHUGenMELA", "MELA", "data", "slc6_amd64_gcc530") + ":" + os.environ["LD_LIBRARY_PATH"]).rstrip(":")
+    os.environ["LD_LIBRARY_PATH"] = (os.path.join(JHUbasedir, "JHUGenMELA", "MELA", "data", os.environ["SCRAM_ARCH"]) + ":" + os.environ["LD_LIBRARY_PATH"]).rstrip(":")
 
   command="./JHUGen $(cat ../JHUGen.input) VegasNc2=${nevt} Seed=${rnum}"
   if args.decay_card is not None:
@@ -75,11 +75,15 @@ def main(args):
       subprocess.check_call(["wget", "--no-check-certificate", "http://spin.pha.jhu.edu/Generator/JHUGenerator."+JHUGenversion+".tar.gz", "-O", "JHUGenerator.tar.gz"])
       subprocess.check_call(["tar", "xvzf", "JHUGenerator.tar.gz"])
       os.remove("JHUGenerator.tar.gz")
-      os.remove("manJHUGenerator."+JHUGenversion+".pdf")
-      shutil.rmtree("AnalyticMELA")
+      shutil.move("JHUGenerator."+JHUGenversion+"/JHUGenerator","./")
+      shutil.move("JHUGenerator."+JHUGenversion+"/JHUGenMELA","./")
+      shutil.rmtree("JHUGenerator."+JHUGenversion)
       if args.link_mela:
-        with cd("JHUGenMELA/MELA"):
-          subprocess.check_call(["./setup.sh"])
+        subprocess.check_call(["scramv1","project","CMSSW",os.environ['CMSSW_VERSION']])
+        shutil.move("JHUGenMELA",os.environ['CMSSW_VERSION']+"/src")
+        os.environ["LD_LIBRARY_PATH"] = (os.path.join(JHUbasedir, os.environ['CMSSW_VERSION'], "src", "JHUGenMELA", "MELA", "data", os.environ["SCRAM_ARCH"]) + ":" + os.environ["LD_LIBRARY_PATH"]).rstrip(":")
+        with cd(os.environ['CMSSW_VERSION']+"/src/JHUGenMELA/MELA"):
+          subprocess.check_call(["./setup.sh","-j"])
       else:
         shutil.rmtree("JHUGenMELA")
       with cd("JHUGenerator"):
@@ -92,7 +96,11 @@ def main(args):
 
         find = "(^MELADir *= *).*"
         assert re.search(find, makefile, flags=re.MULTILINE)
-        makefile = re.sub(find, r"\1../JHUGenMELA/MELA", makefile, flags=re.MULTILINE) #use the RELATIVE path.  make creates symlinks that have to be valid wherever the gridpack is opened.
+        makefile = re.sub(find, r"\1../"+os.environ['CMSSW_VERSION']+"/src/JHUGenMELA/MELA", makefile, flags=re.MULTILINE) #use the RELATIVE path.  make creates symlinks that have to be valid wherever the gridpack is opened.
+
+        find = "(^  MELADir *= *).*"
+        assert re.search(find, makefile, flags=re.MULTILINE)
+        makefile = re.sub(find, r"\1$(Here)/../"+os.environ['CMSSW_VERSION']+"/src/JHUGenMELA/MELA", makefile, flags=re.MULTILINE)
 
         find = "(^UseLHAPDF *= *)(Yes|No)"
         assert re.search(find, makefile, flags=re.MULTILINE)
@@ -246,7 +254,7 @@ def main(args):
       shutil.rmtree("data/")
 
   with cd(JHUbasedir):
-    subprocess.check_call(["tar", "czvf", "../JHUGen_%s_%s_%s.tgz" % (args.name, os.environ["SCRAM_ARCH"], os.environ["CMSSW_VERSION"])] + glob.glob("*"))
+    subprocess.check_call(["tar", "-czvf", "../%s_%s_%s.tgz" % (args.name, os.environ["SCRAM_ARCH"], os.environ["CMSSW_VERSION"])] + glob.glob("*"))
 
 if __name__ == "__main__":
   main(args)

--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -254,7 +254,7 @@ def main(args):
       shutil.rmtree("data/")
 
   with cd(JHUbasedir):
-    subprocess.check_call(["tar", "-czvf", "../%s_%s_%s.tgz" % (args.name, os.environ["SCRAM_ARCH"], os.environ["CMSSW_VERSION"])] + glob.glob("*"))
+    subprocess.check_call(["tar", "czvf", "../JHUGen_%s_%s_%s.tgz" % (args.name, os.environ["SCRAM_ARCH"], os.environ["CMSSW_VERSION"])] + glob.glob("*"))
 
 if __name__ == "__main__":
   main(args)

--- a/bin/JHUGen/runcmsgrid_template.sh
+++ b/bin/JHUGen/runcmsgrid_template.sh
@@ -45,8 +45,8 @@ set -euo pipefail
 
 cd $LHEWORKDIR
 
-if [ -d JHUGenMELA ]; then
-  eval $(JHUGenMELA/MELA/setup.sh env)
+if [ -d CMSSW_VERSION_REPLACE/src/JHUGenMELA ]; then
+  export LD_LIBRARY_PATH=../CMSSW_VERSION_REPLACE/src/JHUGenMELA/MELA/data/$SCRAM_ARCH/:${LD_LIBRARY_PATH}
 fi
 
 cd JHUGenerator/

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -6,7 +6,7 @@ export WORKDIR=$rootfolder
 export patches_dir=$patches_dir 
 # Release to be used to define the environment and the compiler needed
 export RELEASE=$${CMSSW_VERSION}
-export jhugenversion="v7.2.7" 
+export jhugenversion="v7.5.1" 
 
 cd $$WORKDIR
 pwd
@@ -184,7 +184,7 @@ if [ $$jhugen = 1 ]; then
   fi
 
   tar zxf JHUGenerator.$${jhugenversion}.tar.gz
-  cd JHUGenerator
+  cd JHUGenerator.$${jhugenversion}/JHUGenerator
   sed -i -e "s#Comp = ifort#Comp = gfort#g" makefile
   sed -i -e "s#linkMELA = Yes#linkMELA = No#g" makefile
   make

--- a/bin/Powheg/run_pwg.py
+++ b/bin/Powheg/run_pwg.py
@@ -286,7 +286,7 @@ def runGetSource(parstage, xgrid, folderName, powInputName, process, noPdfCheck,
 '''
 # Release to be used to define the environment and the compiler needed
 export RELEASE=${CMSSW_VERSION}
-export jhugenversion="v7.2.7"
+export jhugenversion="v7.5.1"
 
 cd $WORKDIR
 pwd


### PR DESCRIPTION
Updated JHUGen version to 7.5.1 in JHUGen and POWHEG scripts. Main changes needed to support this version:
> path to JHUGenerator is now ./JHUGenerator.v7.5.1/JHUGenerator
> MELA must now be compiled within CMSSW_x_x_x/src
> correct LD_LIBRARY_PATH must be exported to link JHUGen to MELA