### PR TITLE
Fix automated gridpack production for Powheg Box RES

### DIFF
--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -43,8 +43,9 @@ ISVRES="false"
 grep -qi "powhegboxRES" $$WORKDIR/$$folderName/VERSION ; test $$? -ne 0  || ISVRES="true"
 # For Powheg vRES, if the gridpack has been produced in several stages (using manyseeds 1),
 # we need to turn on manyseeds & parallelstage also for the final gridpack.
-# we test whether manyseeds has been used by checking if "pwgubound-0001.dat" exists
-if [ $$ISVRES == "true" -a -f "$$WORKDIR/$$folderName/pwgubound-0001.dat" ]; then
+# we test whether manyseeds has been used by checking if there is more than one "pwgubound-XXXX.dat" file exists
+NUMUBOUND=`ls $${WORKDIR}/$${folderName} | egrep 'pwgubound-.+.dat' | wc -l`
+if [ $$ISVRES == "true" -a $$NUMUBOUND -gt 1 ]; then
   echo "Detected Powheg Box RES and a parallel gridpack production. Turning on manyseeds in final gridpack"
   sed -i "s/^.*manyseeds.*/manyseeds 1/g" powheg.input
   sed -i "s/^.*parallelstage.*/parallelstage 4/g" powheg.input

--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -39,10 +39,21 @@ sed -i "s/^numevts.*/numevts NEVENTS/g" powheg.input
 sed -i "s/^iseed.*/iseed SEED/g" powheg.input
 grep -q "withnegweights" powheg.input; test $$? -eq 0 || printf "\nwithnegweights 1\n" >> powheg.input
 
-# turn into single run mode
-sed -i "s/^manyseeds.*/#manyseeds 1/g" powheg.input
-sed -i "s/^parallelstage.*/#parallelstage 4/g" powheg.input
-sed -i "s/^xgriditeration/#xgriditeration 1/g" powheg.input
+ISVRES=`grep -i 'powhegboxRES' $$WORKDIR/$$folderName/VERSION`
+# For Powheg vRES, if the gridpack has been produced in several stages (using manyseeds 1),
+# we need to turn on manyseeds & parallelstage also for the final gridpack.
+# we test whether manyseeds has been used by checking if "pwgubound-0001.dat" exists
+if [ -n $$ISVRES -a -f "$$WORKDIR/$$folderName/pwgubound-0001.dat" ]; then
+  echo "Detected Powheg Box RES and a parallel gridpack production. Turning on manyseeds in final gridpack"
+  sed -i "s/^.*manyseeds.*/manyseeds 1/g" powheg.input
+  sed -i "s/^.*parallelstage.*/parallelstage 4/g" powheg.input
+  sed -i "s/^.*xgriditeration.*/xgriditeration 1/g" powheg.input
+else
+  # turn into single run mode
+  sed -i "s/^manyseeds.*/#manyseeds 1/g" powheg.input
+  sed -i "s/^parallelstage.*/#parallelstage 4/g" powheg.input
+  sed -i "s/^xgriditeration.*/#xgriditeration 1/g" powheg.input
+fi
 
 # turn off obsolete stuff
 sed -i "s/^pdfreweight.*/#pdfreweight 0/g" powheg.input

--- a/bin/Powheg/Templates/createTarBall_template.sh
+++ b/bin/Powheg/Templates/createTarBall_template.sh
@@ -39,11 +39,12 @@ sed -i "s/^numevts.*/numevts NEVENTS/g" powheg.input
 sed -i "s/^iseed.*/iseed SEED/g" powheg.input
 grep -q "withnegweights" powheg.input; test $$? -eq 0 || printf "\nwithnegweights 1\n" >> powheg.input
 
-ISVRES=`grep -i 'powhegboxRES' $$WORKDIR/$$folderName/VERSION`
+ISVRES="false"
+grep -qi "powhegboxRES" $$WORKDIR/$$folderName/VERSION ; test $$? -ne 0  || ISVRES="true"
 # For Powheg vRES, if the gridpack has been produced in several stages (using manyseeds 1),
 # we need to turn on manyseeds & parallelstage also for the final gridpack.
 # we test whether manyseeds has been used by checking if "pwgubound-0001.dat" exists
