### PR TITLE
Added cards for legacy rereco (non-UL) t-channel 5FS at 5 TeV.

### DIFF
--- a/bin/Powheg/production/2017/5TeV/st_tch_5f_ckm_13TeV/powheg_antitop.input
+++ b/bin/Powheg/production/2017/5TeV/st_tch_5f_ckm_13TeV/powheg_antitop.input
@@ -1,0 +1,84 @@
+! ST-tchannel inputs
+
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop nominal value for hdamp for Fall18
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+iseed    SEED    ! initialize random number sequence 
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 2510
+ebeam2 2510
+
+! To be set only if using LHA pdfs
+lhans1 306000 ! 5FS
+lhans2 306000 ! 5FS
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+ttype        -1
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
+                     ! primary-w-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 1.33 
+
+topmass      172.5
+wmass        80.385
+wwidth       2.141
+sthw2        0.23129
+alphaem_inv  137.035999139
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.78
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.78
+bottomthrpdf 4.78
+charmthr     1.67
+charmthrpdf  1.67
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97434
+CKM_Vus   0.22506
+CKM_Vub   0.00357
+CKM_Vcd   0.22492
+CKM_Vcs   0.97351
+CKM_Vcb   0.0411
+CKM_Vtd   0.00875
+CKM_Vts   0.0403
+CKM_Vtb   0.99915
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0

--- a/bin/Powheg/production/2017/5TeV/st_tch_5f_ckm_13TeV/powheg_top.input
+++ b/bin/Powheg/production/2017/5TeV/st_tch_5f_ckm_13TeV/powheg_top.input
@@ -1,0 +1,88 @@
+! ST-tchannel inputs
+
+withdamp       1
+hdamp 237.8775 ! 1.379*mtop nominal value for hdamp for Fall18
+
+renscfact  1d0    ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0    ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+iseed    SEED    ! initialize random number sequence 
+
+numevts NEVENTS     ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+
+ebeam1 2510
+ebeam2 2510
+
+! To be set only if using LHA pdfs
+lhans1 306000    ! 5FS
+lhans2 306000    ! 5FS
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000         ! number of calls for initializing the integration grid
+itmx1   4         ! number of iterations for initializing the integration grid
+ncall2 100000         ! number of calls for computing the integral and finding upper bound
+itmx2   4         ! number of iterations for computing the integral and finding upper bound
+foldcsi   5       ! number of folds on csi integration
+foldy     5       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound  100000       ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+ttype        1
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
+                     ! primary-w-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.108  ! W electronic branching fraction
+tdec/sin2cabibbo 0.051
+topwidth 1.33 
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+! According to other previous rereco 5TeV samples produced. New values used in UL have not been propagated.
+topmass      172.5
+wmass        80.385
+wwidth       2.141
+sthw2        0.23129
+alphaem_inv  137.035999139
+
+lhfm/emass   0.00051
+lhfm/mumass  0.1057
+lhfm/taumass 1.777
+lhfm/cmass   1.27
+lhfm/bmass   4.78
+tdec/emass   0.00051
+tdec/mumass  0.1057
+tdec/taumass 1.777
+
+bottomthr    4.78
+bottomthrpdf 4.78
+charmthr     1.67
+charmthrpdf  1.67
+
+
+! PDG Values http://pdg.lbl.gov/2019/reviews/rpp2018-rev-ckm-matrix.pdf
+CKM_Vud   0.97434
+CKM_Vus   0.22506
+CKM_Vub   0.00357
+CKM_Vcd   0.22492
+CKM_Vcs   0.97351
+CKM_Vcb   0.0411
+CKM_Vtd   0.00875
+CKM_Vts   0.0403
+CKM_Vtb   0.99915
+
+pdfreweight 0
+storeinfo_rwgt 0 ! store weight information
+withnegweights 1 ! default 0


### PR DESCRIPTION
This is a new PR after talking about the previous 4FS analogous card [1] in CMS Talk and with authors. In this case, these are cards for the t-ch. in 5FS with analogous settings as similar samples of the same campaign and energy for coherence.

[1]: https://github.com/cms-sw/genproductions/pull/3316 