### PR TITLE
Add Run3 Higgs(bb) fragments

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/GluGluHToBB_Pt-200ToInf_M-125_TuneCP5_MINLO_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/GluGluHToBB_Pt-200ToInf_M-125_TuneCP5_MINLO_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HJ_slc7_amd64_gcc700_CMSSW_10_2_29_GluGluHToBB.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    generateConcurrently = cms.untracked.bool(True),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to datacards: 
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/HJ_MINLO_Pt-200ToInf/HJ_MiNLO_NNPDF31_13p6TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton                            	
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/VBFHToBB_M-125_dipoleRecoilOn_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/VBFHToBB_M-125_dipoleRecoilOn_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/VBF_H_slc7_amd64_gcc700_CMSSW_10_2_29_VBFHToBB.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to datacards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/VBF_H_NNPDF31_13TeV/VBF_H_NNPDF31_13p6TeV.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            'SpaceShower:dipoleRecoil = on',
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/WminusH_HToBB_WToLNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/WminusH_HToBB_WToLNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HWJ_slc7_amd64_gcc700_CMSSW_10_2_29_WminusH_HToBB_WToLNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/WminusHJ_HanythingJ_NNPDF31_13p6TeV/HWminusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vleptonic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/WminusH_HToBB_WToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/WminusH_HToBB_WToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HWJ_slc7_amd64_gcc700_CMSSW_10_2_29_WminusH_HToBB_WToQQ.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/WminusHJ_HanythingJ_NNPDF31_13p6TeV/HWminusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vhadronic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/WplusH_HToBB_WToLNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/WplusH_HToBB_WToLNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HWJ_slc7_amd64_gcc700_CMSSW_10_2_29_WplusH_HToBB_WToLNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/WplusHJ_HanythingJ_NNPDF31_13p6TeV/HWplusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vleptonic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/WplusH_HToBB_WToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/WplusH_HToBB_WToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HWJ_slc7_amd64_gcc700_CMSSW_10_2_29_WplusH_HToBB_WToQQ.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/WplusHJ_HanythingJ_NNPDF31_13p6TeV/HWplusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vhadronic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToLL_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToLL_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HZJ_slc7_amd64_gcc700_CMSSW_10_2_29_ZH_HToBB_ZToQQ.tgz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/HZJ_HanythingJ_NNPDF31_13p6TeV/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vleptonic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToNuNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToNuNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HZJ_slc7_amd64_gcc700_CMSSW_10_2_29_ZH_HToBB_ZToNuNu.tgz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/HZJ_HanythingJ_NNPDF31_13p6TeV/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vneutrinos.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ZH_HToBB_ZToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/HZJ_slc7_amd64_gcc700_CMSSW_10_2_29_ZH_HToBB_ZToQQ.tgz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/HZJ_HanythingJ_NNPDF31_13p6TeV/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vhadronic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToLL_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToLL_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/ggHZ_slc7_amd64_gcc700_CMSSW_10_2_29_ggZH_HToBB_ZToLL.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13p6TeV/ggHZ_HanythingJ_NNPDF31_13p6TeV_M125_Vleptonic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2',
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToNuNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToNuNu_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/ggHZ_slc7_amd64_gcc700_CMSSW_10_2_29_ggZH_HToBB_ZToNuNu.tgz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to input cards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13p6TeV/ggHZ_HanythingJ_NNPDF31_13p6TeV_M125_Vneutrinos.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2',                            
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ggZH_HToBB_ZToQQ_M-125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/ggHZ_slc7_amd64_gcc700_CMSSW_10_2_29_ggZH_HToBB_ZToQQ.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    generateConcurrently = cms.untracked.bool(True),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh'),
+                                     )
+
+# Link to datacards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHZ_HanythingJ_NNPDF31_13p6TeV/ggHZ_HanythingJ_NNPDF31_13p6TeV_M125_Vhadronic.input
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(pythia8CommonSettingsBlock,
+                                                     pythia8CP5SettingsBlock,
+                                                     pythia8PSweightsSettingsBlock,
+                                                     processParameters = cms.vstring('POWHEG:nFinal = 2',   ## Number of final state particles
+                                                                                     ## (BEFORE THE DECAYS) in the LHE
+                                                                                     ## other than emitted extra parton
+                                                                                     '25:m0 = 125.0',
+                                                                                     '25:onMode = off',
+                                                                                     '25:onIfMatch = 5 -5',
+                                                                                     ),
+                                                     parameterSets = cms.vstring('pythia8CommonSettings',
+                                                                                 'pythia8CP5Settings',
+                                                                                 'pythia8PSweightsSettings',
+                                                                                 'processParameters'
+                                                                                 )
+                                                     )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ThirteenPointSixTeV/Higgs/ttHTobb_M125_TuneCP5_13p6TeV-powheg-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/ttHTobb_M125_TuneCP5_13p6TeV-powheg-pythia8.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc700/Powheg/V2/ttH_slc7_amd64_gcc700_CMSSW_10_2_29_ttHTobb.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh')
+)
+
+# Link to datacards:
+# https://github.com/cms-sw/genproductions/blob/7625d99f760709a3609d2c5796cdc71ce9b8a8f6/bin/Powheg/production/Run3/13p6TeV/Higgs/ttH_inclusive_hdamp_NNPDF31_13p6TeV_M125/ttH_inclusive_hdamp_NNPDF31_13p6TeV_M125.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 3',   ## Number of final state particles
+                                   ## (BEFORE THE DECAYS) in the LHE
+                                   ## other than emitted extra parton
+            '23:mMin = 0.05',      
+	    	'24:mMin = 0.05',      
+            '25:m0 = 125.0',
+            '25:onMode = off',
+			'25:onIfMatch = 5 -5' #Higgs decays only to bb pair
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8PowhegEmissionVetoSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
Hi,

I would like to review the following Run 3 fragments for Higgs(bb) production. The fragments are the same as for UL, with the exception of 
- New gridpack
- Changed `comEnergy` to 13600
- Changed the tune to `MCTunesRun3ECM13p6TeV`
- Updated the link to the input cards

Cheers, Adelina