### PR TITLE
Gen fragment for Wprime ->l nu (l=e/mu) at 13.6 TeV in 2022

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_1000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_1000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 1000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_1600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_1600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 1600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_2000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_2000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 2000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_200_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_200_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 200',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_2600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_2600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 2600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_3000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_3000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 3000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_3600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_3600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 3600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_4000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_4000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 4000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_400_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_400_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 400',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_4600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_4600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 4600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_5000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_5000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 5000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_5600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_5600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 5600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_6000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_6000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 6000',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_6600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToENu/WprimeToENu_M_6600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 6600',
+                        '34:onMode = off',
+                        '34:onIfAny = 11,12',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_1000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_1000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 1000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_1600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_1600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 1600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_2000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_2000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 2000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_200_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_200_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 200',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_2600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_2600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 2600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_3000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_3000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 3000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_3600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_3600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 3600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_4000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_4000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 4000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_400_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_400_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 400',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_4600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_4600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 4600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_5000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_5000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 5000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_5600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_5600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 5600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_6000_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_6000_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 6000',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_6600_TuneCP5_13p6TeV_pythia8_cfi.py
+++ b/genfragments/ThirteenPointSixTeV/Wprime/WprimeToMuNu/WprimeToMuNu_M_6600_TuneCP5_13p6TeV_pythia8_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+        maxEventsToPrint = cms.untracked.int32(1),
+        pythiaPylistVerbosity = cms.untracked.int32(1),
+        filterEfficiency = cms.untracked.double(1),
+        pythiaHepMCVerbosity = cms.untracked.bool(False),
+        comEnergy = cms.double(13600.0),
+
+        PythiaParameters = cms.PSet(
+            pythia8CommonSettingsBlock,
+            pythia8CP5SettingsBlock,
+            processParameters = cms.vstring(
+                        'NewGaugeBoson:ffbar2Wprime = on',
+                        '34:m0 = 6600',
+                        '34:onMode = off',
+                        '34:onIfAny = 13,14',
+                        ),
+            parameterSets = cms.vstring(
+                        'pythia8CommonSettings',
+                        'pythia8CP5Settings',
+                        'processParameters'
+                        )
+            )
+)
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Gen fragment for the process Wprime ->l nu (l=e/mu) at 13.6 TeV in 2022.
Same as Run-2 fragment except the center of mass energy. [link](https://github.com/cms-sw/genproductions/tree/master/genfragments/ThirteenTeV/Wprime)
Please check these fragments and let us know if these need to be fixed.