### PR TITLE
Compile processes in subdirectories

### DIFF
--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -1,12 +1,21 @@
 export name=$folderName
 export cardInput=$powInputName
-export process=$process
+export processtemp=$processtemp
 export noPdfCheck=$noPdfCheck
 export WORKDIR=$rootfolder
 export patches_dir=$patches_dir 
 # Release to be used to define the environment and the compiler needed
 export RELEASE=$${CMSSW_VERSION}
 export jhugenversion="v7.5.2" 
+
+### Check if subdirectory
+process=$$(echo $${processtemp} | cut -f1 -d "/")
+subprocess=$$(echo $${processtemp} | cut -f2 -d "/")
+echo "Process is: $${process}";
+if [[ $${process} = $${subprocess} ]]; then
+  subprocess=''
+fi
+echo "Sub-process (if available) is: $${subprocess}";
 
 cd $$WORKDIR
 pwd
@@ -89,7 +98,7 @@ if [ -e POWHEG-BOX/$${process}.tgz ]; then
   cd -
 else
   cd POWHEG-BOX/
-  svn co --revision $svnRev --username anonymous --password anonymous $svnProc/$process
+  svn co --revision $svnRev --username anonymous --password anonymous $svnProc/$${process}
   cd -
 fi
 
@@ -103,7 +112,7 @@ sed -i -e "s#500#1350#g"  POWHEG-BOX/include/pwhg_rwl.h
 
 echo $${POWHEGSRC} > VERSION
 
-cd POWHEG-BOX/$${process}
+cd POWHEG-BOX/$${process}/$${subprocess}
 
 # This is just to please gcc 4.8.1
 mkdir -p include

--- a/bin/Powheg/Utilities/helpers.py
+++ b/bin/Powheg/Utilities/helpers.py
@@ -167,7 +167,9 @@ sed -i 's/4.5d0/4.75d0/g' init_couplings.f",
     "gg_H_MSSM" : "sed -i 's/leq/le/g' nloreal.F\n \
 cp -p ../gg_H_quark-mass-effects/SLHA.h .\n \
 cp -p ../gg_H_quark-mass-effects/SLHADefs.h .",
-    }.get(process,"")
+    "HJ/HJMiNNLO" : "sed -i -e \"s#PDF=hoppet#PDF=lhapdf#\" Makefile \n \
+     sed -i -e \"s#internal_parameters.o coefficient_functions_nnlops.o#internal_parameters.o coefficient_functions_nnlops.o sudakov_radiators.o#\" Makefile",    
+  }.get(process,"")
 
 def runGetSource_patch_5(process) :
   return {

--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -280,7 +280,7 @@ def runGetSource(parstage, xgrid, folderName, powInputName, process, noPdfCheck,
     template_dict = {
         "folderName" : folderName,
         "powInputName" : powInputName,
-        "process" : process,
+        "processtemp" : process,
         "noPdfCheck" : noPdfCheck,
         "rootfolder" : rootfolder,
         "patches_dir" : os.path.dirname(os.path.realpath(__file__)) + "/patches",
@@ -472,6 +472,11 @@ if __name__ == "__main__":
     parser.add_argument('--svn'    , dest="svnRev",    default= 0,           help='SVN revision. If 0, use tarball [0]')
 
     args = parser.parse_args ()
+
+    message2 = "After step 0, you must input the process name _without_ the slash (e.g. HJ/MiNNLOPS must be just HJ)"
+
+    if args.parstage != '0' and '/' in args.prcName:
+        raise RuntimeError(message2)
 
     QUEUE = args.doQueue
     EOSfolder = args.folderName


### PR DESCRIPTION
New feature: processes in POWHEG-BOX subdirectories can be now compiled.

WORKING MODE: If the process name is supplied with a slash e.g. "-m HVV/HWW" at step "-p 0" the related sub-process will be compiled.

N.B.: there are several of these occurrences, none of them supported in CMS, need to go one by one now.

@agrohsje   