### PR TITLE
Madgraph - fix colour miss-asignment for multi-jet processes in 5fs

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0037-fix_colour_missasignment.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0037-fix_colour_missasignment.patch
@@ -1,5 +1,5 @@
---- madgraph_interface.py	2019-02-04 12:19:42.000000000 +0100
-+++ madgraph_interface_patched.py	2022-06-07 16:49:04.120519000 +0200
+--- a/madgraph/interface/madgraph_interface.py	2019-02-04 12:19:42.000000000 +0100
++++ b/madgraph/interface/madgraph_interface_patched.py	2022-06-07 16:49:04.120519000 +0200
 @@ -5465,6 +5465,8 @@
                  scheme = 5
                  

--- a/bin/MadGraph5_aMCatNLO/patches/0037-fix_colour_missasignment.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0037-fix_colour_missasignment.patch
@@ -1,0 +1,11 @@
+--- madgraph_interface.py	2019-02-04 12:19:42.000000000 +0100
++++ madgraph_interface_patched.py	2022-06-07 16:49:04.120519000 +0200
+@@ -5465,6 +5465,8 @@
+                 scheme = 5
+                 
+         if scheme in [4,5]:
++            self.optimize_order(multi)
++            self._multiparticles[qcd_container] = multi
+             logger.warning("Pass the definition of \'j\' and \'p\' to %s flavour scheme." % scheme)
+             for container in ['p', 'j']:
+                 if container in defined_multiparticles:


### PR DESCRIPTION
Patch for madgraph bug reported here: https://bugs.launchpad.net/mg5amcnlo/+bug/1975733 - this bug was caused by b-jets not being properly ordered with quarks before anti-quarks for 5fs processes, leading to quarks with anti-colour, causing crashes when attempting to shower the LHEs.