### PR TITLE
Add cards for Higgs+2jet CP gridpack production for Run 3

### DIFF
--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -131,7 +131,7 @@ if [ $$keepTop == '1' ]; then
     echo 'Packing...' $${WORKDIR}'/'$${process}'_'$${SCRAM_ARCH}'_'$${CMSSW_VERSION}'_'$${folderName}'.tgz'
     tar zcf $${WORKDIR}'/'$${process}'_'$${SCRAM_ARCH}'_'$${CMSSW_VERSION}'_'$${folderName}'.tgz' * --exclude=POWHEG-BOX --exclude=powhegbox*.tar.gz --exclude=*.lhe --exclude=run_*.sh --exclude=*temp --exclude=pwgbtlupb-*.dat --exclude=pwgrmupb-*.dat --exclude=run_*.out --exclude=run_*.err --exclude=run_*.log --exclude=minlo-run --exclude=dynnlo* $$exclude_extra
 else
-  if [ $$process == 'WWJ']; then
+  if [ $$process == 'WWJ' ]; then
     echo 'Preparing WWJ gridpack'
     echo 'Packing...' $${WORKDIR}'/'$${process}'_'$${SCRAM_ARCH}'_'$${CMSSW_VERSION}'_'$${folderName}'.tar.xz'
     tar -cJpsf $${WORKDIR}'/'$${process}'_'$${SCRAM_ARCH}'_'$${CMSSW_VERSION}'_'$${folderName}'.tar.xz' * --exclude=POWHEG-BOX --exclude=powhegbox*.tar.gz --exclude=*.top --exclude=*.lhe --exclude=run_*.sh --exclude=*temp --exclude=pwgbtlupb-*.dat --exclude=pwgrmupb-*.dat --exclude=run_*.out --exclude=run_*.err --exclude=run_*.log --exclude=minlo-run --exclude=dynnlo*

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -164,13 +164,16 @@ fi
 if [ `grep particle_identif pwhg_analysis-dummy.f` = ""]; then
    cp ../pwhg_analysis-dummy.f .
 fi
-sed -i -e "s#PWHGANAL[ \t]*=[ \t]*#\#PWHGANAL=#g" Makefile
-sed -i -e "s#ANALYSIS[ \t]*=[ \t]*#\#ANALYSIS=#g" Makefile
-sed -i -e "s#_\#ANALYSIS*#_ANALYSIS=#g" Makefile
+if [[ $$process != "WWJ" ]]; then
+  echo "test!!!"
+  sed -i -e "s#PWHGANAL[ \t]*=[ \t]*#\#PWHGANAL=#g" Makefile
+  sed -i -e "s#ANALYSIS[ \t]*=[ \t]*#\#ANALYSIS=#g" Makefile
+  sed -i -e "s#_\#ANALYSIS*#_ANALYSIS=#g" Makefile
+  sed -i -e "s#pwhg_bookhist.o# #g" Makefile
+  sed -i -e "s#pwhg_bookhist-new.o# #g" Makefile
+  sed -i -e "s#pwhg_bookhist-multi.o# #g" Makefile
+fi
 sed -i -e "s#LHAPDF_CONFIG[ \t]*=[ \t]*#\#LHAPDF_CONFIG=#g" Makefile
-sed -i -e "s#pwhg_bookhist.o# #g" Makefile
-sed -i -e "s#pwhg_bookhist-new.o# #g" Makefile
-sed -i -e "s#pwhg_bookhist-multi.o# #g" Makefile
 $patch_4 
 
 

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -164,7 +164,13 @@ fi
 if [ `grep particle_identif pwhg_analysis-dummy.f` = ""]; then
    cp ../pwhg_analysis-dummy.f .
 fi
