### PR TITLE
Upload cards for ALP model for WZG analysis

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 9000005 1.000000e+02
+set param_card decay 9000005 AUTO

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_extramodels.dat
@@ -1,0 +1,1 @@
+Relaxion_Full_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_proc_card.dat
@@ -1,0 +1,6 @@
+import model Relaxion_Full_UFO
+
+generate p p > l+ vl l+ l- a QED>6
+add process p p > l- vl~ l+ l- a QED>6
+
+output ALP_lvlla_4f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/ALP_lvlla_4f_LO_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+    'lhapdf'    = pdlabel     ! PDF set                                  
+    $DEFAULT_PDF_SETS = lhaid
+    $DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf number 
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0 = lhe_version       ! Change the way clustering information pass to shower.        
+  True = clusinfo         ! include clustering tag in output
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+ 0.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   True = cut_decays    ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10.0  = ptj       ! minimum pt for the jets 
+ 0.0  = ptb       ! minimum pt for the b 
+ 5.0  = pta       ! minimum pt for the photons 
+ 5.0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0 = etaj    ! max rap for the jets 
+  -1.0  = etab    ! max rap for the b
+ 5.0  = etaa    ! max rap for the photons 
+ 5.0  = etal    ! max rap for the charged leptons 
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drjj    ! min distance between jets 
+ 0.0   = drbb    ! min distance between b's 
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = draa    ! min distance between gammas 
+ 0.0   = drbj    ! min distance between b and jet 
+ 0.0 = draj    ! min distance between gamma and jet 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ 0.0   = drab    ! min distance between gamma and b 
+ 0.0   = drbl    ! min distance between b and lepton 
+ 0.0 = dral    ! min distance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair 
+ 0.0   = mmbb    ! min invariant mass of a b pair 
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy   ! minimum pt for at least one heavy final state
+ 0.0  = xptj ! minimum pt for at least one jet  
+ 0.0  = xptb ! minimum pt for at least one b 
+ 0.0  = xpta ! minimum pt for at least one photon 
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+ 0.0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham        
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule
+# Syscalc is deprecated but to see the associate options type'update syscalc'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/generateCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/ALP_lvlla_4f_LO/generateCards.py
@@ -1,0 +1,25 @@
+#! /bin/env python
+
+import os, shutil, subprocess
+
+Ref_dir = "./"
+Ref_name = "ALP_lvlla_4f_LO"
+ALP_pdgid = '9000005' #ALP pdgid number
+MassesALP = [50, 90, 100, 110, 160, 200, 300, 400]
+
+for mALP in MassesALP:
+    sampleName = 'ALP_lvlla_4f_LO_m' + str(mALP)
+    print sampleName
+    if os.path.isdir(sampleName):
+        shutil.rmtree(sampleName)
+    os.makedirs(sampleName)
+    # Copy cards
+    shutil.copyfile(Ref_dir + Ref_name + '_run_card.dat',sampleName+'/'+sampleName+'_run_card.dat')
+    shutil.copyfile(Ref_dir + Ref_name + '_extramodels.dat',sampleName+'/'+sampleName+'_extramodels.dat')
+    shutil.copyfile(Ref_dir + Ref_name + '_proc_card.dat',sampleName+'/'+sampleName+'_proc_card.dat')
+    #customization
+    os.system('sed -i "s/output\ ALP_lvlla_4f_LO/output\ {0}/g" {0}/{0}_proc_card.dat'.format(sampleName))
+    #create customization card
+    with open("{0}/{0}_customizecards.dat".format(sampleName), "w") as f:
+        f.write("set param_card mass %s %s\n" % (ALP_pdgid, str(mALP)))
+        f.write("set param_card decay %s  %s\n" % (ALP_pdgid, 'AUTO'))


### PR DESCRIPTION
Dear GEN experts,

1. The model is from https://arxiv.org/abs/1805.06538, which is an extended Axion-Like-Particle (ALP) model which includes couplings with gauge bosons besides photon.
2. This model is also used by [SMP-17-013](https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=SMP-17-013).
3. For proc card, with QED>6 requirement, all SM processes are discarded. Since the decay width given by the auto computing is pretty small (~e-08), the interference effect could be ignored.
4. For run card, we remove most of the deltaR cut and loose the pt cut. The gray line in the figure is the scheme we choose, which shows good agreement with the results given by the theoretic paper. Also this scheme is more inclusive compared with the purple line, which is using the default Madgraph cut. ![WZG_ALP_xs](https://user-images.githubusercontent.com/32735814/154892918-0843643a-7593-4c0d-9809-c8efcec1527a.png)
5. For the parameter, `fa`, which is the floating parameter that directly affects the couplings between ALP and bosons, is chosen to use 1TeV to get a larger cross section and is set in the model. The decay width of the ALP (9000005/p1 in the model) is set to AUTO. Several mass points will be set to scan from 50GeV to 400GeV. For brevity, the cards uploaded here only contain 100GeV mass point as an example.