### PR TITLE
changing pta to ptgmin in run card

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Znunugamma_Monophoton_Ptg40to130_NLO_fxfx/Znunugamma_Monophoton_Ptg40to130_NLO_fxfx_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/Znunugamma_Monophoton_Ptg40to130_NLO_fxfx/Znunugamma_Monophoton_Ptg40to130_NLO_fxfx_run_card.dat
@@ -133,7 +133,7 @@
 # Photon-isolation cuts, according to hep-ph/9801442                   *
 # When ptgmin=0, all the other parameters are ignored                  *
 #***********************************************************************
-  40.0   =  pta     ! Min photon transverse momentum
+  40.0   =  ptgmin     ! Min photon transverse momentum
   2.6   =  etagamma   ! Max photon abs(pseudo-rap)
   0.05  =  R0gamma    ! Radius of isolation code
   1.0   =  xn         ! n parameter of eq.(3.4) in hep-ph/9801442


### PR DESCRIPTION
Hi there,
There was some issue of 'pta' variable coming up while creating gridpacks for 'Znunugamma_MonoPhoton_PtG40to130' process using the cards here which were merged to master branch via this PR, 
https://github.com/cms-sw/genproductions/pull/3454

After consulting with experts, I found out that 'pta' should be replace with 'ptgmin' and then it is working. 
In this PR I have changed 'pta' to 'ptgmin'