### PR TITLE
DY MiNNLO 13p6TeV

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/WminusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm-powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/WminusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm-powheg.input
@@ -1,0 +1,88 @@
+! W^+ + jet production parameter
+idvecbos -24
+vdecaymode 2
+
+CKM_Vud 0.97446
+CKM_Vus 0.22452
+CKM_Vub 0.00365
+CKM_Vcd 0.22438
+CKM_Vcs 0.97359
+CKM_Vcb 0.04214
+CKM_Vtd 0.00896
+CKM_Vts 0.04133
+CKM_Vtb 0.999105
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13600d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1

--- a/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/WplusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm-powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/WplusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm-powheg.input
@@ -1,0 +1,88 @@
+! W^+ + jet production parameter
+idvecbos 24
+vdecaymode 2
+
+CKM_Vud 0.97446
+CKM_Vus 0.22452
+CKM_Vub 0.00365
+CKM_Vcd 0.22438
+CKM_Vcs 0.97359
+CKM_Vcb 0.04214
+CKM_Vtd 0.00896
+CKM_Vts 0.04133
+CKM_Vtb 0.999105
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_W_mass 1d0    ! Lower mass cut-off for W boson production
+max_W_mass 13600d0   ! Upper mass cut-off for W boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1

--- a/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/ZJToMuMu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/ZJToMuMu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 50d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 13600d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/minnloHelper_Run3.sh
+++ b/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/minnloHelper_Run3.sh
@@ -57,7 +57,8 @@ case $WHAT in
             DIR=${PROC}-${SUFFIX}
             cd ${DIR}/POWHEG-BOX/${PROC:0:1}j/${PROC:0:1}jMiNNLO
             make
-            cd ..
+            cd -
+            cp -v ${DIR}/POWHEG-BOX/${PROC:0:1}j/${PROC:0:1}jMiNNLO/pwhg_main ${DIR}/
         done
     ;;
     

