### PR TITLE
Change dynamic scale option

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/LFV_TopProduction_TopDecay/SMEFTfr_TT_clequ1_emutu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/LFV_TopProduction_TopDecay/SMEFTfr_TT_clequ1_emutu_run_card.dat
@@ -59,6 +59,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF     ! if pdlabel=lhapdf, this is the lhapdf 
  91.188   = scale            ! fixed ren scale
  91.188   = dsqrt_q2fact1    ! fixed fact scale for pdf1
  91.188   = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = dynamical_scale_choice ! Choose one of the preselected dynamical choices
  1        = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta


### PR DESCRIPTION
Dear @sihyunjeon and @agrohsje,
The default dynamic scale of madgraph appears to be buggy when running with UFO: SMEFT_2l2q_UFO_unitary. The solution (switching to option 1) discussed in [1] solves this problem.
[1]https://cms-talk.web.cern.ch/t/gridpack-generation/6561?u=jingyan