### PR TITLE
Force nb_core = 1 for aMCatNLO reweighting

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -91,6 +91,7 @@ prepare_reweight () {
     if [ "$isnlo" -gt "0" ]; then
         cd $WORKDIR/processtmp
         config=./Cards/amcatnlo_configuration.txt
+        echo “nb_core = 1” >> $config
     else
         cd $WORKDIR/process
 	mkdir -p madevent/Events/pilotrun


### PR DESCRIPTION
Force nb_core = 1 for NLO reweighting, following up on [this thread](https://cms-talk.web.cern.ch/t/making-gridpacks-using-mgv3/9512/18).
The PR will also be merged into mg29x & mg33x branches (with other python3-related commits).

FYI @agrohsje @rgoldouz just to make sure this only matters for NLO, not LO 