### PR TITLE
[mg29x] Fix madspin LO crash + reweighting f2py compile errors

### DIFF
--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -95,44 +95,27 @@ prepare_reweight () {
         cd $WORKDIR/process
 	mkdir -p madevent/Events/pilotrun
         cp $WORKDIR/unweighted_events.lhe.gz madevent/Events/pilotrun
+        config=$PWD/madevent/Cards/me5_configuration.txt
         cd madevent
-        config=./madevent/Cards/me5_configuration.txt
     fi
 
-    # No longer necessary in gcc6
-    if [[ ${scram_arch} == *"gcc48"* ]]; then
-        echo "f2py_compiler=" `which gfortran` >> $config
-        #need to set library path or f2py won't find libraries
-        export LIBRARY_PATH=$LD_LIBRARY_PATH
-    fi
-
-    # Use f2py2 instead of f2py to install a py2 version of "rwgt2py"
-    # (occurs in CMSSW_10_6_19 where default f2py points to a py3 version)
-    if [ -e $(readlink -f `which f2py`)2 ]; then
-        echo "f2py_compiler="$(readlink -f `which f2py`)2 >> $config
+    # as of 12_0_X the default binary for f2py for python3 is f2py3
+    if [ -e $(readlink -f `which f2py3`) ]; then
+        echo "f2py_compiler_py3="$(readlink -f `which f2py3`) >> $config
     fi
 
     if [ "$isnlo" -gt "0" ]; then
         # Needed to get around python import errors
         rwgt_dir="$WORKDIR/process/rwgt"
+        set +u
         export PYTHONPATH=$rwgt_dir:$PYTHONPATH
+        set -u
         echo "0" | ./bin/aMCatNLO --debug reweight pilotrun
     else
         echo "0" | ./bin/madevent --debug reweight pilotrun
     fi
 
-    # Explicitly compile all subprocesses to avoid
-    # compilation on the cluster
-    for file in $(ls -d rwgt/*/SubProcesses/P*); do
-        echo "Compiling subprocess $(basename $file)"
-        cd $file
-        for i in 2 3; do
-            MENUM=$i make matrix${i}py.so >& /dev/null
-            echo "Library MENUM=$i compiled with status $?"
-        done
-        cd -
-    done
-    cd ..      
+    cd .. 
 }
 
 # Extract decay width in reweighting

--- a/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/gridpack_helpers.sh
@@ -91,6 +91,7 @@ prepare_reweight () {
     if [ "$isnlo" -gt "0" ]; then
         cd $WORKDIR/processtmp
         config=./Cards/amcatnlo_configuration.txt
+        echo “nb_core = 1” >> $config
     else
         cd $WORKDIR/process
 	mkdir -p madevent/Events/pilotrun

--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -572,7 +572,6 @@ make_gridpack () {
       
       echo "cleaning temporary output"
       mv $WORKDIR/processtmp/pilotrun_gridpack.tar.gz $WORKDIR/
-      mv $WORKDIR/processtmp/Events/pilotrun/unweighted_events.lhe.gz $WORKDIR/
       rm -rf processtmp
       mkdir process
       cd process
@@ -580,6 +579,11 @@ make_gridpack () {
       tar -xzf $WORKDIR/pilotrun_gridpack.tar.gz
       echo "cleaning temporary gridpack"
       rm $WORKDIR/pilotrun_gridpack.tar.gz
+
+      # as of mg29x, it does not generate any event if 'True = gridpack' in the run card
+      # generate a few events manually
+      ./run.sh 1000 234567 # nevents seed
+      mv events.lhe.gz $WORKDIR/unweighted_events.lhe.gz
 
       # precompile reweighting if necessary
       if [ -e $CARDSDIR/${name}_reweight_card.dat ]; then


### PR DESCRIPTION
The PR consists of two fixes:
1. As of mg29x the LO gridpack generation does not generate any event when `True = gridpack`, this leads to a crash at the Madspin step. This can be fixed by generating a small number of events as before.
2. `f2py` compiler option had been changed to `f2py3` after migrating to the python3, this can fix a crash during the compile step of the reweighting on mg29x & mg33x.

Follow up of https://cms-talk.web.cern.ch/t/making-gridpacks-using-mgv3/9512