### PR TITLE
Fix a crash for processes with tagged photon

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0078-fix_gamma-process-crash.diff
+++ b/bin/MadGraph5_aMCatNLO/patches/0078-fix_gamma-process-crash.diff
@@ -1,0 +1,113 @@
+--- a/Template/NLO/SubProcesses/cuts.f
++++ b/Template/NLO/SubProcesses/cuts.f
+@@ -216,6 +216,12 @@
+ 
+       REAL*8 pt,eta
+       external pt,eta
++
++      include "orders.inc"
++      logical split_type_used(nsplitorders)
++      common/to_split_type_used/split_type_used
++
++      integer n_needed_photons
+  
+       passcuts_photons = .true.
+ 
+@@ -353,7 +359,18 @@
+          enddo
+ c End of loop over photons
+ 
+-         if(nphiso.lt.get_n_tagged_photons())then
++C now check that there are enough photons
++         if (split_type_used(QED_pos)) then
++         ! if the process has QED splittings, use the 
++         ! get_n_tagged_photons function
++             n_needed_photons = get_n_tagged_photons()
++         else
++         ! otherwise, just use the number of photons
++         ! that has been counted
++             n_needed_photons = nph
++         endif
++
++         if(nphiso.lt.n_needed_photons)then
+             passcuts_photons=.false.
+             return
+          endif
+
+--- a/madgraph/iolibs/export_fks.py
++++ b/madgraph/iolibs/export_fks.py
+@@ -528,11 +528,14 @@
+ 
+         filename = 'fks_info.inc'
+         # write_fks_info_list returns a set of the splitting types
++        split_types = self.write_fks_info_file(writers.FortranWriter(filename), 
++                                 matrix_element, 
++                                 fortran_model)
++
++        # update the splitting types
+         self.proc_characteristic['splitting_types'] = list(\
+                 set(self.proc_characteristic['splitting_types']).union(\
+-                    self.write_fks_info_file(writers.FortranWriter(filename), 
+-                                 matrix_element, 
+-                                 fortran_model)))
++                    split_types))
+ 
+         filename = 'leshouche_info.dat'
+         nfksconfs,maxproc,maxflow,nexternal=\
+@@ -617,7 +620,7 @@
+         filename = 'rescale_alpha_tagged.f'
+         self.write_rescale_a0gmu_file(
+                             writers.FortranWriter(filename),
+-                            startfroma0, matrix_element)
++                            startfroma0, matrix_element, split_types)
+ 
+         filename = 'orders.h'
+         self.write_orders_c_header_file(
+@@ -1120,9 +1123,11 @@
+         writer.writelines(text)
+ 
+ 
+-    def write_rescale_a0gmu_file(self, writer, startfroma0, matrix_element):
++    def write_rescale_a0gmu_file(self, writer, startfroma0, matrix_element, split_types):
+         """writes the function that computes the rescaling factor needed in
+-        the case of external photons
++        the case of external photons.
++        If split types does not contain [QED] or if there are not tagged photons,
++        dummy informations are filled
+         """
+ 
+         # get the model parameters
+@@ -1131,7 +1136,8 @@
+ 
+         bornproc = matrix_element.born_me['processes'][0]
+         # this is to ensure compatibility with standard processes
+-        if not any([l['is_tagged'] and l['id'] == 22 for l in bornproc['legs']]):
++        if not any([l['is_tagged'] and l['id'] == 22 for l in bornproc['legs']])\
++                or 'QED' not in split_types:
+             to_check = []
+             expr = '1d0'
+             conv_pol = '0d0'
+
+--- a/madgraph/various/banner.py
++++ b/madgraph/various/banner.py
+@@ -4904,6 +4904,7 @@
+           e+ e- beam -> lpp:0 ebeam:500  
+           p p beam -> set maxjetflavor automatically
+           process with tagged photons -> gamma_is_j = false
++          process without QED splittings -> gamma_is_j = false, recombination = false
+         """
+ 
+         for block in self.blocks:
+@@ -4948,6 +4949,11 @@
+         if 22 in tagged_particles:
+             self['gamma_is_j'] = False
+ 
++        if 'QED' not in proc_characteristic['splitting_types']:
++            self['gamma_is_j'] = False
++            self['lepphreco'] = False
++            self['quarkphreco'] = False
++
+         matching = False
+         if min_particle != max_particle:
+             #take one of the process with min_particle
+


### PR DESCRIPTION
There is a bug in mg5 3.3.1 that it crashes when trying to generate processes with tagged photon, e.g. `p p > a a [QCD]` (https://bugs.launchpad.net/mg5amcnlo/+bug/1960832). The patch will be part of the official mg5 in 3.3.2, but we'll need this until the release of the new mg5 version (along with #3080 & #3081).