+sed -i -e "s#PWHGANAL[ \t]*=[ \t]*#\#PWHGANAL=#g" Makefile
+sed -i -e "s#ANALYSIS[ \t]*=[ \t]*#\#ANALYSIS=#g" Makefile
+sed -i -e "s#_\#ANALYSIS*#_ANALYSIS=#g" Makefile
 sed -i -e "s#LHAPDF_CONFIG[ \t]*=[ \t]*#\#LHAPDF_CONFIG=#g" Makefile
+sed -i -e "s#pwhg_bookhist.o# #g" Makefile
+sed -i -e "s#pwhg_bookhist-new.o# #g" Makefile
+sed -i -e "s#pwhg_bookhist-multi.o# #g" Makefile
 $patch_4 
 
 

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -165,7 +165,6 @@ if [ `grep particle_identif pwhg_analysis-dummy.f` = ""]; then
    cp ../pwhg_analysis-dummy.f .
 fi
 if [[ $$process != "WWJ" ]]; then
-  echo "test!!!"
   sed -i -e "s#PWHGANAL[ \t]*=[ \t]*#\#PWHGANAL=#g" Makefile
   sed -i -e "s#ANALYSIS[ \t]*=[ \t]*#\#ANALYSIS=#g" Makefile
   sed -i -e "s#_\#ANALYSIS*#_ANALYSIS=#g" Makefile

--- a/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/Instructions.md
+++ b/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/Instructions.md
@@ -1,0 +1,43 @@
+Instructions for producing HJJ CP samples
+
+## Powheg input files
+
+    The following input files are used for producing gridpacks:
+
+    SM without bornsuppfact: examples/V2/X0jj_13p6TeV/X0jj_SM.input 
+    
+    PS without bornsuppfact: examples/V2/X0jj_13p6TeV/X0jj_PS.input 
+    
+    MM without bornsuppfact: examples/V2/X0jj_13p6TeV/X0jj_MM.input 
+
+    Note the bornsuppfact option ensures that most of the events are produced with additional jets, the generator weight is then adjusted to give the correct distributions, however, we found that this resulted in a few events with very large weights passing the final selections and as this results in large bbb uncertainties in some cases we decided to remove it
+  
+
+## Producing gridpacks
+
+    Run stage 0 locally:
+
+       python ./run_pwg_condor.py -p 0 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 
+
+    Run stage 1 on condor. Need to execute this stage 5 times, waiting for the jobs to all finish after each submission:
+    
+        python ./run_pwg_condor.py -p 1 -x 1 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 35
+        python ./run_pwg_condor.py -p 1 -x 2 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 35
+        python ./run_pwg_condor.py -p 1 -x 3 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 35
+        python ./run_pwg_condor.py -p 1 -x 4 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 35
+        python ./run_pwg_condor.py -p 1 -x 5 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 35
+
+    Run stage 2 on condor:
+
+    python ./run_pwg_condor.py -p 2 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 200
+
+    Run stage 3 on condor:
+
+    python ./run_pwg_condor.py -p 3 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1 -q workday -j 10
+
+    Run stage 9 locally:
+
+    python ./run_pwg_condor.py -p 9 -i examples/V2/X0jj_13p6TeV/X0jj_SM.input -m X0jj -f X0jj_SM_HTT_13p6TeV_v1
+
+    Note that for stage 9 in order to keep the gridpacks from being too large we dont use the -k 1 option, and we also modified Templates/createTarBall_template.sh adding the exclude_extra parameter to remove some of the .dat files that are produced during the gridpack generation that aren't needed in the tarball 
+

