### PR TITLE
Add support for MG bias weighting

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -34,6 +34,10 @@ make_tarball () {
     mkdir InputCards
     cp $CARDSDIR/${name}*.* InputCards
 
+    if [ -e $CARDSDIR/BIAS ]; then
+      cp -r $CARDSDIR/BIAS InputCards/
+    fi
+
     EXTRA_TAR_ARGS=""
     if [ -e $CARDSDIR/${name}_externaltarball.dat ]; then
         EXTRA_TAR_ARGS="external_tarball header_for_madspin.txt "
@@ -181,6 +185,19 @@ make_gridpack () {
       if ls $CARDSDIR/${name}*.patch; then
         echo "    WARNING: Applying custom user patch. I hope you know what you're doing!"
         cat $CARDSDIR/${name}*.patch | patch -p1
+      fi
+
+      # Copy bias module (cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias)
+      # Expected structure: 
+      # $CARDSDIR/BIAS/{module_name}/...
+      #     .../makefile (mandatory)
+      #     .../{module_name}.f (mandatory)
+      #     .../bias_dependencies (optional)
+      if [ -e $CARDSDIR/BIAS ]; then
+        echo "copying bias module folder. Current dir:"
+        pwd
+        ls -lrth
+        cp -r $CARDSDIR/BIAS/* $MGBASEDIRORIG/Template/LO/Source/BIAS
       fi
     
       LHAPDFCONFIG=`echo "$LHAPDF_DATA_PATH/../../bin/lhapdf-config"`


### PR DESCRIPTION
This PR demonstrates adding support for custom MG bias weighting modules (https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias). In this example, the bias module code should be placed under ```$CARDSDIR/BIAS/{module_name}```. As described in the MG documentation, the minimal required elements are

```
$CARDSDIR/BIAS/{module_name}/makefile
$CARDSDIR/BIAS/{module_name}/{module_name}.f
```

I don't know if this has been discussed in GEN previously (I know several others have tried bias weights in the past), so I'm happy to chat further if people think it's a useful thing to support.