-if [ -n $$ISVRES -a -f "$$WORKDIR/$$folderName/pwgubound-0001.dat" ]; then
+if [ $$ISVRES == "true" -a -f "$$WORKDIR/$$folderName/pwgubound-0001.dat" ]; then
   echo "Detected Powheg Box RES and a parallel gridpack production. Turning on manyseeds in final gridpack"
   sed -i "s/^.*manyseeds.*/manyseeds 1/g" powheg.input
   sed -i "s/^.*parallelstage.*/parallelstage 4/g" powheg.input

--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -366,7 +366,7 @@ def runEvents(parstage, folderName, EOSfolder, njobs, powInputName, jobtag, proc
           f.write('tar xzf WW_MiNNLO_2loop_grids_reduced1.tar.gz\n')
           f.write('ls\n')
         f.write('cp -p ' + rootfolder + '/' + folderName + '/powheg.input.' + parstage + ' ./powheg.input' + '\n') # copy input file for this stage explicitly, needed by condor dag
-        f.write('echo ' + str (i) + ' | ./pwhg_main \n')
+        f.write('echo ' + str (i+1) + ' | ./pwhg_main \n')
         f.write('echo "Workdir after run:" \n')
         f.write('ls -ltr \n')
         f.write('cp -p -v -u *.top ' + rootfolder + '/' + folderName + '/. \n')

--- a/bin/Powheg/runcmsgrid_powheg.sh
+++ b/bin/Powheg/runcmsgrid_powheg.sh
@@ -169,8 +169,33 @@ if [ "$process" = "Z_ew-BMNNPV" ] || [ "$process" = "W_ew-BMNNP" ]; then
   sed -i '/rwl_file/d' powheg.input
 fi
 
-cat powheg.input
-../pwhg_main 2>&1 | tee log_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+# Check if we are running with the "manyseeds" option
+manyseeds="false"
+grep -qFx "manyseeds 1" powheg.input ; test $? -ne 0  || manyseeds="true"
+
+if [ "$manyseeds" == "true" ]; then
+  if [ "$produceWeights" == "true" ]; then
+    fail_exit "Error: not implemented"
+  fi
+
+  # With "manyseeds", powheg reads the seed from pwgseeds.dat
+  echo $seed > pwgseeds.dat
+
+  # Powheg expects the index of the seed to use as an command line argument
+  # Since we dont actually use the parallelization functionality of Powheg,
+  # we just write one seed to pwgseeds.dat and always pick seed 1
+  cat powheg.input
+  ../pwhg_main iwhichseed=1 2>&1 | tee log_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+
+  # Rename the produced LHE file to be what the rest of the script expects
+  mv pwgevents-0001.lhe pwgevents.lhe
+
+else
+  cat powheg.input
+  ../pwhg_main 2>&1 | tee log_${process}_${seed}.txt; test $? -eq 0 || fail_exit "pwhg_main error: exit code not 0"
+  
+fi
+
 
 if [ "${process}" == "X0jj" ]; then
     # now run reweighting for X0jj process


### PR DESCRIPTION
This PR fixes a problem in gridpacks for Powheg Box version RES which caused  the pre-sampling information, calculated during the gridpack production, to not be read in correctly. The result was that, when producing events, Powheg would hang for several hours while calculating the grid, only to end up with bad statistics since it only ran on one core. 

The cause for the bug is that Powheg vRES (in contrast to V2) only reads in information from previous stages when the option `manyseeds 1` is set. We use this option to compute the pre-sampling (`parallelstage 1-3`), but not for the actual event generation (`parallelstage 4`).

The fix consists of two parts:

a) When creating the final tarball, we make sure that the `manyseeds 1`,  `parallelstage 4` and `xgriditeration 1` options are set. `xgriditeration 1` is only needed because without it, Powheg will complain when `manyseeds 1` is set - its actual value is ignored.

b) As a consequence, the `runcmsgrid.sh` script has to be modified to run Powheg with the `manyseeds 1` option. This involves writing the RNG seed to the `pwgseeds.dat` file in addition to the `powheg.input` file, passing an additional command line argument to select said seed, and finally making sure the produced LHE file is at the correct spot for any post-processing.

I have checked that a working gridpack is produced with the `b_bbar_4l` process as an example. I also checked with the `hvq` process that Powheg Box V2 works the same as before.

In addition to this, an additional minor fix in `run_pwg_condor.py` is included which fixes the job index passed to Powheg during the pre-sampling in stages 2 and 3. For Powheg, indices start at 1 but so far, the first job had index 0, which caused this particular job to crash and thus one independent pre-sampling file less to be produced.