### PR TITLE
Increased the threshold for the 5F/4F check in gridpack_generation.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -339,7 +339,7 @@ make_gridpack () {
       fi
 	
       is5FlavorScheme=0
-      if tail -n 20 $LOGFILE | grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~"; then 
+      if tail -n 999 $LOGFILE | grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~"; then 
         is5FlavorScheme=1
       fi
     


### PR DESCRIPTION
Hi,

## Description
We have encountered an issue with some processes for which the 5F scheme is not properly settled
in the run card. The issue comes from the following check:

```
if tail -n 20 $LOGFILE | grep -q -e "^p *=.*b\~.*b" -e "^p *=.*b.*b\~"; then 
  is5FlavorScheme=1
fi
```

At that point, the `gridpack_generation.sh` script reads the last 20 lines of the logfile and searches for that line. It seems that searching for the last 20 lines is not enough for some cases, and because of this the process is considered as 4F. This is solved
by simply increasing the number of lines that are grepped with tail.

## Test bench
This has been tested in particular for ttW Run3 with MG29: with  `tail -n 20 $LOGFILE` the process was considered as 4F, with ` tail -n 999 $LOGFILE` the process is considered 5F.