--- a/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_MM.input
+++ b/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_MM.input
@@ -1,0 +1,108 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0    ! energy of beam 1
+ebeam2 6800d0    ! energy of beam 2
+! ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+! ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using LHA pdfs
+lhans1 325300      ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300      ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+hmass  125             ! Higgs mass
+hwidth 0.00409d0  ! Higgs width
+
+bwcutoff 15       ! Mass window is hmass +- bwcutoff*hwidth
+
+#higgsfixedwidth 1 ! (default 0), If 1 uses standard, fixed width Breith-Wigner
+                   ! formula, if 0 it uses the running width Breit-Wigner
+
+#ckkwscalup 1 ! (default 1), If 1 compute the scalup scale for subsequent
+              ! shower using the smallest kt in the final state;
+              ! If 0, use the standard POWHEG BOX scalup
+
+#runningscales 1  ! (default 0), if 0 use hmass as central
+                  ! factorization and renormalization scale;
+                  ! if 1 use the Ht scale
+
+# fullphsp 1         ! use ISR/FSR phase space parametrization, default 0
+
+ncall1 30000   ! number of calls for initializing the integration grid
+itmx1    1     ! number of iterations for initializing the integration grid
+ncall2 5000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+
+#bornktmin 0.26    ! Minimum transverse momentum if the Higgs at the underlying Born level
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+
+# Option for alternative splitting R-> R_s + R_f
+# These were study to see the effect on the unphysical negative value of the a0
+# angular correlation coefficients
+# bornzerodamp 1    ! Turn this on (without this the program behaves as usual)
+# new_damp 1        ! R_s = max(0,min(1, R_app/R)), where R_app is the soft collinear approximation to R, R_app = R_soft + R_coll - R_soft_coll
+# hnew_damp 0.5     ! if this flag appears together with new_damp 1, then R_app -> R_app * h^2 * m^2 / ( h^2 * m^2 + pt2 ), where
+                    ! h is the value of hnew_damp, m is the mass of the vector boson, and pt2 is the square of its transverse momentum
+# hdamp 1.0         ! if this flag appears, R_s -> R_s *  h^2 * m^2 / ( h^2 * m^2 + pt2 ), where h is the value of hdamp.
+                    ! The following combination seem to yield a0 consistent with non-negative values:
+                    ! new_damp 1 + hdamp 0.25; new_damp 1 + hnew_damp 0.5 ;
+                    ! Looking at the Bornzerodamp.f routine should clarify all doubts on these options.
+                    ! You can experiment with other values. Remember: too small  hnew_damp and/or hdamp factors can cause troubles,
+                    ! check that you get a nice sudakov shape of the vector boson pt.
+
+ withnegweights 1   ! (1 default) If 1 output negative weighted events.
+                   ! If 0 descard them
+
+# reweighting info
+storeinfo_rwgt 1
+# compute_rwgt 1
+lhrwgt_id 'nominal'
+
+
+#bornsuppfact 30  ! if minlo is active, set it to zero
+
+# use minlo
+minlo   1
+
+
+# fast btilde bound
+fastbtlbound 1
+# if parallel, save in a file
+storemintupb 1
+
+#btildevirt  0    ! no virtual
+
+
+
+MGcosa -0.707107d0    	  ! cosine of alpha; alpha parametrises the CP nature
+
+

