### PR TITLE
Change URL of hnnlo-v2.0 package

### DIFF
--- a/bin/Powheg/Utilities/helpers.py
+++ b/bin/Powheg/Utilities/helpers.py
@@ -469,7 +469,7 @@ cd ..",
 def runGetSource_patch_8(process) :
   return {
     "HJ" : "echo \"Compiling HNNLO....\"\n \
-wget --no-verbose http://theory.fi.infn.it/grazzini/codes/hnnlo-v2.0.tgz\n \
+wget --no-verbose https://www.physik.uzh.ch/~grazzini/codes/hnnlo-v2.0.tgz\n \
 tar -xzvf hnnlo-v2.0.tgz\n \
 cd hnnlo-v2.0\n \
 cp ../POWHEG-BOX/HJ/NNLOPS-mass-effects/HNNLO-makefile ./makefile\n \


### PR DESCRIPTION
As discussed on [MatterMost](https://mattermost.web.cern.ch/lpcrun2discuss/pl/dtrfjq3acpya9kkqy79coucdmc), the URL of the hnnlo-v2.0 package has been moved to https://www.physik.uzh.ch/~grazzini/codes/hnnlo-v2.0.tgz.

This PR updates the path in the code.