### PR TITLE
Manually Set VLQ BR to 1/3 for Wb,Ht,Zt

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic/SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic/SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -2,3 +2,8 @@ set param_card mass 9936661 8.000000e+03
 set param_card mass 9936662 3.000000e+03
 set param_card decay 9936661 1.000000e+02 
 set param_card decay 9936662 1.595357e+01
+#          BR         NDA      ID1       ID2
+     0.33333333E+00    2           5        24   # BR(chi ->  b    W+)
+     0.33333333E+00    2           6        23   # BR(chi ->  t    Z)
+     0.33333333E+00    2           6        25   # BR(chi ->  t    H)
+#


### PR DESCRIPTION
In the customize_card I manually set the chi (VLQ) branching fraction to 1/3 for each of its decays (Wb,Zt,Ht). This makes MC coming from these cards more convenient for NN training where you will want equal numbers of each decay product. 