### PR TITLE
Patch to bypass DIS warning when running photoproduction at NLO

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TT_PHOTOPRODUCTION/antoniocotar_ttbar_NLO_photoproduction_bypassDISWarning-nlo.patch
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TT_PHOTOPRODUCTION/antoniocotar_ttbar_NLO_photoproduction_bypassDISWarning-nlo.patch
@@ -1,0 +1,13 @@
+--- a/madgraph/various/banner.py	2023-03-28 23:08:20.692089612 +0200
++++ b/madgraph/various/banner.py	2023-03-28 23:08:15.083542354 +0200
+@@ -4286,8 +4286,8 @@
+
+         # for lepton-lepton collisions, ignore 'pdlabel' and 'lhaid'
+         if abs(self['lpp1'])!=1 or abs(self['lpp2'])!=1:
+-            if self['lpp1'] == 1 or self['lpp2']==1:
+-                raise InvalidRunCard('Process like Deep Inelastic scattering not supported at NLO accuracy.')
++       #     if self['lpp1'] == 1 or self['lpp2']==1:
++       #         raise InvalidRunCard('Process like Deep Inelastic scattering not supported at NLO accuracy.')
+
+             if self['pdlabel']!='nn23nlo' or self['reweight_pdf']:
+                 self['pdlabel']='nn23nlo'

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TW_PHOTOPRODUCTION/antoniocotar_tw_NLO_photoproduction_bypassDISWarning-nlo.patch
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TW_PHOTOPRODUCTION/antoniocotar_tw_NLO_photoproduction_bypassDISWarning-nlo.patch
@@ -1,0 +1,13 @@
+--- a/madgraph/various/banner.py	2023-03-28 23:08:20.692089612 +0200
++++ b/madgraph/various/banner.py	2023-03-28 23:08:15.083542354 +0200
+@@ -4286,8 +4286,8 @@
+
+         # for lepton-lepton collisions, ignore 'pdlabel' and 'lhaid'
+         if abs(self['lpp1'])!=1 or abs(self['lpp2'])!=1:
+-            if self['lpp1'] == 1 or self['lpp2']==1:
+-                raise InvalidRunCard('Process like Deep Inelastic scattering not supported at NLO accuracy.')
++       #     if self['lpp1'] == 1 or self['lpp2']==1:
++       #         raise InvalidRunCard('Process like Deep Inelastic scattering not supported at NLO accuracy.')
+
+             if self['pdlabel']!='nn23nlo' or self['reweight_pdf']:
+                 self['pdlabel']='nn23nlo'


### PR DESCRIPTION
# PR description
TMG had a request for ttbar and tW photoproduction with aMC@NLO. The plan is to produce ttbar and tW samples at NLO, but aMC@NLO Deep Inelastic Scattering production is only supported up to LO. This can be patched with the files I include in this PR.

# Modifications
This PR includes a patch file in two different directories:
   `cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TT_PHOTOPRODUCTION/`
   `cards/production/2017/13TeV/TT_TW_PHOTOPRODUCTION/TW_PHOTOPRODUCTION/`

# Validation
So far with this patch I've been able to generate ttbar photoproduction at NLO, and I get the following result at NLO:

      Summary:
      Process p a > t t~ [QCD] ; a p > t t~ [QCD]
      Run at p-elastic photon from p collider (6500.0 + 6500.0 GeV)
      Number of events generated: 5000
      Total cross section: 3.905e+00 +- 3.3e-02 pb

The corresponding gridpack can be found in `/afs/cern.ch/work/c/cvicovil/public/antoniocotar_ttbar_NLO_photoproduction_slc7_amd64_gcc10_CMSSW_12_4_8_tarball.tar.xz`
# More information
- The cards above were initially merged in the master branch during PR [3336](https://github.com/cms-sw/genproductions/pull/3336). 
- There is a discussion in [launchapd](https://answers.launchpad.net/mg5amcnlo/+question/689742) where a similar issue to what we have was discussed by Olivier, Marco Zaro and the creator of the post. The solution given by Olivier in post 37 is what I implement in this PR.  