### PR TITLE
Fix for issue 3137: cmsconnect worker nodes has git

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -703,7 +703,7 @@ fi
 helpers_dir=${PRODHOME%genproductions*}/genproductions/Utilities
 helpers_file=${helpers_dir}/gridpack_helpers.sh
 if [ ! -f "$helpers_file" ]; then
-  if ! [ -x "$(command -v git)" ]; then
+  if [ -f "${PRODHOME}/Utilities/gridpack_helpers.sh" ]; then
     helpers_dir=${PRODHOME}/Utilities
   else
     helpers_dir=$(git rev-parse --show-toplevel)/bin/MadGraph5_aMCatNLO/Utilities


### PR DESCRIPTION
For the issue #3137 

This issue is due to https://github.com/cms-sw/genproductions/blob/8ba8e246adc8db9625e85caa0f726c874efb87eb/bin/MadGraph5_aMCatNLO/gridpack_generation.sh#L706.
In past there was no *git* at worker nodes, so it is used to determine whether the script is running on worker nodes or local. Now worker nodes seems to have *git*. To fix this, new line will just check whether gridpack_helpers.sh exists.
