### PR TITLE
Updating PDF to NNPDF31_lo_as_0130 for ggZZ Run3 HZZ bkg samples

### DIFF
--- a/bin/MCFM/cards/ggZZ/ggZZbx_2e2Tau_lord_NNPDF31_13p6TeV.DAT
+++ b/bin/MCFM/cards/ggZZ/ggZZbx_2e2Tau_lord_NNPDF31_13p6TeV.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'  [LHAPDF group]
+'NNPDF31_lo_as_0130'  [LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/ggZZ/ggZZbx_2e2mu_lord_NNPDF31_13p6TeV.DAT
+++ b/bin/MCFM/cards/ggZZ/ggZZbx_2e2mu_lord_NNPDF31_13p6TeV.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'  [LHAPDF group]
+'NNPDF31_lo_as_0130'  [LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/ggZZ/ggZZbx_2mu2Tau_lord_NNPDF31_13p6TeV.DAT
+++ b/bin/MCFM/cards/ggZZ/ggZZbx_2mu2Tau_lord_NNPDF31_13p6TeV.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'  [LHAPDF group]
+'NNPDF31_lo_as_0130'  [LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]

--- a/bin/MCFM/cards/ggZZ/ggZZbx_4Tau_lord_NNPDF31_13p6TeV.DAT
+++ b/bin/MCFM/cards/ggZZ/ggZZbx_4Tau_lord_NNPDF31_13p6TeV.DAT
@@ -43,7 +43,7 @@ SEED		[ij]
 cteq6_l [pdlabel]
 4       [NGROUP, see PDFLIB]
 46      [NSET - see PDFLIB]
-'NNPDF31_nnlo_as_0118_mc_hessian_pdfas'  [LHAPDF group]
+'NNPDF31_lo_as_0130'  [LHAPDF group]
 0              [LHAPDF set]
 
 [Jet definition and event cuts]


### PR DESCRIPTION
The new pdf setting already discussed here : https://cms-talk.web.cern.ch/t/hig-hzz-pdf-settings-to-use-for-gluglutocontintozzt4l-hzz-bkg-samples/20447