### PR TITLE
enhance cms cluster stability when condor is busy

### DIFF
--- a/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
+++ b/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
@@ -173,6 +173,7 @@ class CMSCondorCluster(CondorCluster):
             return 0
 
         q = self.query([str(id)], ["JobDuration", "MaxWallTimeMins", "LastMaxWalltimeUpdate_JobDuration"], lim=1)
+        if len(q)==0: return 0
         job_maxwalltime = q[0]["MaxWallTimeMins"] if "MaxWallTimeMins" in q[0] else 0
         if hasattr(job_maxwalltime, "eval"):
             job_maxwalltime = job_maxwalltime.eval()
@@ -361,8 +362,9 @@ class CMSCondorCluster(CondorCluster):
                             self.hold_msg = "ClusterId %s with HoldReason: %s" % (str(id), job["HoldReason"])
                             logger.warning(self.hold_msg)
                             fail += 1
-                elif status == 'C' and self.spool:
-                    self.retrieve_output(id)
+                elif status == 'C':
+                    if self.spool:
+                        self.retrieve_output(id)
                 else:
                     logger.warning("Failed condor job " + str(id) + " with status " + status)
                     logger.warning( job )


### PR DESCRIPTION
* During checking job walltime
https://github.com/cms-sw/genproductions/blob/ad40e1eaa52abc59c41ca8b8376a9da8bd7d94a9/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py#L176
When condor is busy, it may fail to query job attributes, and this line will give `IndexError: list index out of range`. I added a line to check this.

* During checking job status
https://github.com/cms-sw/genproductions/blob/ad40e1eaa52abc59c41ca8b8376a9da8bd7d94a9/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py#L364-L365
When condor is busy, the complete job may stay in queue very short time. If this happens, current code identify it as failed job which make stop the gridpack generation.