### PR TITLE
Higgs 13.6 TeV bkg samples

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_madspin_card.dat
@@ -1,0 +1,9 @@
+set ms_dir ./madspingrid
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+set max_running_process 1
+decay t > w+ b, w+ > all all
+decay t~ > w- b~, w- > all all
+decay w+ > all all
+decay w- > all all
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_proc_card.dat
@@ -1,0 +1,9 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+generate p p > t t~ w+ w-
+output TTWW_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_proc_card.dat
@@ -1,9 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set loop_color_flows False
-set gauge unitary
-set complex_mass_scheme False
-set max_npoint_for_channel 0
 import model sm-no_b_mass
 generate p p > t t~ w+ w-
 output TTWW_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_run_card.dat
@@ -90,7 +90,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
+  15.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTWW_5f_LO/TTWW_5f_LO_run_card.dat
@@ -1,0 +1,275 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	=  run_tag  ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  1000	=  nevents  ! Number of unweighted events requested 
+  0	=  iseed    ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	=  lpp1     ! beam 1 type 
+  1	=  lpp2     ! beam 2 type
+  6800.0	=  ebeam1   ! beam 1 total energy in GeV
+  6800.0	=  ebeam2   ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+  0.0	=  polbeam1  ! beam polarization for beam 1
+  0.0	=  polbeam2  ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	=  pdlabel      ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  .false.	=  fixed_ren_scale   ! if .true. use fixed ren scale
+  .false.	=  fixed_fac_scale   ! if .true. use fixed fac scale
+  91.188	=  scale             ! fixed ren scale
+  91.188	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
+  91.188	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
+  -1	=  dynamical_scale_choice  ! Choose one of the preselected dynamical choices
+  1.0	=  scalefact         ! scale factor for event-by-event scales
+#*********************************************************************
+# Time of flight information. (-1 means not run)
+#*********************************************************************
+  -1.0	=  time_of_flight  ! threshold below which info is not written
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+  0	=  ickkw             ! 0 no matching, 1 MLM, 2 CKKW matching
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	=  alpsfact          ! scale factor for QCD emission vx
+  .false.	=  chcluster         ! cluster only according to channel diag
+  T =  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	=  asrwgtflavor      ! highest quark flavor for a_s reweight
+  .true.	=  clusinfo          ! include clustering tag in output
+  3.0	=  lhe_version        ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+  .false.	=  auto_ptj_mjj   ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+  .false.	=  cut_decays     ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+  0	=  nhel           ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.01	=  ptj        ! minimum pt for the jets 
+  0.0	=  ptb        ! minimum pt for the b 
+  10.0	=  pta        ! minimum pt for the photons 
+  0.0	=  ptl        ! minimum pt for the charged leptons 
+  0.0	=  misset     ! minimum missing Et (sum of neutrino's momenta)
+  0.0	=  ptheavy    ! minimum pt for one heavy final state
+  -1.0	=  ptjmax     ! maximum pt for the jets
+  -1.0	=  ptbmax     ! maximum pt for the b
+  -1.0	=  ptamax     ! maximum pt for the photons
+  -1.0	=  ptlmax     ! maximum pt for the charged leptons
+  -1.0	=  missetmax  ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0	=  ej      ! minimum E for the jets 
+  0.0	=  eb      ! minimum E for the b 
+  0.0	=  ea      ! minimum E for the photons 
+  0.0	=  el      ! minimum E for the charged leptons 
+  -1.0	=  ejmax  ! maximum E for the jets
+  -1.0	=  ebmax  ! maximum E for the b
+  -1.0	=  eamax  ! maximum E for the photons
+  -1.0	=  elmax  ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0	=  etaj     ! max rap for the jets 
+  -1.0	=  etab     ! max rap for the b
+  -1.0	=  etaa     ! max rap for the photons 
+  -1.0	=  etal     ! max rap for the charged leptons 
+  0.0	=  etajmin  ! min rap for the jets
+  0.0	=  etabmin  ! min rap for the b
+  0.0	=  etaamin  ! min rap for the photons
+  0.0	=  etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0	=  drjj     ! min distance between jets 
+  0.0	=  drbb     ! min distance between b's 
+  0.0	=  drll     ! min distance between leptons 
+  0.0	=  draa     ! min distance between gammas 
+  0.0	=  drbj     ! min distance between b and jet 
+  0.1	=  draj     ! min distance between gamma and jet 
+  0.0	=  drjl     ! min distance between jet and lepton 
+  0.0	=  drab     ! min distance between gamma and b 
+  0.0	=  drbl     ! min distance between b and lepton 
+  0.1	=  dral     ! min distance between gamma and lepton 
+  -1.0	=  drjjmax  ! max distance between jets
+  -1.0	=  drbbmax  ! max distance between b's
+  -1.0	=  drllmax  ! max distance between leptons
+  -1.0	=  draamax  ! max distance between gammas
+  -1.0	=  drbjmax  ! max distance between b and jet
+  -1.0	=  drajmax  ! max distance between gamma and jet
+  -1.0	=  drjlmax  ! max distance between jet and lepton
+  -1.0	=  drabmax  ! max distance between gamma and b
+  -1.0	=  drblmax  ! max distance between b and lepton
+  -1.0	=  dralmax  ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  0.0	=  mmjj     ! min invariant mass of a jet pair 
+  0.0	=  mmbb     ! min invariant mass of a b pair 
+  0.0	=  mmaa     ! min invariant mass of gamma gamma pair
+  4.0	=  mmll     ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	=  mmjjmax  ! max invariant mass of a jet pair
+  -1.0	=  mmbbmax  ! max invariant mass of a b pair
+  -1.0	=  mmaamax  ! max invariant mass of gamma gamma pair
+  -1.0	=  mmllmax  ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	=  mmnl     ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	=  mmnlmax  ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	=  ptllmin   ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	=  ptllmax   ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	=  xptj  ! minimum pt for at least one jet  
+  0.0	=  xptb  ! minimum pt for at least one b 
+  0.0	=  xpta  ! minimum pt for at least one photon 
+  0.0	=  xptl  ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	=  ptj1min  ! minimum pt for the leading jet in pt
+  0.0	=  ptj2min  ! minimum pt for the second jet in pt
+  0.0	=  ptj3min  ! minimum pt for the third jet in pt
+  0.0	=  ptj4min  ! minimum pt for the fourth jet in pt
+  -1.0	=  ptj1max  ! maximum pt for the leading jet in pt 
+  -1.0	=  ptj2max  ! maximum pt for the second jet in pt
+  -1.0	=  ptj3max  ! maximum pt for the third jet in pt
+  -1.0	=  ptj4max  ! maximum pt for the fourth jet in pt
+  0	=  cutuse   ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	=  ptl1min  ! minimum pt for the leading lepton in pt
+  0.0	=  ptl2min  ! minimum pt for the second lepton in pt
+  0.0	=  ptl3min  ! minimum pt for the third lepton in pt
+  0.0	=  ptl4min  ! minimum pt for the fourth lepton in pt
+  -1.0	=  ptl1max  ! maximum pt for the leading lepton in pt 
+  -1.0	=  ptl2max  ! maximum pt for the second lepton in pt
+  -1.0	=  ptl3max  ! maximum pt for the third lepton in pt
+  -1.0	=  ptl4max  ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	=  htjmin  ! minimum jet HT=Sum(jet pt)
+  -1.0	=  htjmax  ! maximum jet HT=Sum(jet pt)
+  0.0	=  ihtmin   !inclusive Ht for all partons (including b)
+  -1.0	=  ihtmax   !inclusive Ht for all partons (including b)
+  0.0	=  ht2min  ! minimum Ht for the two leading jets
+  0.0	=  ht3min  ! minimum Ht for the three leading jets
+  0.0	=  ht4min  ! minimum Ht for the four leading jets
+  -1.0	=  ht2max  ! maximum Ht for the two leading jets
+  -1.0	=  ht3max  ! maximum Ht for the three leading jets
+  -1.0	=  ht4max  ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	=  ptgmin  ! Min photon transverse momentum
+  0.4	=  R0gamma  ! Radius of isolation code
+  1.0	=  xn  ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	=  epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	=  xetamin  ! minimum rapidity for two jets in the WBF case  
+  0.0	=  deltaeta  ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+  -1.0	=   ktdurham        
+   0.4	=   dparameter 
+ #*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	=  maxjetflavor     ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+  0	=  xqcut    ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+  True	=  use_syst       ! Enable systematics studies
+#
+#**************************************
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_customizecards.dat
@@ -1,0 +1,4 @@
+#put card customizations here (change top and higgs mass for example)
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_madspin_card.dat
@@ -1,0 +1,8 @@
+set ms_dir ./madspingrid
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+set max_running_process 1
+decay t > w+ b, w+ > all all
+decay t~ > w- b~, w- > all all
+decay z > all all
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_proc_card.dat
@@ -1,0 +1,9 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+generate p p > t t~ z z
+output TTZZ_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_proc_card.dat
@@ -1,9 +1,3 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set loop_color_flows False
-set gauge unitary
-set complex_mass_scheme False
-set max_npoint_for_channel 0
 import model sm-no_b_mass
 generate p p > t t~ z z
 output TTZZ_5f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_run_card.dat
@@ -90,7 +90,7 @@ $DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf
 #**********************************
 # BW cutoff (M+/-bwcutoff*Gamma)
 #**********************************
-  15000.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
+  15.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
 #**********************************************************
 # Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTZZ_5f_LO/TTZZ_5f_LO_run_card.dat
@@ -1,0 +1,275 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	=  run_tag  ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  1000	=  nevents  ! Number of unweighted events requested 
+  0	=  iseed    ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	=  lpp1     ! beam 1 type 
+  1	=  lpp2     ! beam 2 type
+  6800.0	=  ebeam1   ! beam 1 total energy in GeV
+  6800.0	=  ebeam2   ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+  0.0	=  polbeam1  ! beam polarization for beam 1
+  0.0	=  polbeam2  ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	=  pdlabel      ! PDF set                                     
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  .false.	=  fixed_ren_scale   ! if .true. use fixed ren scale
+  .false.	=  fixed_fac_scale   ! if .true. use fixed fac scale
+  91.188	=  scale             ! fixed ren scale
+  91.188	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
+  91.188	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
+  -1	=  dynamical_scale_choice  ! Choose one of the preselected dynamical choices
+  1.0	=  scalefact         ! scale factor for event-by-event scales
+#*********************************************************************
+# Time of flight information. (-1 means not run)
+#*********************************************************************
+  -1.0	=  time_of_flight  ! threshold below which info is not written
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+  0	=  ickkw             ! 0 no matching, 1 MLM, 2 CKKW matching
+  1	=  highestmult       ! for ickkw=2, highest mult group
+  1	=  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+  1.0	=  alpsfact          ! scale factor for QCD emission vx
+  .false.	=  chcluster         ! cluster only according to channel diag
+  T	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
+  5	=  asrwgtflavor      ! highest quark flavor for a_s reweight
+  .true.	=  clusinfo          ! include clustering tag in output
+  3.0	=  lhe_version        ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+  .false.	=  auto_ptj_mjj   ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15000.0	=  bwcutoff       ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+  .false.	=  cut_decays     ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+  0	=  nhel           ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.01	=  ptj        ! minimum pt for the jets 
+  0.0	=  ptb        ! minimum pt for the b 
+  10.0	=  pta        ! minimum pt for the photons 
+  0.0	=  ptl        ! minimum pt for the charged leptons 
+  0.0	=  misset     ! minimum missing Et (sum of neutrino's momenta)
+  0.0	=  ptheavy    ! minimum pt for one heavy final state
+  -1.0	=  ptjmax     ! maximum pt for the jets
+  -1.0	=  ptbmax     ! maximum pt for the b
+  -1.0	=  ptamax     ! maximum pt for the photons
+  -1.0	=  ptlmax     ! maximum pt for the charged leptons
+  -1.0	=  missetmax  ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0	=  ej      ! minimum E for the jets 
+  0.0	=  eb      ! minimum E for the b 
+  0.0	=  ea      ! minimum E for the photons 
+  0.0	=  el      ! minimum E for the charged leptons 
+  -1.0	=  ejmax  ! maximum E for the jets
+  -1.0	=  ebmax  ! maximum E for the b
+  -1.0	=  eamax  ! maximum E for the photons
+  -1.0	=  elmax  ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0	=  etaj     ! max rap for the jets 
+  -1.0	=  etab     ! max rap for the b
+  -1.0	=  etaa     ! max rap for the photons 
+  -1.0	=  etal     ! max rap for the charged leptons 
+  0.0	=  etajmin  ! min rap for the jets
+  0.0	=  etabmin  ! min rap for the b
+  0.0	=  etaamin  ! min rap for the photons
+  0.0	=  etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0	=  drjj     ! min distance between jets 
+  0.0	=  drbb     ! min distance between b's 
+  0.0	=  drll     ! min distance between leptons 
+  0.0	=  draa     ! min distance between gammas 
+  0.0	=  drbj     ! min distance between b and jet 
+  0.1	=  draj     ! min distance between gamma and jet 
+  0.0	=  drjl     ! min distance between jet and lepton 
+  0.0	=  drab     ! min distance between gamma and b 
+  0.0	=  drbl     ! min distance between b and lepton 
+  0.1	=  dral     ! min distance between gamma and lepton 
+  -1.0	=  drjjmax  ! max distance between jets
+  -1.0	=  drbbmax  ! max distance between b's
+  -1.0	=  drllmax  ! max distance between leptons
+  -1.0	=  draamax  ! max distance between gammas
+  -1.0	=  drbjmax  ! max distance between b and jet
+  -1.0	=  drajmax  ! max distance between gamma and jet
+  -1.0	=  drjlmax  ! max distance between jet and lepton
+  -1.0	=  drabmax  ! max distance between gamma and b
+  -1.0	=  drblmax  ! max distance between b and lepton
+  -1.0	=  dralmax  ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  0.0	=  mmjj     ! min invariant mass of a jet pair 
+  0.0	=  mmbb     ! min invariant mass of a b pair 
+  0.0	=  mmaa     ! min invariant mass of gamma gamma pair
+  4.0	=  mmll     ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	=  mmjjmax  ! max invariant mass of a jet pair
+  -1.0	=  mmbbmax  ! max invariant mass of a b pair
+  -1.0	=  mmaamax  ! max invariant mass of gamma gamma pair
+  -1.0	=  mmllmax  ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0	=  mmnl     ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	=  mmnlmax  ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	=  ptllmin   ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	=  ptllmax   ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	=  xptj  ! minimum pt for at least one jet  
+  0.0	=  xptb  ! minimum pt for at least one b 
+  0.0	=  xpta  ! minimum pt for at least one photon 
+  0.0	=  xptl  ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	=  ptj1min  ! minimum pt for the leading jet in pt
+  0.0	=  ptj2min  ! minimum pt for the second jet in pt
+  0.0	=  ptj3min  ! minimum pt for the third jet in pt
+  0.0	=  ptj4min  ! minimum pt for the fourth jet in pt
+  -1.0	=  ptj1max  ! maximum pt for the leading jet in pt 
+  -1.0	=  ptj2max  ! maximum pt for the second jet in pt
+  -1.0	=  ptj3max  ! maximum pt for the third jet in pt
+  -1.0	=  ptj4max  ! maximum pt for the fourth jet in pt
+  0	=  cutuse   ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	=  ptl1min  ! minimum pt for the leading lepton in pt
+  0.0	=  ptl2min  ! minimum pt for the second lepton in pt
+  0.0	=  ptl3min  ! minimum pt for the third lepton in pt
+  0.0	=  ptl4min  ! minimum pt for the fourth lepton in pt
+  -1.0	=  ptl1max  ! maximum pt for the leading lepton in pt 
+  -1.0	=  ptl2max  ! maximum pt for the second lepton in pt
+  -1.0	=  ptl3max  ! maximum pt for the third lepton in pt
+  -1.0	=  ptl4max  ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	=  htjmin  ! minimum jet HT=Sum(jet pt)
+  -1.0	=  htjmax  ! maximum jet HT=Sum(jet pt)
+  0.0	=  ihtmin   !inclusive Ht for all partons (including b)
+  -1.0	=  ihtmax   !inclusive Ht for all partons (including b)
+  0.0	=  ht2min  ! minimum Ht for the two leading jets
+  0.0	=  ht3min  ! minimum Ht for the three leading jets
+  0.0	=  ht4min  ! minimum Ht for the four leading jets
+  -1.0	=  ht2max  ! maximum Ht for the two leading jets
+  -1.0	=  ht3max  ! maximum Ht for the three leading jets
+  -1.0	=  ht4max  ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	=  ptgmin  ! Min photon transverse momentum
+  0.4	=  R0gamma  ! Radius of isolation code
+  1.0	=  xn  ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	=  epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	=  isoEM  ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	=  xetamin  ! minimum rapidity for two jets in the WBF case  
+  0.0	=  deltaeta  ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+  -1.0	=   ktdurham        
+   0.4	=   dparameter 
+ #*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	=  maxjetflavor     ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+  0	=  xqcut    ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+  True	=  use_syst       ! Enable systematics studies
+#
+#**************************************
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_madspin_card.dat
@@ -1,0 +1,9 @@
+set ms_dir ./madspingrid
+set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
+set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+set max_running_process 1
+decay t > w+ b, w+ > all all
+decay t~ > w- b~, w- > all all
+decay w+ > all all
+decay w- > all all
+launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_madspin_card.dat
@@ -2,8 +2,6 @@ set ms_dir ./madspingrid
 set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
 set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
 set max_running_process 1
-decay t > w+ b, w+ > all all
-decay t~ > w- b~, w- > all all
 decay w+ > all all
 decay w- > all all
 launch

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_proc_card.dat
@@ -1,14 +1,4 @@
-set group_subprocesses Auto
-set ignore_six_quark_processes False
-set loop_optimized_output True
-set complex_mass_scheme False
-import model loop_sm-no_b_mass
-define l+ = e+ mu+
-define l- = e- mu-
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define p = g u c d s u~ c~ d~ s~
-define j = g u c d s u~ c~ d~ s~
+import model loop_sm
 define w = w+ w-
 generate p p > w w w $$ t t~ [QCD] @0
 output WWWJets_4f_NLO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_proc_card.dat
@@ -1,0 +1,14 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model loop_sm-no_b_mass
+define l+ = e+ mu+
+define l- = e- mu-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+define p = g u c d s u~ c~ d~ s~
+define j = g u c d s u~ c~ d~ s~
+define w = w+ w-
+generate p p > w w w $$ t t~ [QCD] @0
+output WWWJets_4f_NLO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/WWWJets_4f/WWWJets_4f_NLO_run_card.dat
@@ -1,0 +1,146 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    20 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6800   = ebeam1  ! beam 1 energy in GeV
+ 6800   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ $DEFAULT_PDF_SETS    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+$DEFAULT_PDF_MEMBERS  = reweight_PDF     ! reweight to get PDF uncertainty
+   ! First of the error PDF sets 
+   ! Last of the error PDF sets
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 0        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 0.7  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 4 = maxjetflavor
+#***********************************************************************


### PR DESCRIPTION
Dear expert,
We have produced some Higgs analysis madgraph cards for background samples at 13.6 TeV for RunIII production, which include:

TTZZ_5f_LO
TTWW_5f_LO
WWWJets_4f

Only the beam energy is changed in the run_card.
Please review them, if there are any issues, please inform us.
Soumyadip
(ttH MC contact)

Adding @hftsoi @attikis