--- a/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_PS.input
+++ b/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_PS.input
@@ -1,0 +1,108 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0    ! energy of beam 1
+ebeam2 6800d0    ! energy of beam 2
+! ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+! ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using LHA pdfs
+lhans1 325300      ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300      ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+hmass  125             ! Higgs mass
+hwidth 0.00409d0  ! Higgs width
+
+bwcutoff 15       ! Mass window is hmass +- bwcutoff*hwidth
+
+#higgsfixedwidth 1 ! (default 0), If 1 uses standard, fixed width Breith-Wigner
+                   ! formula, if 0 it uses the running width Breit-Wigner
+
+#ckkwscalup 1 ! (default 1), If 1 compute the scalup scale for subsequent
+              ! shower using the smallest kt in the final state;
+              ! If 0, use the standard POWHEG BOX scalup
+
+#runningscales 1  ! (default 0), if 0 use hmass as central
+                  ! factorization and renormalization scale;
+                  ! if 1 use the Ht scale
+
+# fullphsp 1         ! use ISR/FSR phase space parametrization, default 0
+
+ncall1 30000   ! number of calls for initializing the integration grid
+itmx1    1     ! number of iterations for initializing the integration grid
+ncall2 5000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+
+#bornktmin 0.26    ! Minimum transverse momentum if the Higgs at the underlying Born level
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+
+# Option for alternative splitting R-> R_s + R_f
+# These were study to see the effect on the unphysical negative value of the a0
+# angular correlation coefficients
+# bornzerodamp 1    ! Turn this on (without this the program behaves as usual)
+# new_damp 1        ! R_s = max(0,min(1, R_app/R)), where R_app is the soft collinear approximation to R, R_app = R_soft + R_coll - R_soft_coll
+# hnew_damp 0.5     ! if this flag appears together with new_damp 1, then R_app -> R_app * h^2 * m^2 / ( h^2 * m^2 + pt2 ), where
+                    ! h is the value of hnew_damp, m is the mass of the vector boson, and pt2 is the square of its transverse momentum
+# hdamp 1.0         ! if this flag appears, R_s -> R_s *  h^2 * m^2 / ( h^2 * m^2 + pt2 ), where h is the value of hdamp.
+                    ! The following combination seem to yield a0 consistent with non-negative values:
+                    ! new_damp 1 + hdamp 0.25; new_damp 1 + hnew_damp 0.5 ;
+                    ! Looking at the Bornzerodamp.f routine should clarify all doubts on these options.
+                    ! You can experiment with other values. Remember: too small  hnew_damp and/or hdamp factors can cause troubles,
+                    ! check that you get a nice sudakov shape of the vector boson pt.
+
+ withnegweights 1   ! (1 default) If 1 output negative weighted events.
+                   ! If 0 descard them
+
+# reweighting info
+storeinfo_rwgt 1
+# compute_rwgt 1
+lhrwgt_id 'nominal'
+
+
+#bornsuppfact 30  ! if minlo is active, set it to zero
+
+# use minlo
+minlo   1
+
+
+# fast btilde bound
+fastbtlbound 1
+# if parallel, save in a file
+storemintupb 1
+
+#btildevirt  0    ! no virtual
+
+
+
+MGcosa 0d0   	  ! cosine of alpha; alpha parametrises the CP nature
+
+

