### PR TITLE
POWHEG fixes for CMSSW12 and 13 (processes with GoSam libraries and multiple fullgrid files)

### DIFF
--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -18,8 +18,11 @@ if [ -e $$WORKDIR/$$folderName/pwg-st3-0001-stat.dat ]; then
   cp -p $$WORKDIR/$$folderName/pwg-st3-0001-stat.dat $$WORKDIR/$$folderName/pwg-stat.dat
 fi
 
-FULLGRIDRM=`ls $${WORKDIR}/$${folderName} | grep fullgrid-rm`
-FULLGRIDBTL=`ls $${WORKDIR}/$${folderName} | grep fullgrid-btl`
+FULLGRIDRM=`ls $${WORKDIR}/$${folderName} | grep fullgrid-rm | head -n 1`
+FULLGRIDBTL=`ls $${WORKDIR}/$${folderName} | grep fullgrid-btl | head -n 1`
+FULLGRIDRM=$${FULLGRIDRM%?}
+FULLGRIDBTL=$${FULLGRIDBTL%?}
+
 if [ $${#FULLGRIDRM} -gt 0 -a $${#FULLGRIDBTL} -gt 0 ]; then
   cp -p $$WORKDIR/$$folderName/$${FULLGRIDRM} $$WORKDIR/$$folderName/pwgfullgrid-rm.dat
   cp -p $$WORKDIR/$$folderName/$${FULLGRIDBTL} $$WORKDIR/$$folderName/pwgfullgrid-btl.dat

--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -138,7 +138,7 @@ pwhg_main:#g' Makefile
 echo "pwhg_main.o: svn.version" >> Makefile
 echo "lhefwrite.o: svn.version" >> Makefile
 
-# Fix gcc8 error
+# Fix gcc>8 error
 sed -i -e "s#F77=gfortran#F77=gfortran -std=legacy#g" Makefile
 sed -i -e "s#F77= gfortran#F77= gfortran -std=legacy#g" Makefile
 sed -i -e "s#FFLAGS= #FFLAGS= -std=legacy #g" virtual/Source/make_opts
@@ -184,15 +184,24 @@ sed -i -e "s#LHAPDF_CONFIG[ \t]*=[ \t]*#\#LHAPDF_CONFIG=#g" Makefile
 sed -i -e "s#DEBUG[ \t]*=[ \t]*#\#DEBUG=#g" Makefile
 sed -i -e "s#FPE[ \t]*=[ \t]*#\#FPE=#g" Makefile
 
-$patch_4 
+if [[ `grep GoSam Makefile` != "" || `grep Gosam Makefile` != "" || `grep GOSAM Makefile` != "" ]]; then
+  sed -i -e "s#-fno-automatic#-fallow-invalid-boz#g" Makefile
+fi
 
+$patch_4 
 
 # Add libraries now
 NEWRPATH1=`ls /cvmfs/cms.cern.ch/$${SCRAM_ARCH}/external/gcc/*/* | grep "/lib64" | head -n 1`
 NEWRPATH1=$${NEWRPATH1%?}
 NEWRPATH2=`ls /cvmfs/cms.cern.ch/$${SCRAM_ARCH}/external/zlib-x86_64/*/* | grep "/lib" | head -n 1`
 NEWRPATH2=$${NEWRPATH2%?}
-echo "RPATHLIBS= -Wl,-rpath,$${NEWRPATH1} -L$${NEWRPATH1} -lgfortran -lstdc++ -Wl,-rpath,$${NEWRPATH2} -L$${NEWRPATH2} -lz" >> tmpfile
+
+# Add back python3.6m brutally
+if [[ $$process == "ggHH" || $$process == "ggHH_SMEFT" ]]; then
+  echo "RPATHLIBS= -Wl,-rpath,$${NEWRPATH1} -L$${NEWRPATH1} -lgfortran -lstdc++ -Wl,-rpath,$${NEWRPATH2} -L$${NEWRPATH2} -lz -L/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_0_0_pre13/external/slc7_amd64_gcc900/lib -lpython3.6m" >> tmpfile
+else
+  echo "RPATHLIBS= -Wl,-rpath,$${NEWRPATH1} -L$${NEWRPATH1} -lgfortran -lstdc++ -Wl,-rpath,$${NEWRPATH2} -L$${NEWRPATH2} -lz" >> tmpfile
+fi
 
 $patch_5 
 


### PR DESCRIPTION
Cumulative fixes for:

- Processes using GoSam which needs special compilation flags for gfortran >= 10.3
- POWHEG-RES processes that produce multiple "fullgrid" files at stage 3

@agrohsje 