### PR TITLE
Add FKS file for vbf and adjust maxweight in tth card

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/tth01j_5f_ckm_NLO_FXFX_MH/tth01j_5f_ckm_NLO_FXFX_MH_madspin_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/tth01j_5f_ckm_NLO_FXFX_MH/tth01j_5f_ckm_NLO_FXFX_MH_madspin_card.dat
@@ -1,7 +1,7 @@
 set ms_dir ./madspingrid
 
-set Nevents_for_max_weight 250 # number of events for the estimate of the max. weight
-set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
+set Nevents_for_max_weight 300 # number of events for the estimate of the max. weight
+set max_weight_ps_point 500  # number of PS to estimate the maximum for each event
 
 set max_running_process 1
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/vbfh_5f_NLO_/vbfh_5f_NLO__FKS_params.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/vbfh_5f_NLO_/vbfh_5f_NLO__FKS_params.dat
@@ -1,0 +1,71 @@
+! ==========================================================================
+! This file sets the different technical parameters intrinsic to the
+! FKS program and which controls the behaviour of the code at run
+! time.  The common user should not edit this file and only experts
+! should venture editing these parameters.
+! ==========================================================================
+!
+! ==========================================================================
+! Arbitrary numerical parameters used in the FKS formalism
+! ==========================================================================
+!
+! To be implemented by the FKS authors
+!
+! ==========================================================================
+! Parameters controlling the tests based on the IR poles comparison
+! ==========================================================================
+!
+! This threshold sets the limiting value for the comparison of the
+! relative difference of the IR pole from the OLP and the one computed
+! internaly by MadFKS.  The value below is used for the first PS
+! points to assess the sanity of the computation. A value ten times
+! smaller will be used for the systematic check of IR poles at
+! runtime.
+! Notice that the systematic comparison of IR poles at run time is
+! only performed when the Monte-Carlo over helicity configurations
+! method is not used.  Set this value to '-1.0d0' if you want the
+! check to always pass.
+#IRPoleCheckThreshold
+-1d0
+! Default :: 1.0d-5
+!
+! ==========================================================================
+! OLP (virtuals) behavior at run time
+! ==========================================================================
+!
+!
+! Set the precision required from the OLP code. The IR poles check
+! will be performed at run time with a threshold ten times loser than
+! the value below. When equal to '-1d0' the default value of the OLP
+! is used, and the poles check is disabled at run time
+!
+#PrecisionVirtualAtRunTime
+-1d0
+! Default :: 1.0d-3
+!
+! ==========================================================================
+! Parameters defining the techniques used for the MC integration
+! ==========================================================================
+!
+! This integer sets what is the minimum number of contributing
+! helicities (in a given subrpocess) which is necessary for MadFKS to
+! switch to the Monte-Carlo over helicity configurations method. Set
+! this to '-1' if you want to forbid the use of this method
+! altogether.
+#NHelForMCoverHels
+4
+! Default :: 4
+!
+! This parameter sets for which fraction of the events the virtual
+! matrix elements should be included. When using MINT, during the
+! grid-setup phase, this number will be updated automatically after
+! each iteration depending on the relative MC uncertainties.
+#VirtualFraction
+1.0d0
+! Default :: 1.0d0
+!
+! This parameter sets the minimal fraction of the events for which the
+! virtual matrix elements should be included.
+#MinVirtualFraction
+0.005d0
+! Default :: 0.005d0


### PR DESCRIPTION
Dear expert,
For NLO VBF we need to bypass the pole checking, the FKS is needed for this NLO VBF processes.
Based on Dicky Chant's comment:
https://github.com/cms-sw/genproductions/pull/3307#discussion_r1091658275

For the tth card, we have adjusted the maxweight, in case there are too many big weights events.
Previously, we got these information occasionally when we generating the tth gridpack.
```
CRITICAL:  over_weight: 1.2250868517297813 ('t_bwp_wp_sxc', 'tx_wmbx_wm_uxd'), occurence: 0.11210762331838565%, occurence_channel: 1.408450704225352%
                    production_tag:P1_gu_ttxhgu [((2, 21), (-6, 2, 6, 21, 25))], decay:P1_gu_ttxhgu_t_bwp_wp_csx_tx_bxwm_wm_dux [('t_bwp_wp_sxc', 'tx_wmbx_wm_uxd')], BW_cut: 6.26165

                     [decay.py at line 2386] 
INFO: Event nb 1000  2m 47s  
CRITICAL:  over_weight: 1.2603536002541982 ('t_bwp_wp_tapvt', 'tx_wmbx_wm_vtxtam'), occurence: 0.15710919088766692%, occurence_channel: 5.2631578947368425%
                    production_tag:P1_gg_ttxhgg [((21, 21), (-6, 6, 21, 21, 25))], decay:P1_gg_ttxhgg_t_bwp_wp_vttap_tx_bxwm_wm_vtxtam [('t_bwp_wp_tapvt', 'tx_wmbx_wm_vtxtam')], BW_cut: 8.0245
                     [decay.py at line 2386] 
INFO: Total number of events written: 1500/1500  
INFO: Average number of trial points per production event: 7.775333333333333 
INFO: Branching ratio to allowed decays: 1 
INFO: Number of events with weights larger than max_weight: 2 
INFO: Number of subprocesses 1 
INFO: Number of failures when restoring the Monte Carlo masses: 0  
INFO: The decayed event file has been moved to the following location:
```
So that we updated the maxweight in the tth madspin file.