### PR TITLE
fix path for new version JHUGen and LO MG5 reweighting configuration

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -96,7 +96,7 @@ prepare_reweight () {
 	mkdir -p madevent/Events/pilotrun
         cp $WORKDIR/unweighted_events.lhe.gz madevent/Events/pilotrun
         cd madevent
-        config=./madevent/Cards/me5_configuration.txt
+        config=./Cards/me5_configuration.txt # already in madevent dir
     fi
 
     # No longer necessary in gcc6

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -194,7 +194,7 @@ if [ $$jhugen = 1 ]; then
   cp -pr pdfs $${WORKDIR}/$${name}/.
 
 
-  cd ..
+  cd ../.. # Directory structure changed
 fi
 
 $patch_6 


### PR DESCRIPTION
Two updates for correcting small path issue of genproduction scripts:

1. After updating JHUGen the directory structure for running Powheg+JHUGen changes
2. Configuration path for MG5 LO reweighting is incorrect, which will lead bug for SLC6 preUL 2016 production.