--- a/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_SM.input
+++ b/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/X0jj_SM.input
@@ -1,0 +1,108 @@
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0    ! energy of beam 1
+ebeam2 6800d0    ! energy of beam 2
+! ndns1 131         ! pdf set for hadron 1 (mlm numbering)
+! ndns2 131         ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using LHA pdfs
+lhans1 325300      ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300      ! pdf set for hadron 2 (LHA numbering)	
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5  0.25 ! for not equal pdf sets 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+hmass  125             ! Higgs mass
+hwidth 0.00409d0  ! Higgs width
+
+bwcutoff 15       ! Mass window is hmass +- bwcutoff*hwidth
+
+#higgsfixedwidth 1 ! (default 0), If 1 uses standard, fixed width Breith-Wigner
+                   ! formula, if 0 it uses the running width Breit-Wigner
+
+#ckkwscalup 1 ! (default 1), If 1 compute the scalup scale for subsequent
+              ! shower using the smallest kt in the final state;
+              ! If 0, use the standard POWHEG BOX scalup
+
+#runningscales 1  ! (default 0), if 0 use hmass as central
+                  ! factorization and renormalization scale;
+                  ! if 1 use the Ht scale
+
+# fullphsp 1         ! use ISR/FSR phase space parametrization, default 0
+
+ncall1 30000   ! number of calls for initializing the integration grid
+itmx1    1     ! number of iterations for initializing the integration grid
+ncall2 5000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 200000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+#bornonly   1      ! (default 0) if 1 do Born only
+#smartsig   0      ! (default 1) remember equal amplitudes (0 do not remember)
+#ptsqmin    0.8    ! (default 0.8 GeV) minimum pt for generation of radiation
+#charmthr   1.5    ! (default 1.5 GeV) charm treshold for gluon splitting 
+#bottomthr  5.0    ! (default 5.0 GeV) bottom treshold for gluon splitting
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+#charmthrpdf  1.5  ! (default 1.5 GeV) pdf charm treshold
+#bottomthrpdf 5.0  ! (default 5.0 GeV) pdf bottom treshold
+
+#bornktmin 0.26    ! Minimum transverse momentum if the Higgs at the underlying Born level
+
+iseed    SEED    ! initialize random number sequence 
+#rand1     -1      ! initialize random number sequence 
+#rand2     -1      ! initialize random number sequence 
+
+
+# Option for alternative splitting R-> R_s + R_f
+# These were study to see the effect on the unphysical negative value of the a0
+# angular correlation coefficients
+# bornzerodamp 1    ! Turn this on (without this the program behaves as usual)
+# new_damp 1        ! R_s = max(0,min(1, R_app/R)), where R_app is the soft collinear approximation to R, R_app = R_soft + R_coll - R_soft_coll
+# hnew_damp 0.5     ! if this flag appears together with new_damp 1, then R_app -> R_app * h^2 * m^2 / ( h^2 * m^2 + pt2 ), where
+                    ! h is the value of hnew_damp, m is the mass of the vector boson, and pt2 is the square of its transverse momentum
+# hdamp 1.0         ! if this flag appears, R_s -> R_s *  h^2 * m^2 / ( h^2 * m^2 + pt2 ), where h is the value of hdamp.
+                    ! The following combination seem to yield a0 consistent with non-negative values:
+                    ! new_damp 1 + hdamp 0.25; new_damp 1 + hnew_damp 0.5 ;
+                    ! Looking at the Bornzerodamp.f routine should clarify all doubts on these options.
+                    ! You can experiment with other values. Remember: too small  hnew_damp and/or hdamp factors can cause troubles,
+                    ! check that you get a nice sudakov shape of the vector boson pt.
+
+ withnegweights 1   ! (1 default) If 1 output negative weighted events.
+                   ! If 0 descard them
+
+# reweighting info
+storeinfo_rwgt 1
+# compute_rwgt 1
+lhrwgt_id 'nominal'
+
+
+#bornsuppfact 30  ! if minlo is active, set it to zero
+
+# use minlo
+minlo   1
+
+
+# fast btilde bound
+fastbtlbound 1
+# if parallel, save in a file
+storemintupb 1
+
+#btildevirt  0    ! no virtual
+
+
+
+MGcosa 1d0   	  ! cosine of alpha; alpha parametrises the CP nature
+
+

--- a/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/mg5.cmd
+++ b/bin/Powheg/production/Run3/13p6TeV/X0jj_13p6TeV/mg5.cmd
@@ -1,0 +1,6 @@
+import model HC_NLO_X0_UFO-heft
+generate p p > x0 j j / t [QCD]
+install ninja
+install collier
+output X0jj
+exit


### PR DESCRIPTION
- This is adding the equivalent cards used for the Run2 production for Run3. The energy is changed to 13.6 TeV but all other options in the cards are kept the same. PR for Run2 production is this one: https://github.com/cms-sw/genproductions/pull/3207
- After producing the Run3 gridpacks, there was an issue producing events with runcmsgrid.sh. Only 1 event is produced even when asking for more than 1 and then it gives the error "pwhg_main error: Did not produce expected number of events". I traced this issue back to the modification made to runGetSource_template.sh in this commit: https://github.com/cms-sw/genproductions/commit/0f6bf5947251db98672c6e4ccef6a12ad0b58331#diff-083c2ecbee2516fb3aaf4cb519eea4bbeb462666352937c4562fb5f9ed11d662. After I added back the sed commands it seems to work. I have therefore reverted this change in the PR, but as a non-expert I don't know if there is some other reason to remove these lines, and perhaps a different fix is needed..?