### PR TITLE
Adding Run2 and Run3 0-40GeV Diphoton Sherpa Datacards

### DIFF
--- a/bin/Sherpa/cards/production/13TeV/higgs/Run.dat_13TeV_gamgam_3j_loop_Mgg0-40
+++ b/bin/Sherpa/cards/production/13TeV/higgs/Run.dat_13TeV_gamgam_3j_loop_Mgg0-40
@@ -1,0 +1,35 @@
+ (run){
+ EVENTS 1000;
+ EVENT_MODE HepMC;
+ ME_SIGNAL_GENERATOR Comix Internal;
+ EVENT_GENERATION_MODE Unweighted;
+ BEAM_1 2212; BEAM_ENERGY_1 6500.;
+ BEAM_2 2212; BEAM_ENERGY_2 6500.;
+ PDF_LIBRARY     LHAPDFSherpa;
+ PDF_SET         NNPDF30_nnlo_as_0118;
+ PDF_SET_VERSION 0;
+ PDF_GRID_PATH   PDFsets;
+ CSS_EW_MODE 1;
+ ME_QED Off;
+}(run)
+ (processes){
+ Process 21 21 -> 22 22;
+ Scales VAR{Abs2(p[2]+p[3])};
+ ME_Generator Internal;
+ Loop_Generator gg_yy;
+ End process;
+ Process 93 93 -> 22 22 93{3};
+ Order (*,2);
+ Enhance_Factor 2 {3};
+ Enhance_Factor 5 {4};
+ Enhance_Factor 10 {5};
+ CKKW sqr(20./E_CMS);
+ Integration_Error 0.005 {3};
+ Integration_Error 0.03 {4};
+ Integration_Error 0.05 {5};
+ End process;
+}(processes)
+ (selector){
+ Mass  22 22 0. 40.;
+ PT 22 10. E_CMS;
+}(selector)

--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_gamgam_3j_loop_Mgg0-40
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_gamgam_3j_loop_Mgg0-40
@@ -1,0 +1,35 @@
+ (run){
+ EVENTS 1000;
+ EVENT_MODE HepMC;
+ ME_SIGNAL_GENERATOR Comix Internal;
+ EVENT_GENERATION_MODE Unweighted;
+ BEAM_1 2212; BEAM_ENERGY_1 6800.;
+ BEAM_2 2212; BEAM_ENERGY_2 6800.;
+ PDF_LIBRARY     LHAPDFSherpa;
+ PDF_SET         NNPDF30_nnlo_as_0118;
+ PDF_SET_VERSION 0;
+ PDF_GRID_PATH   PDFsets;
+ CSS_EW_MODE 1;
+ ME_QED Off;
+}(run)
+ (processes){
+ Process 21 21 -> 22 22;
+ Scales VAR{Abs2(p[2]+p[3])};
+ ME_Generator Internal;
+ Loop_Generator gg_yy;
+ End process;
+ Process 93 93 -> 22 22 93{3};
+ Order (*,2);
+ Enhance_Factor 2 {3};
+ Enhance_Factor 5 {4};
+ Enhance_Factor 10 {5};
+ CKKW sqr(20./E_CMS);
+ Integration_Error 0.005 {3};
+ Integration_Error 0.03 {4};
+ Integration_Error 0.05 {5};
+ End process;
+}(processes)
+ (selector){
+ Mass  22 22 0. 40.;
+ PT 22 10. E_CMS;
+}(selector)


### PR DESCRIPTION
This PR is for adding the datacards of the Run 2 and Run 3 0-40 GeV diphoton background sample generated using Sherpa for official production.