### PR TITLE
Add ZHHTo4B and WHHTo4B madgraph LO,NLO cards and gen fragment (Run 3)

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/WHH_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/WHH_proc_card.dat
@@ -1,0 +1,10 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model SM_HEL_UFO_noLightYukawa
+define p = u c d s u~ c~ d~ s~
+define j = p
+define w = w+ w-
+generate p p > h h w  QED=4
+output WHH_CV_TEMPCV_C2V_TEMPC2V_C3_TEMPKL_13TeV-madgraph -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/ZHH_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/ZHH_proc_card.dat
@@ -1,0 +1,9 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
+import model SM_HEL_UFO_noLightYukawa
+define p = u c d s u~ c~ d~ s~
+define j = p
+generate p p > h h z  QED=4
+output ZHH_CV_TEMPCV_C2V_TEMPC2V_C3_TEMPKL_13TeV-madgraph -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/customizecards.dat
@@ -1,0 +1,3 @@
+set param_card new 1 TEMPCV
+set param_card new 2 TEMPC2V
+set param_card new 3 TEMPKL

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/extramodels.dat
@@ -1,0 +1,1 @@
+SM_HEL_UFO_noLightYukawa_HH_VBF.tar.gz   

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/Templates/run_card.dat
@@ -1,0 +1,268 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+     0.0     = polbeam1 ! beam polarization for beam 1
+     0.0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ lhapdf = pdlabel ! PDF set
+ $DEFAULT_PDF_SETS = lhaid
+ $DEFAULT_PDF_MEMBERS  = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0 = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1 = highestmult      ! for ickkw=2, highest mult group
+ 1 = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ True = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True = clusinfo         ! include clustering tag in output
+ 3.0 = lhe_version       ! Change the way clustering information pass to shower.
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   False  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+   False  = cut_decays    ! Cut decay products
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************
+# Standard Cuts
+#*******************
+#
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 2.0  = ptj       ! minimum pt for the jets
+ 0.0  = ptb       ! minimum pt for the b
+ 1.0  = pta       ! minimum pt for the photons
+ 1.0  = ptl       ! minimum pt for the charged leptons 
+ 0.0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+ 0.0  = ptheavy   ! minimum pt for one heavy final state
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptbmax    ! maximum pt for the b
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ -1.0  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej     ! minimum E for the jets
+  0.0  = eb     ! minimum E for the b
+  0.0  = ea     ! minimum E for the photons
+  0.0  = el     ! minimum E for the charged leptons
+  -1.0   = ejmax ! maximum E for the jets
+ -1.0   = ebmax ! maximum E for the b
+ -1.0   = eamax ! maximum E for the photons
+ -1.0   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  10.0 = etaj    ! max rap for the jets
+  -1.0  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons
+ 2.5  = etal    ! max rap for the charged leptons
+ 0.0  = etajmin ! min rap for the jets
+ 0.0  = etabmin ! min rap for the b
+ 0.0  = etaamin ! min rap for the photons
+ 0.0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.4 = drjj    ! min distance between jets
+ 0.0   = drbb    ! min distance between b's
+ 0.4 = drll    ! min distance between leptons
+ 0.4 = draa    ! min distance between gammas
+ 0.0   = drbj    ! min distance between b and jet
+ 0.4 = draj    ! min distance between gamma and jet
+ 0.4 = drjl    ! min distance between jet and lepton
+ 0.0   = drab    ! min distance between gamma and b
+ 0.0   = drbl    ! min distance between b and lepton
+ 0.4 = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair
+ 0.0   = mmbb    ! min invariant mass of a b pair
+ 0.0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptj ! minimum pt for at least one jet
+ 0.0  = xptb ! minimum pt for at least one b
+ 0.0  = xpta ! minimum pt for at least one photon
+ 0.0  = xptl ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ 0.0   = ptl3min ! minimum pt for the third lepton in pt
+ 0.0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+ 0.0   = ht2min ! minimum Ht for the two leading jets
+ 0.0   = ht3min ! minimum Ht for the three leading jets
+ 0.0   = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+ 0.0 = ptgmin ! Min photon transverse momentum
+ 0.4 = R0gamma ! Radius of isolation code
+ 1.0 = xn ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1.0    =  ktdurham
+ 0.4  =  dparameter
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0.0   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/makeCardPerCouplingPoint.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH/makeCardPerCouplingPoint.py
@@ -1,0 +1,93 @@
+import os
+
+# the prototype name of the production folder
+prod_proto = "{0}_CV_{1}_C2V_{2}_C3_{3}_13TeV-madgraph"
+
+### things to replace are
+### TEMPLATEMH02 [mX]
+### TEMPLATEMH03 [mY]
+
+def change_cards(cardname, replacements):
+    
+    ## first make a backup copy
+    bkpname = cardname + '.bak'
+    print cardname, bkpname
+    os.system('mv %s %s' % (cardname, bkpname))
+
+    # edit the file
+    fin  = open(bkpname, 'r')
+    fout = open(cardname, 'w')
+
+    for line in fin:
+        for key, rep in replacements.items():
+            line = line.replace(key, rep)
+        fout.write(line)
+
+    fin.close()
+    fout.close()
+
+    ## delete the backup file
+    os.system('rm %s' % bkpname)
+
+
+def do_point(vhh, cv, c2v, kL):
+    # 1 - create the folder
+    folder = prod_proto.format(vhh, str(cv).replace(".","_"), 
+        str(c2v).replace(".","_"), str(kL).replace(".","_"))
+    if os.path.isdir(folder):
+        print " >> folder", folder, "already existing, forcing its deletion"
+        os.system('rm -r %s' % folder)
+    os.system('mkdir ' + folder)
+    
+    # 2 - copy the original files
+    templateFolder = 'Templates'
+    
+    run_card      = 'run_card.dat'
+    proc_card     = vhh+'_proc_card.dat'
+    # param_card    = 'param_card.dat'
+    extramodels   = 'extramodels.dat'
+    customizecard = 'customizecards.dat'
+    
+    # to_copy = [run_card, proc_card, param_card, extramodels, customizecard]
+    to_copy = [run_card, proc_card, extramodels, customizecard]
+
+    for fileName in to_copy:
+        os.system('cp %s/%s %s/%s_%s' % (templateFolder, fileName, folder, folder, fileName.split(vhh+"_")[-1] ))
+
+    replacementNumbers = {
+        'TEMPCV'  : str(cv),
+        'TEMPC2V' : str(c2v),
+        'TEMPKL'  : str(kL),
+    }
+
+    replacementStrings = {
+        'TEMPCV'  : str(cv).replace(".","_"),
+        'TEMPC2V' : str(c2v).replace(".","_"),
+        'TEMPKL'  : str(kL).replace(".","_"),
+    }
+
+    # 3 - edit in place the cards
+    change_cards('%s/%s_%s' % (folder, folder, customizecard), replacementNumbers)
+    change_cards('%s/%s_%s' % (folder, folder, proc_card.split(vhh+"_")[-1]), replacementStrings)
+
+
+####################################################################################
+
+## cv, c2v, kL
+points = [
+    (0.5, 1.0, 1.0),
+    (1.0, 0.0, 1.0),
+    (1.0, 1.0, 0.0),
+    (1.0, 1.0, 1.0),
+    (1.0, 2.0, 1.0),
+    (1.0, 1.0, 2.0),
+    (1.5, 1.0, 1.0),
+    (1.0, 10.0, 1.0),
+    (1.0, 1.0, 20.0)
+]
+
+
+for p in points:
+    print '... generating', p
+    do_point("ZHH",*p)
+    do_point("WHH",*p)

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_proc_card.dat
@@ -1,0 +1,6 @@
+import model loop_sm 
+define p = u c d s u~ c~ d~ s~
+define j = p
+define w = w+ w-
+generate p p > h h w  [QCD]
+output WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/WHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_run_card.dat
@@ -1,0 +1,171 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 2000 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm    ! valid settings: average, sum, bias
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6800.0   = ebeam1  ! beam 1 energy in GeV
+ 6800.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ $DEFAULT_PDF_SETS  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1         = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ $DEFAULT_PDF_MEMBERS = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 0        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  1.0  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  0.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Cuts associated to MASSIVE particles identified by their PDG codes.  *
+# All cuts are applied to both particles and anti-particles, so use    *
+# POSITIVE PDG CODES only. Example of the syntax is {6 : 100} or       *
+# {6:100, 25:200} for multiple particles                               *
+#***********************************************************************
+  {} = pt_min_pdg ! Min pT for a massive particle
+  {} = pt_max_pdg ! Max pT for a massive particle
+  {} = mxx_min_pdg ! inv. mass for any pair of (anti)particles
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_proc_card.dat
@@ -1,0 +1,5 @@
+import model loop_sm 
+define p = u c d s u~ c~ d~ s~
+define j = p
+generate p p > h h z  [QCD]
+output ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/Higgs/VHH_NLO/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph/ZHH_NLO_CV_1_0_C2V_1_0_C3_1_0_13TeV-madgraph_run_card.dat
@@ -1,0 +1,171 @@
+#***********************************************************************
+#                        MadGraph5_aMC@NLO                             *
+#                                                                      *
+#                      run_card.dat aMC@NLO                            *
+#                                                                      *
+#  This file is used to set the parameters of the run.                 *
+#                                                                      *
+#  Some notation/conventions:                                          *
+#                                                                      *
+#   Lines starting with a hash (#) are info or comments                *
+#                                                                      *
+#   mind the format:   value    = variable     ! comment               *
+#                                                                      *
+#   Some of the values of variables can be list. These can either be   *
+#   comma or space separated.                                          *
+#***********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of LHE events (and their normalization) and the required      *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+ 2000 = nevents ! Number of unweighted events requested 
+ 0.001 = req_acc ! Required accuracy (-1=auto determined from nevents)
+ -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+#***********************************************************************
+# Normalize the weights of LHE events such that they sum or average to *
+# the total cross section                                              *
+#***********************************************************************
+ average = event_norm    ! valid settings: average, sum, bias
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+ 0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+ 1   = lpp1    ! beam 1 type (0 = no PDF)
+ 1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6800.0   = ebeam1  ! beam 1 energy in GeV
+ 6800.0   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf = pdlabel ! PDF set
+ $DEFAULT_PDF_SETS  = lhaid   ! If pdlabel=lhapdf, this is the lhapdf number. Only 
+              ! numbers for central PDF sets are allowed. Can be a list; 
+              ! PDF sets beyond the first are included via reweighting.
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+  1         = shower_scale_factor ! multiply default shower starting
+                                  ! scale by this factor
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses divided by two of all final state particles    * 
+# and partons. This can be changed in SubProcesses/set_scales.f or via *
+# dynamical_scale_choice option)                                       *
+#***********************************************************************
+ False    = fixed_ren_scale  ! if .true. use fixed ren scale
+ False    = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.118   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.118   = muF_ref_fixed    ! fixed fact reference scale
+ -1 = dynamical_scale_choice ! Choose one (or more) of the predefined
+           ! dynamical choices. Can be a list; scale choices beyond the
+           ! first are included via reweighting
+ 1.0  = muR_over_ref  ! ratio of current muR over reference muR
+ 1.0  = muF_over_ref  ! ratio of current muF over reference muF
+#*********************************************************************** 
+# Reweight variables for scale dependence and PDF uncertainty          *
+#***********************************************************************
+ 1.0, 2.0, 0.5 = rw_rscale ! muR factors to be included by reweighting
+ 1.0, 2.0, 0.5 = rw_fscale ! muF factors to be included by reweighting
+ True = reweight_scale ! Reweight to get scale variation using the 
+            ! rw_rscale and rw_fscale factors. Should be a list of 
+            ! booleans of equal length to dynamical_scale_choice to
+            ! specify for which choice to include scale dependence.
+ $DEFAULT_PDF_MEMBERS = reweight_PDF  ! Reweight to get PDF uncertainty. Should be a
+            ! list booleans of equal length to lhaid to specify for
+            !  which PDF set to include the uncertainties.
+#***********************************************************************
+# Store reweight information in the LHE file for off-line model-       *
+# parameter reweighting at NLO+PS accuracy                             *
+#***********************************************************************
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# ickkw parameter:                                                     *
+#   0: No merging                                                      *
+#   3: FxFx Merging - WARNING! Applies merging only at the hard-event  *
+#      level. After showering an MLM-type merging should be applied as *
+#      well. See http://amcatnlo.cern.ch/FxFx_merging.htm for details. *
+#   4: UNLOPS merging (with pythia8 only). No interface from within    *
+#      MG5_aMC available, but available in Pythia8.                    *
+#  -1: NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph].    *
+#***********************************************************************
+ 0        = ickkw
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma). Determines which resonances are      *
+# written in the LHE event file                                        *
+#***********************************************************************
+ 15.0  = bwcutoff
+#***********************************************************************
+# Cuts on the jets. Jet clustering is performed by FastJet.            *
+#  - When matching to a parton shower, these generation cuts should be *
+#    considerably softer than the analysis cuts.                       *
+#  - More specific cuts can be specified in SubProcesses/cuts.f        *
+#***********************************************************************
+  1.0  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+  1.0  = jetradius ! The radius parameter for the jet algorithm
+ 10.0  = ptj       ! Min jet transverse momentum
+ -1.0  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+  0.0  = ptl     ! Min lepton transverse momentum
+ -1.0  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+  0.0  = drll    ! Min distance between opposite sign lepton pairs
+  0.0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+  0.0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  0.0  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442. When ptgmin=0,   *
+# all the other parameters are ignored.                                *
+# More specific cuts can be specified in SubProcesses/cuts.f           *
+#***********************************************************************
+ 20.0  = ptgmin    ! Min photon transverse momentum
+ -1.0  = etagamma  ! Max photon abs(pseudo-rap)
+  0.4  = R0gamma   ! Radius of isolation code
+  1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Cuts associated to MASSIVE particles identified by their PDG codes.  *
+# All cuts are applied to both particles and anti-particles, so use    *
+# POSITIVE PDG CODES only. Example of the syntax is {6 : 100} or       *
+# {6:100, 25:200} for multiple particles                               *
+#***********************************************************************
+  {} = pt_min_pdg ! Min pT for a massive particle
+  {} = pt_max_pdg ! Max pT for a massive particle
+  {} = mxx_min_pdg ! inv. mass for any pair of (anti)particles
+#***********************************************************************
+# For aMCfast+APPLGRID use in PDF fitting (http://amcfast.hepforge.org)*
+#***********************************************************************
+ 0 = iappl ! aMCfast switch (0=OFF, 1=prepare grids, 2=fill grids)
+#***********************************************************************

