### PR TITLE
Adding missing Run3 H production cards with H undecayed

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinc.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive/HZJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinc.input
@@ -1,0 +1,76 @@
+vdecaymode   10  ! 1,2,3 => electron,muon,tau; 4,5,6 => respective neutrinos
+                 ! 4:    nu e,     5:    nu mu,     6:    nu tau,
+                 ! 0:    had,     10:    inc
+hdecaymode  -1  ! undecayed Higgs boson (for PYTHIA and HERWIG)
+
+hmass  125d0        ! Higgs boson mass 
+hwidth 0.407d-2     ! Higgs boson width 
+
+min_h_mass    10d0      
+max_h_mass  1000d0 
+
+min_z_mass     10d0
+max_z_mass    1000d0
+
+
+
+numevts NEVENTS   ! number of events to be generated
+ih1 1             ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2 1             ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+bornktmin 0.26d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
+
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)	
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+! the typical call uses 1/1400 seconds (1400 calls per second)
+ncall1 100000      ! Number of calls for the construction of the importance sampling grid
+itmx1 1           ! Number of iterations for grid
+ncall2 100000      ! Number of calls for the computation of the upper bounding envelope
+                  ! for the generation of radiation
+itmx2 1           ! Number of iterations for the above
+! Notice: the total number of calls is ncall2*itmx2*foldcsi*foldy*foldphi
+foldcsi 2         ! number of folds on csi integration
+foldy   5         ! number of folds on  y  integration
+foldphi 2         ! number of folds on phi integration
+
+nubound 100000 ! number of calls to set up the upper bounding norms for radiation
+               ! This is performed using only the Born cross section (fast)
+
+
+! OPTIONAL PARAMETERS
+
+withnegweights 1  ! (default 0) if on (1) use negative weights
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+iseed    SEED        !  Start the random number generator with seed iseed
+
+xgriditeration 1
+fastbtlbound 1
+
+storeinfo_rwgt 0   ! store info to allow for reweighting
+pdfreweight 0
+
+
+
+minlo 1    
+minlo_nnll 1  
+
+# if running with minlo, set the following to 0
+massivetop   0 
+
+sudscalevar   1
+
+doublefsr 1 
+
+nohad   1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/WminusHJ_HanythingJ_NNPDF31_13p6TeV/HWminusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/WminusHJ_HanythingJ_NNPDF31_13p6TeV/HWminusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive.input
@@ -1,0 +1,75 @@
+idvecbos          -24   !    24:    W+  boson,    -24:    W-  boson
+vdecaymode        10    ! 1: e-nu, 2: mu-nu, 3: tau-nu, 0: hadronic, 10: inclusive, 11: inclusive leptons
+hdecaymode        -1    ! undecayed Higgs boson (for PYTHIA and HERWIG)
+
+hmass  125d0        ! Higgs boson mass 
+hwidth 0.00407d0     ! Higgs boson width 
+
+min_h_mass    10d0      
+max_h_mass  1000d0 
+
+min_w_mass     10d0
+max_w_mass   1000d0
+
+
+numevts NEVENTS
+ih1 1             ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2 1             ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+bornktmin 0.26d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
+
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)	
+
+bornktmin 0.26d0 ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0) mass param for Born suppresion factor. If < 0 suppfact = 1
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+! the typical call uses 1/1400 seconds (1400 calls per second)
+ncall1 400000      ! Number of calls for the construction of the importance sampling grid
+itmx1 1           ! Number of iterations for grid
+ncall2 400000      ! Number of calls for the computation of the upper bounding envelope
+                  ! for the generation of radiation
+itmx2 1           ! Number of iterations for the above
+! Notice: the total number of calls is ncall2*itmx2*foldcsi*foldy*foldphi
+foldcsi 2         ! number of folds on csi integration
+foldy   5         ! number of folds on  y  integration
+foldphi 2         ! number of folds on phi integration
+
+nubound 600000 ! number of calls to set up the upper bounding norms for radiation
+               ! This is performed using only the Born cross section (fast)
+
+
+! OPTIONAL PARAMETERS
+
+withnegweights 1  ! (default 0) if on (1) use negative weights
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+iseed SEED
+
+fastbtlbound 1
+storemintupb 1
+
+storeinfo_rwgt 0
+pdfreweight 0
+
+minlo 1    
+minlo_nnll 1  
+
+# if running with minlo, set the following to 0
+massivetop   0 
+
+sudscalevar   1
+
+doublefsr 1 
+
+nohad   1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/WplusHJ_HanythingJ_NNPDF31_13p6TeV/HWplusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/WplusHJ_HanythingJ_NNPDF31_13p6TeV/HWplusJ_HanythingJ_NNPDF31_13p6TeV_M125_Vinclusive.input
@@ -1,0 +1,76 @@
+idvecbos          24    !    24:    W+  boson,    -24:    W-  boson
+vdecaymode        10    ! 1: e-nu, 2: mu-nu, 3: tau-nu, 0: hadronic, 10: inclusive, 11: inclusive leptons
+hdecaymode        -1    ! undecayed Higgs boson (for PYTHIA and HERWIG)
+
+hmass  125d0        ! Higgs boson mass 
+hwidth 0.00407d0     ! Higgs boson width 
+
+min_h_mass    10d0      
+max_h_mass  1000d0 
+
+min_w_mass     10d0
+max_w_mass   1000d0
+
+
+numevts NEVENTS
+ih1 1             ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2 1             ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+bornktmin 0.26d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
+
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)	
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+! the typical call uses 1/1400 seconds (1400 calls per second)
+ncall1 400000      ! Number of calls for the construction of the importance sampling grid
+itmx1 1           ! Number of iterations for grid
+ncall2 400000      ! Number of calls for the computation of the upper bounding envelope
+                  ! for the generation of radiation
+itmx2 1           ! Number of iterations for the above
+! Notice: the total number of calls is ncall2*itmx2*foldcsi*foldy*foldphi
+foldcsi 2         ! number of folds on csi integration
+foldy   5         ! number of folds on  y  integration
+foldphi 2         ! number of folds on phi integration
+
+nubound 600000 ! number of calls to set up the upper bounding norms for radiation
+               ! This is performed using only the Born cross section (fast)
+
+
+! OPTIONAL PARAMETERS
+
+withnegweights 1 ! (default 0) if on (1) use negative weights
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+
+
+iseed SEED
+fastbtlbound 1
+storemintupb 1
+
+storeinfo_rwgt 0
+pdfreweight 0
+
+
+
+minlo 1    
+minlo_nnll 1  
+
+# if running with minlo, set the following to 0
+massivetop   0 
+
+sudscalevar   1
+
+doublefsr 1 
+
+nohad   1
+

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13p6TeV/gg_H_quark-mass-effects_NNPDF31_13p6TeV.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/gg_H_quark-mass-effects_NNPDF31_13p6TeV/gg_H_quark-mass-effects_NNPDF31_13p6TeV.input
@@ -1,0 +1,58 @@
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
+itmx2  5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+hfact    60.0d0    ! (default no dumping factor) dump factor for high-pt radiation: > 0 dumpfac=h**2/(pt2+h**2)
+runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality;
+                  ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
+
+iseed SEED
+
+! GGF_H production:
+! **** Mandatory parameters for ALL models ****
+massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
+zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+model 0
+gfermi 0.116637D-04        ! GF
+hdecaymode -1      ! PDG code for first decay product of the higgs
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+
+! **** Mandatory parameters for SM or MW ****
+hmass 125d0            ! Higgs boson mass
+hwidth 0.00407D0     ! Higgs boson width
+topmass 172.5        ! top quark mass
+bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quark
+
+! Optional
+hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
+withnegweights 1 
+pdfreweight 0
+storeinfo_rwgt 0
+bwshape 3 ! complex-pole scheme according to Passarino et al.


### PR DESCRIPTION
Adding missing Run3 H production cards for the standard Higgs and processes (ggH, W-H, W+H, and HZ). Plan is to use for the future H->tau tau requests.