--- a/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/minnloHelper_Run3.sh
+++ b/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV/minnloHelper_Run3.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+trap "exit" INT
+
+WHAT=$1;
+PARAM=$2;
+if [ "$#" -lt 1 ]; then
+    echo "minnloHelper_Run3.sh <OPTION>";
+    exit 1;
+fi
+
+NJOBS=200
+SVN=3900
+ARCH=slc7_amd64_gcc10
+CMSSW=CMSSW_12_3_1
+SUFFIX=powheg-MiNNLO31-svn${SVN}-ew-rwl6-j${NJOBS}-st2fix-ana-hoppetweights-ymax20-pdf2
+
+PROCS=(ZJToMuMu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139 WplusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm WminusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm)
+
+case $WHAT in
+
+    SLC6 )
+        cmssw-cc6 --command-to-run ./$0 $PARAM
+    ;;
+    
+    SLC7 )
+        cmssw-cc7 --command-to-run ./$0 $PARAM
+    ;;
+    
+    INIT )
+        ln -s ../../genproductions/bin/Powheg/*.py .
+        ln -s ../../genproductions/bin/Powheg/*.sh .
+        ln -s ../../genproductions/bin/Powheg/patches .
+        ln -s ../../genproductions/bin/Powheg/Templates .
+        ln -s ../../genproductions/bin/Powheg/Utilities .
+        ln -s ../../genproductions/bin/Powheg/production/Run3/13p6TeV/DY_MiNNLO_NNPDF31_13p6TeV .
+    ;;
+    
+    PRINT )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC}
+        done
+    ;;
+    
+    COMPILE )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            python ./run_pwg_condor.py -p 0 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -d 1 --svn ${SVN}
+        done
+    ;;
+    
+    RECOMPILE )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            cd ${DIR}/POWHEG-BOX/${PROC:0:1}j/${PROC:0:1}jMiNNLO
+            make
+            cd ..
+        done
+    ;;
+    
+    ONESHOT )
+        for PROC in ${PROCS[@]}
+        do
+            python ./run_pwg_condor.py -p f -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -d 1 --svn ${SVN}
+        done
+    ;;
+
+    GRIDS )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 123 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -q 1:longlunch,2:workday,3:longlunch --step3pilot -x 3 -j ${NJOBS} --slc ${ARCH:3:1}
+        done
+    ;;
+    
+    DAG )
+        for PROC in ${PROCS[@]}
+        do
+            if [ ! -f "${PROC}-${SUFFIX}/pwg-st3-0000-stat.dat" ]; then
+                condor_submit_dag run_${PROC}-${SUFFIX}.dag
+            fi
+        done
+    ;;
+    
+    LONGGRIDS )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 123 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -q 1:workday,2:tomorrow,3:longlunch --step3pilot -x 3 -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS1 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 1 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -q workday -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS2 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 2 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -q workday -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS3 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python ./run_pwg_parallel_condor.py -p 3 -i DY_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} -q longlunch -j ${NJOBS} --step3pilot &
+        done
+    ;;
+    
+    XS )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC}
+            cat ${PROC}-${SUFFIX}/pwg-st3-0000-stat.dat | grep total
+        done
+    ;;
+    
+    PACK )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            python ./run_pwg_condor.py -p 9 -m ${PROC:0:1}j -f ${PROC}-${SUFFIX} 
+        done
+        ./minnloHelper_Run3.sh PACK_REDUCED
+        ./minnloHelper_Run3.sh PACK_NORWL
+    ;;
+    
+    TEST )
+        mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            /usr/bin/time -v ./runcmsgrid.sh 20 1 1 &
+            cd ..
+        done
+    ;;
+    
+    LONGTEST )
+        mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            /usr/bin/time -v ./runcmsgrid.sh 800 1 1 &
+            cd ..
+        done
+    ;;
+    
+    PACK_REDUCED )
+        mkdir PACK_REDUCED; cd PACK_REDUCED
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            cp ../../pwg-rwl-reduced.dat pwg-rwl.dat
+            tar zcf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz *
+            cd ..
+        done
+    ;;
+    
+    TEST_REDUCED )
+        cd PACK_REDUCED; mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz
+            ./runcmsgrid.sh 10 1 1 &
+            cd ..
+        done
+    ;;
+    
+    PACK_LEP )
+        mkdir PACK_LEP; cd PACK_LEP
+        for PROC in ${PROCS[@]}
+        do
+            for LEP in E Tau
+            do
+                NEWPROC=${PROC//Mu/$LEP}
+                DIR=${NEWPROC}-${SUFFIX}
+                rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+                tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+                if [ "$LEP" == "E" ]; then
+                    LEPID=1
+                elif [ "$LEP" == "Tau" ]; then
+                    LEPID=3
+                fi
+                sed -i "s/vdecaymode .*/vdecaymode ${LEPID}/g" powheg.input
+                tar zcf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${NEWPROC}-${SUFFIX}.tgz *
+                cd ..
+            done
+        done
+    ;;
+    
+    COPY_LEP )
+        cd PACK_LEP
+        for PROC in ${PROCS[@]}
+        do
+            for LEP in E Tau
+            do
+                NEWPROC=${PROC//Mu/$LEP}
+                cp -p -v ${PROC:0:1}j_${ARCH}_${CMSSW}_${NEWPROC}-${SUFFIX}.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            done
+        done
+    ;;
+    
+    PACK_NORWL )
+        mkdir PACK_REDUCED; cd PACK_REDUCED
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}-norwl
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            sed -i '/rwl_file/d' powheg.input
+            sed -i '/MINNLO="true"/d' runcmsgrid.sh
+            tar zcf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz *
+            cd ..
+        done
+    ;;
+    
+    TEST_NORWL )
+        cd PACK_REDUCED; mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}-norwl
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz
+            ./runcmsgrid.sh 5 1 1 &
+            cd ..
+        done
+    ;;
+    
+    COPY )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            echo ${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz
+            echo ${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz
+            cp -p -v ${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            cp -p -v PACK_REDUCED/${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            cp -p -v PACK_REDUCED/${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+        done
+    ;;
+    
+    COPY_GRIDS )
+        OLDPATH=/afs/cern.ch/work/m/mseidel/generator/CMSSW_10_2_23/src/
+        OLDSUFFIX=powheg-MiNNLO31-svn3900-ew-rwl6-j${NJOBS}-st2fix-ana-hoppetweights-ymax20
+        for PROC in ${PROCS[@]}
+        do
+            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.dat ${PROC}-${SUFFIX}/
+            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.top ${PROC}-${SUFFIX}/
+        done
+    ;;
+    
+    MAKE_MASSRWGT )
+        mkdir PACK_MASSRWGT; cd PACK_MASSRWGT
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            PROCSPLIT=(`echo ${PROC} | tr "-" "\n"`)
+            cp ../../DY_MiNNLO_NNPDF31_13p6TeV/lheWriter_cfg.py .
+            sed -i "s/ZJToMuMu/${PROCSPLIT[0]}/g" lheWriter_cfg.py
+            diff ../../DY_MiNNLO_NNPDF31_13p6TeV/lheWriter_cfg.py lheWriter_cfg.py
+            cp ../../DY_MiNNLO_NNPDF31_13p6TeV/runcmsgrid_addMassWeights.sh runcmsgrid.sh
+            sed -i "s/process=.*/process=\"${PROC:0:1}j\"/g" runcmsgrid.sh
+            sed -i s/SCRAM_ARCH_VERSION_REPLACE/${ARCH}/g runcmsgrid.sh
+            sed -i s/CMSSW_VERSION_REPLACE/${CMSSW}/g runcmsgrid.sh
+            diff ../../DY_MiNNLO_NNPDF31_13p6TeV/runcmsgrid_addMassWeights.sh runcmsgrid.sh
+            tar zcf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-addmassweights.tgz *
+            cd ..
+        done
+    ;;
+    
+    MAKE_MASSRWGT_LEP )
+        mkdir PACK_MASSRWGT; cd PACK_MASSRWGT
+        for PROC in ${PROCS[@]}
+        do
+            for LEP in E Tau
+            do
+                NEWPROC=${PROC//Mu/$LEP}
+                DIR=${NEWPROC}-${SUFFIX}
+                rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+                tar -xzf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-addmassweights.tgz
+                if [ "$LEP" == "E" ]; then
+                    LEPID=1
+                elif [ "$LEP" == "Tau" ]; then
+                    LEPID=3
+                fi
+                sed -i "s/vdecaymode .*/vdecaymode ${LEPID}/g" powheg.input
+                PROCSPLIT=(`echo ${PROC} | tr "-" "\n"`)
+                NEWPROCSPLIT=(`echo ${NEWPROC} | tr "-" "\n"`)
+                sed -i "s/${PROCSPLIT[0]}/${NEWPROCSPLIT[0]}/g" lheWriter_cfg.py
+                diff ../../DY_MiNNLO_NNPDF31_13p6TeV/lheWriter_cfg.py lheWriter_cfg.py
+                diff ../../DY_MiNNLO_NNPDF31_13p6TeV/runcmsgrid.sh runcmsgrid.sh
+                tar zcf ../${PROC:0:1}j_${ARCH}_${CMSSW}_${NEWPROC}-${SUFFIX}-addmassweights.tgz *
+                cd ..
+            done
+        done
+    ;;
+    
+    COPY_MASSRWGT )
+        cd PACK_MASSRWGT
+        for PROC in ${PROCS[@]}
+        do
+            for LEP in E Mu Tau
+            do
+                NEWPROC=${PROC//Mu/$LEP}
+                cp -p -v ${PROC:0:1}j_${ARCH}_${CMSSW}_${NEWPROC}-${SUFFIX}-addmassweights.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            done
+        done
+    ;;
+    
+
+esac

--- a/bin/Powheg/production/pre2017/13TeV/DY_MiNNLO_NNPDF31_13TeV/minnloHelper.sh
+++ b/bin/Powheg/production/pre2017/13TeV/DY_MiNNLO_NNPDF31_13TeV/minnloHelper.sh
@@ -60,7 +60,8 @@ case $WHAT in
             DIR=${PROC}-${SUFFIX}
             cd ${DIR}/POWHEG-BOX/${PROC:0:1}j/${PROC:0:1}jMiNNLO
             make
-            cd ..
+            cd -
+            cp -v ${DIR}/POWHEG-BOX/${PROC:0:1}j/${PROC:0:1}jMiNNLO/pwhg_main ${DIR}/
         done
     ;;
     


### PR DESCRIPTION
DY MiNNLO for 13.6 TeV, these are the NNLO cross sections calculated during gridpack production:
```
ZJToMuMu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139
  total (btilde+remnants) cross section in pb   2103.8137919947922      +-  0.56983756670429542
WplusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm
  total (btilde+remnants) cross section in pb   12292.986509111422      +-   6.5866707599607119
WminusJToMuNu-13p6TeV-suggested-nnpdf31-ncalls-doublefsr-q139-ckm
  total (btilde+remnants) cross section in pb   9134.3028259480725      +-   3.2039854089865671
```