--- a/genfragments/ThirteenPointSixTeV/Higgs/HH/VHH_HToBB_HToBB_M-125_TuneCP5_13p6TeV-madgraph-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HH/VHH_HToBB_HToBB_M-125_TuneCP5_13p6TeV-madgraph-pythia8.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13600.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+                                    '25:onMode = off',
+                                    '25:onIfMatch = 5 -5'
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters')
+    )
+)

--- a/genfragments/ThirteenPointSixTeV/Higgs/HH/VHH_HToBB_HToBB_M-125_TuneCP5_13p6TeV-madgraph-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HH/VHH_HToBB_HToBB_M-125_TuneCP5_13p6TeV-madgraph-pythia8.py
@@ -4,7 +4,7 @@ from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
-generator = cms.EDFilter("Pythia8HadronizerFilter",
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaPylistVerbosity = cms.untracked.int32(1),
     filterEfficiency = cms.untracked.double(1.0),


### PR DESCRIPTION
Dear GEN experts, 

I have prepared MG cards for ZHH to 4b and WHH to 4b non resonant processes for Run-3 analyses. These processes make use of VBF HH's model to modify coupling parameters (kappa_V, kappa_VV and kappa_lambda) at LO. We also need NLO WHH and ZHH (including loop-induced ggZHH diagrams) at SM point to reweigh signals to NLO and NNLO, respectively, as done in Run-2 (HIG-22-006). 

Best,
Chayanit for VHH team 