### PR TITLE
Fixed the same bug of regular expression in both request_fragment_check.py and request_fragment_check_py3.py

### DIFF
--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -1171,7 +1171,7 @@ for num in range(0,len(prepid)):
                 with open(jhufilename) as f:
                     jhu_in = f.read()
                     jhu_in = re.sub(r'(?m)^ *#.*\n?', '',jhu_in)
-                    jhu_wfe = str(re.findall(r'(.*?WriteFailedEvents.*?)',jhu_in))
+                    jhu_wfe = str(re.findall(r'(WriteFailedEvents.*(?=\s))',jhu_in))
                     if (not jhu_wfe or jhu_wfe.isspace()) or (jhu_wfe and not jhu_wfe.isspace() and "2" not in jhu_wfe): 
                         print("[ERROR] WriteFailedEvents should be set to 2 in JHUGen.input in jhugen+powheg samples.")
                         error += 1

--- a/bin/utils/request_fragment_check_py3.py
+++ b/bin/utils/request_fragment_check_py3.py
@@ -932,7 +932,7 @@ for num in range(0,len(prepid)):
                 with open(jhufilename) as f:
                     jhu_in = f.read()
                     jhu_in = re.sub(r'(?m)^ *#.*\n?', '',jhu_in)
-                    jhu_wfe = str(re.findall(r'(.*?WriteFailedEvents.*?)\n',jhu_in))
+                    jhu_wfe = str(re.findall(r'(WriteFailedEvents.*(?=\s))',jhu_in))
                     if (not jhu_wfe or jhu_wfe.isspace()) or (jhu_wfe and not jhu_wfe.isspace() and "2" not in jhu_wfe): 
                         print("[ERROR] WriteFailedEvents should be set to 2 in JHUGen.input in jhugen+powheg samples.")
                         error += 1


### PR DESCRIPTION
### THE REGULAR EXPRESSION IS WRONG
Take `request_fragment_check.py` as an example, the bug in `request_fragment_check_py3.py` is similar.
The original _regular expression_ on line 1174 in `request_fragment_check.py` is `(.*?WriteFailedEvents.*?)` , if I let `jhu_in='DecayMode1=8 DecayMode2=9 WriteFailedEvents=2 NLepMin=4'`, then we'll get `jhu_wfe="['DecayMode1=8 DecayMode2=9 WriteFailedEvents']"` (seen here ![6751650887019_ pic](https://user-images.githubusercontent.com/87391608/165083864-bab81b39-5d70-4621-b659-ec65b1543581.jpg)), which not only reserve unnecessary parameters ahead of 'WriteFailedEvents', but also **CUT OFF** `=2` after `WriteFailedEvents` **BY MISTAKE**!!!
It also caused another bug: `jhu_wfe` passed the conditional statement on line 1175, not because of `WriteFailedEvents=2`, but because there is `'2'` in `'DecayMode2'` ahead of `WriteFailedEvents=2`! So as long as we let `WriteFailedEvents` lay behind `DecayMode2`, then even `WriteFailedEvents=3` could pass the restriction on line 1175. **(Actually all the existed .input files pass the judgement on line 1175 in this way although they use the correct `WriteFailedEvents=2`, e.g. [ZZ2l2any_withtaus_filter4l_fa2AA_dec_05.input](https://github.com/cms-sw/genproductions/blob/master/bin/JHUGen/cards/decay/anomalouscouplings/ZZ2l2any_withtaus_filter4l_fa2AA_dec_05.input))**
So I commit a change on the regular expression of `(.*?WriteFailedEvents.*?)` to `(WriteFailedEvents.*(?=\s))`. Now, given that `jhu_in='DecayMode1=8 DecayMode2=9 WriteFailedEvents=2 NLepMin=4'`, then `jhu_wfe` will be `"['WriteFailedEvents=2']"` correctly (seen here ![6741650886976_ pic](https://user-images.githubusercontent.com/87391608/165083727-1239b4bb-b860-4dae-8e46-9a43b7f1634a.jpg)) instead of `"['DecayMode1=8 DecayMode2=9 WriteFailedEvents']"`.