### PR TITLE
Powheg input card for mass-binned DY->mumu, ee samples

### DIFF
--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m1000to1500-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m1000to1500-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 1000d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 1500d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m100to200-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m100to200-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 100d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 200d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m10to50-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m10to50-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 10d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 50d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m1500to2000-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m1500to2000-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 1500d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 2000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m2000toInf-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m2000toInf-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 2000d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 10000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m200to400-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m200to400-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 200d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 400d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m400to500-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m400to500-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 400d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 500d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m500to700-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m500to700-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 500d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 700d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m700to800-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m700to800-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 700d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 800d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m800to1000-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToEE-suggested-nnpdf31-ncalls-doublefsr-q139-m800to1000-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  1     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 800d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 1000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m1000to1500-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m1000to1500-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 1000d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 1500d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m100to200-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m100to200-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 100d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 200d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m10to50-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m10to50-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 10d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 50d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m1500to2000-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m1500to2000-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 1500d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 2000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m2000toInf-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m2000toInf-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 2000d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 10000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m200to400-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m200to400-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 200d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 400d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m400to500-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m400to500-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 400d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 500d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m500to700-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m500to700-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 500d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 700d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m700to800-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m700to800-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 700d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 800d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+

--- a/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m800to1000-powheg.input
+++ b/bin/Powheg/production/2017/13TeV/DY_MassBinned_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-m800to1000-powheg.input
@@ -1,0 +1,78 @@
+vdecaymode  2     ! Z decay products (default 2): 1 for electronic
+
+bornktmin 0.26
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500d0     ! energy of beam 1
+ebeam2 6500d0     ! energy of beam 2
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+modlog_p 6     ! (optional, only works if minnlo is set to 1)
+               ! if present, activate modified logs and set the exponent
+inc_delta_terms 0 ! (default 1) if 0, as^3 NNLO delta terms are not included
+sudscalevar 1   ! (default 1) scale variation also in Sudakov form factors in minlo 
+distribute_by_ub 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+distribute_by_ub_AP 1 ! (default 0) if 1 distribute d3 terms according to kinematics of ub
+alphas_cutoff_fact 0.0 ! ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+pdf_cutoff_fact 1.1 ! (Higgs: 2.5, DY: 1.8) see setlocalscales.f
+use_NNLOPS_pdfs 1 ! (default 0)
+negative_pdfs_zero 0 ! setting negative PDFs zero
+
+profiledscales 1 ! (default 0) if 1, use the profiled scales with cutoff Q0 and power npow
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+Q0 1.390985      ! (default 2.) Q0 value used in profiled scales (see 2006.04133 for more details)
+                 !              smaller values can be used too.
+npow 1           ! (default 1) power in profiled scales
+
+withdamp 1
+doublefsr 1
+
+! PROCESS PARAMETERS
+# EW input
+
+min_Z_mass 800d0  ! Lower mass cut-off for Z boson production
+max_Z_mass 1000d0 ! Upper mass cut-off for Z boson production
+
+! To be set only if using LHA pdfs
+lhans1   306000     ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000    ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1   200000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   200000     ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 200000 ! number of bbarra calls to setup norm of upper bounding function
+
+check_bad_st1 1
+check_bad_st2 1
+
+ubexcess_correct 1
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+flg_debug  0       ! store extra event info for debugging
+
+iseed SEED        ! initialize random number sequence
+#maxseeds 2000
+#manyseeds 1
+#parallelstage 1
+#xgriditeration 1
+
+storeinfo_rwgt 1   ! store info to allow for reweighting
+#compute_rwgt 1
+


### PR DESCRIPTION
Dear GEN experts,

This PR includes the Powheg input cards used in production for mass-binned DY->mumu, ee samples.
Mass bin edges are same with existing aMC@NLO mass-binned samples, except for the last bin edge (3000 GeV -> 10000 GeV):
- low mass: 10, 50
- high mass: 100, 200, 400, 500, 700, 800, 1000, 1500, 2000, 10000

The cards are based on the one for existing m>50 sample:
 https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/pre2017/13TeV/DY_MiNNLO_NNPDF31_13TeV/ZJToMuMu-suggested-nnpdf31-ncalls-doublefsr-q139-powheg.input
The mass parameters `min_Z_mass` and `max_Z_mass` are changed.
For the DY->ee sample, additionally `vdecaymode` is set to 1.
The others are exactly same with the original card.

The gridpack production was performed under the instruction from the MiNNLO experts (Thanks Markus & Kenneth!),
and the entry in MCM can be found here (Thanks Tanmay to take care of this!) :
https://cms-pdmv.cern.ch/mcm/requests?prepid=*20UL*GEN*&dataset_name=DYJetsToMuMu_M-*_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos,DYJetsToEE_M-*_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos&page=-1&shown=127

The validation plots and cross sections from the gridpacks are available in the slides:
https://www.dropbox.com/s/4l4vak1d1hyjai6/20220829_SampleRequest_DY_MassBinned_MiNNLO_KPLee_v1.pdf?dl=0

Please let me know if you need additional information. Thanks.

Best regards,
Kyeongpil
