### PR TITLE
Add cards for individual VLQ decays for SuuToChiChi Fully Hadronic (mg265ul version) 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/.log
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/.log
@@ -1,0 +1,9 @@
+Starting job on  Mon May 29 21:48:57 CDT 2023
+Running on  Linux cmslpc145.fnal.gov 3.10.0-1160.88.1.el7.x86_64 #1 SMP Tue Mar 7 08:37:40 CST 2023 x86_64 x86_64 x86_64 GNU/Linux
+System release  Scientific Linux release 7.9 (Nitrogen)
+name: cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/
+carddir: cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/
+queue: local
+scram_arch: slc7_amd64_gcc10
+cmssw_version: CMSSW_12_4_8
+/uscms/home/cannaert/nobackup/gridpackGeneration/genproductions/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV//cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/_proc_card.dat  does not exist!

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/.log
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/.log
@@ -1,9 +1,0 @@
-Starting job on  Mon May 29 21:48:57 CDT 2023
-Running on  Linux cmslpc145.fnal.gov 3.10.0-1160.88.1.el7.x86_64 #1 SMP Tue Mar 7 08:37:40 CST 2023 x86_64 x86_64 x86_64 GNU/Linux
-System release  Scientific Linux release 7.9 (Nitrogen)
-name: cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/
-carddir: cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/
-queue: local
-scram_arch: slc7_amd64_gcc10
-cmssw_version: CMSSW_12_4_8
-/uscms/home/cannaert/nobackup/gridpackGeneration/genproductions/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV//cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/_proc_card.dat  does not exist!

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+generate p p > suu > W+ b W+ b, W+ > j5 j5
+
+output SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV_run_card.dat
@@ -51,7 +51,7 @@
  91.188  = scale            ! fixed ren scale
  91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
  91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
- -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 2 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
  1.0  = scalefact        ! scale factor for event-by-event scales
 #*********************************************************************
 # Type and output format

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_WbWb_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbWb/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_WbWb_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_WbWb_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+add process p p > suu > W+ b Z t, W+ > j5 j5, Z > j5 j5, (t > W+ b, W+ > j5 j5)
+
+output SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_WbZt_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_WbZt_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_WbZt/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_WbZt_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+generate p p > suu >  W+ b H t, W+ > j5 j5, (t > W+ b, W+ > j5 j5), H > j5 j5
+
+output SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_Wbht_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_Wbht/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_Wbht_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_Wbht_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+generate p p > suu > Z t Z t, Z > j5 j5, (t > W+ b, W+ > j5 j5)
+
+output SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_ZtZt_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_ZtZt/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_ZtZt_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_ZtZt_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+add process p p > suu > H t Z t, (t > W+ b, W+ > j5 j5), Z > j5 j5, H > j5 j5
+
+output SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_htZt_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_htZt_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htZt/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_htZt_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 9936661 8.000000e+03
+set param_card mass 9936662 3.000000e+03
+set param_card decay 9936661 1.000000e+02 
+set param_card decay 9936662 1.595357e+01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_extramodels.dat
@@ -1,0 +1,1 @@
+diquarkVLQ2020_UFO.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_proc_card.dat
@@ -1,0 +1,6 @@
+import model diquarkVLQ2020_UFO
+define j5 = g u c d s b u~ c~ d~ s~ b~
+
+add process p p > suu > H t H t, (t > W+ b, W+ > j5 j5), H > j5 j5
+
+output SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV/SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV_run_card.dat
@@ -1,0 +1,93 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  5000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6500.0     = ebeam1  ! beam 1 total energy in GeV
+     6500.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     lhapdf = pdlabel ! PDF set
+     $DEFAULT_PDF_SETS = lhaid
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/makeDataCards.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+import sys
+import os
+def makeDataCards():
+    MSuu = [4.0,5.0,6.0,7.0,8.0]
+    MChi = [1.0,1.5,2.0,2.5,3.0]
+    MSuu_str = ["4","5","6","7","8"]
+    MChi_str = ["1","1p5","2","2p5","3"]
+    templateFolder = "SuuToChiChi_FullyHadronic_htht_MSuu8TeV_MChi3TeV"
+    templateSuffix = ["_customizecards.dat", "_extramodels.dat", "_proc_card.dat","_run_card.dat"]
+    for Suu_index,mass_Suu in enumerate(MSuu):
+        for Chi_index, mass_Chi in enumerate(MChi):
+            if ((2*mass_Chi) >=  mass_Suu):
+                continue
+            if mass_Chi == 3.0 and mass_Suu == 8.0:
+                print "skipping template cards"
+                continue
+            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            for suffix in templateSuffix:
+                templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
+                if not os.path.exists(newCardFolder):
+                    os.makedirs(newCardFolder)
+                cardToCreate = open(newCardFolder+"/"+newCardFolder+suffix,"w")
+                #change lines 
+                for line in templateFile:
+                    splitLine = line.split()
+                    if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        #print(1)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
+                        cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")
+                        #print(2)
+                    elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936662"):
+                        cardToCreate.write("set param_card mass 9936662 "+ str(mass_Chi) +"00000e+03\n")
+                        #print(3)
+                    else:
+                        cardToCreate.write(line)   
+
+
+##############################################################################
+#MAIN
+##############################################################################
+def main(argv): 
+    makeDataCards()
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/makeDataCards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/SuuToChiChi_FullyHadronic_htht/makeDataCards.py
@@ -16,7 +16,7 @@ def makeDataCards():
             if mass_Chi == 3.0 and mass_Suu == 8.0:
                 print "skipping template cards"
                 continue
-            newCardFolder = "SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
+            newCardFolder = "SuuToChiChi_FullyHadronic_htht_MSuu"+MSuu_str[Suu_index] + "TeV_MChi"+MChi_str[Chi_index]+"TeV"
             for suffix in templateSuffix:
                 templateFile = open(templateFolder+"/"+templateFolder+suffix,"r")
                 if not os.path.exists(newCardFolder):
@@ -26,7 +26,7 @@ def makeDataCards():
                 for line in templateFile:
                     splitLine = line.split()
                     if len(splitLine) and splitLine[0] == "output": # SuuToChiChi_FullyHadronic_MSuu8TeV_MChi3TeV":
-                        cardToCreate.write("output SuuToChiChi_FullyHadronic_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
+                        cardToCreate.write("output SuuToChiChi_FullyHadronic_htht_MSuu"+MSuu_str[Suu_index]+"TeV_MChi"+MChi_str[Chi_index]+"TeV\n")
                         #print(1)
                     elif (len(splitLine) > 3) and (splitLine[0] == "set") and (splitLine[2] == "mass") and (splitLine[3] == "9936661"):
                         cardToCreate.write("set param_card mass 9936661 "+ str(mass_Suu) +"00000e+03\n")


### PR DESCRIPTION
To get around the problem we were seeing with the branching fractions being off with the full Suu->chi chi -> hadrons process, we decided it would make more sense to generate the subprocesses (Suu -> chi chi > {WbWb, htht, ZtZt, Wbht, WbZt, htZt} individually. This way we can scale to guarantee  branching fractions are what we want, and it ultimately makes it easier for us to do our NN training. The MC these cards will create will be UL16-UL18, so these cards have been created in a fork of the mg265UL branch, and I have made gridpacks from each subprocess and verified that these are working. No other aspect of the cards aside from the process has been changed. 