### PR TITLE
pdf modification ttH cards for Higgs signal sample (Run3)

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ttH_ZZ_NNPDF31_13TeV/ttH_inclusive_ZZ_NNPDF31_13TeV_template.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ttH_ZZ_NNPDF31_13TeV/ttH_inclusive_ZZ_NNPDF31_13TeV_template.input
@@ -18,8 +18,8 @@ ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 6800d0     ! energy of beam 1
 ebeam2 6800d0     ! energy of beam 2
 
-lhans1  306000      ! pdf set for hadron 1 (LHA numbering)
-lhans2  306000      ! pdf set for hadron 2 (LHA numbering)
+lhans1  325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300       ! pdf set for hadron 2 (LHA numbering)
 
 delta_mttmin 0d0 ! (default 0d0) if not zero, use generation cut on mtt
 


### PR DESCRIPTION
In the previous PR, the pdf was not set correctly for Run3. So this is modified input card with correct pdf settings