### PR TITLE
rename HHto4B GEN fragment for general HH productions

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/HH/HHto4B_TuneCP5_13p6TeV_madgraph-pythia8.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HH/HHto4B_TuneCP5_13p6TeV_madgraph-pythia8.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13600.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+                                    '25:onMode = off',
+                                    '25:onIfMatch = 5 -5'
+          ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters')
+    )
+)


### PR DESCRIPTION
Hi GEN expert, 

I would like to rename this GEN fragment so it can be used for general HH to 4b productions (VBF, VHH) 

Thank you in advance.

Best,
Chayanit