### PR TITLE
fix merge script

### DIFF
--- a/Utilities/scripts/merge.pl
+++ b/Utilities/scripts/merge.pl
@@ -60,11 +60,13 @@ foreach $infile (@ARGV) {
     if ($gzbytes == -1) { die("Error reading from file $infile\n"); }
     if ($gzbytes == 0)  { last; }
 
-    # Extract <MGGenerationInfo> information
+    # Extract <MGGenerationInfo> information and lhe_version
     if ($initblock == 0) {
       if ($gzline =~ s/#  Number of Events\s*:\s*(.*)\n/$1/) { $noevents = $gzline; }
       if ($gzline =~ s/#  Integrated weight \(pb\)\s*:\s*(.*)\n/$1/) { $xsec = $gzline; }
-      if ($gzline =~ s/\s*(.*)\s*=\s*lhe_version.*\n/$1/) { $lhe_version = $gzline; }
+
+      #if ($gzline =~ s/\s*(.*)\s*=\s*lhe_version.*\n/$1/) { $lhe_version = $gzline; }
+      if ($gzline =~ s/<LesHouchesEvents version=\"(.*)\">/$1/) { $lhe_version = $gzline; }
 
       # Check if we enter <init> block
       if ($gzline =~ m/$begin_init/) { $initblock++; next; }

--- a/bin/MadGraph5_aMCatNLO/Utilities/merge.pl
+++ b/bin/MadGraph5_aMCatNLO/Utilities/merge.pl
@@ -67,11 +67,13 @@ foreach $infile (@ARGV) {
         if ($gzline =~ s/\s*(.*)\s*=\s*event_norm.*\n/$1/) { $event_norm = $gzline; }
     }
     
-    # Extract <MGGenerationInfo> information
+    # Extract <MGGenerationInfo> information and lhe_version
     if ($initblock == 0) {
       if ($gzline =~ s/#  Number of Events\s*:\s*(.*)\n/$1/) { $noevents = $gzline; }
       if ($gzline =~ s/#  Integrated weight \(pb\)\s*:\s*(.*)\n/$1/) { $xsec = $gzline; }
-      if ($gzline =~ s/\s*(.*)\s*=\s*lhe_version.*\n/$1/) { $lhe_version = $gzline; }
+
+      #if ($gzline =~ s/\s*(.*)\s*=\s*lhe_version.*\n/$1/) { $lhe_version = $gzline; }
+      if ($gzline =~ s/<LesHouchesEvents version=\"(.*)\">/$1/) { $lhe_version = $gzline; }
 
       # Check if we enter <init> block
       if ($gzline =~ m/$begin_init/) { $initblock++; next; }


### PR DESCRIPTION
This fix allows generation of > 5000 events in one job.

Before the fix, if the number of generated events exceeded 5000, then the simulation was split into Nevents / 5000 jobs, and output lhe files were merged using [Utilities/scripts/merge.pl](https://github.com/michael-pitt/genproductions/blob/master/Utilities/scripts/merge.pl) script, which unproperly retrieves the `lhe_version`, assuming it was stored in `MGGenerationInfo` block. The `MGGenerationInfo` block contains lines with `Number of events` and `Integrated weight`, while the version of the LHE file is stored in `LesHouchesEvents` block.

The fix allows the generation of a large number of events which can be later interfaced with external event filtering (e.g. [TaggedProtonHepMCFilter](https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/Core/interface/TaggedProtonHepMCFilter.h) or [EmbeddingHepMCFilter](https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/Core/interface/EmbeddingHepMCFilter.h)).