### PR TITLE
Run2 bb4l

### DIFF
--- a/bin/Powheg/Templates/runGetSource_template.sh
+++ b/bin/Powheg/Templates/runGetSource_template.sh
@@ -48,7 +48,7 @@ grep -q "MGcosa" powheg.input; test $$? -eq 1 || forX0jj=1
 
 cd $$WORKDIR
 cd $${name}
-python ../make_rwl.py $${is5FlavorScheme} $${defaultPDF} $${forMiNNLO} $${forX0jj}
+python ../make_rwl.py $${is5FlavorScheme} $${defaultPDF} $${forMiNNLO} $${forX0jj} $${process}
 
 if [ -s ../JHUGen.input ]; then
   cp -p ../JHUGen.input JHUGen.input

--- a/bin/Powheg/Utilities/helpers.py
+++ b/bin/Powheg/Utilities/helpers.py
@@ -102,7 +102,8 @@ cd HJMiNNLO\n \
 patch -l -p0 -i ${WORKDIR}/patches/vj_minnlo_rwl_pdf_optimization.patch\n \
 patch -l -p0 -i ${WORKDIR}/patches/vj_minnlo_compiler_flags.patch\n \
 fi",
-    }.get(process,"")
+    "b_bbar_4l": "patch -l -p0 -i ${WORKDIR}/patches/b_bbar_4l_sameflavour.patch"
+}.get(process,"")
 
 def runGetSource_patch_3(process) :
   return {

--- a/bin/Powheg/make_rwl.py
+++ b/bin/Powheg/make_rwl.py
@@ -173,12 +173,8 @@ elif process == "b_bbar_4l":
             "PDF_variation2 , replica" :
             [
                 [3400, 316200, 'NNPDF31_nnlo_as_0118_mc', 1],
-                [1500, 292200, 'NNPDF30_nlo_nf_5_pdfas', 1],
-                [1700, 292600, 'NNPDF30_nnlo_nf_5_pdfas', 1],
                 [1800, 315000, 'NNPDF31_lo_as_0118', 1],
                 [1850, 315200, 'NNPDF31_lo_as_0130', 1],
-                [1900, 262000, 'NNPDF30_lo_as_0118', 1],
-                [1950, 263000, 'NNPDF30_lo_as_0130', 1],
                 [15000, 82200, 'LUXqed17_plus_PDF4LHC15_nnlo_100', 1],
                 [16000, 325100, 'NNPDF31_nnlo_as_0118_luxqed', 1],
             ],

--- a/bin/Powheg/make_rwl.py
+++ b/bin/Powheg/make_rwl.py
@@ -131,6 +131,59 @@ elif forX0jj:
               [3000, 305800, 'NNPDF31_nlo_hessian_pdfas', 1],
             ],
   }
+elif process == "b_bbar_4l":
+    # 5F PDF
+    print("b_bbar_4l: Only using nominals for alternate PDFs for generation speed")
+    pdf_sets = {
+            # weight id, LHAPDF id, name, replicas to be written
+            "PDF_variation1 , hessian" :
+            [
+                [3200, 325300, 'NNPDF31_nnlo_as_0118_mc_hessian_pdfas', 103],
+                [2000, 306000, 'NNPDF31_nnlo_hessian_pdfas', 1],
+                [2104, 322500, 'NNPDF31_nnlo_as_0108', 1],
+                [2105, 322700, 'NNPDF31_nnlo_as_0110', 1],
+                [2106, 322900, 'NNPDF31_nnlo_as_0112', 1],
+                [2107, 323100, 'NNPDF31_nnlo_as_0114', 1],
+                [2108, 323300, 'NNPDF31_nnlo_as_0117', 1],
+                [2109, 323500, 'NNPDF31_nnlo_as_0119', 1],
+                [2110, 323700, 'NNPDF31_nnlo_as_0122', 1],
+                [2111, 323900, 'NNPDF31_nnlo_as_0124', 1],
+                [3000, 305800, 'NNPDF31_nlo_hessian_pdfas', 1],
+                [5000, 13000, 'CT14nnlo', 1],
+                [5060, 13065, 'CT14nnlo_as_0116', 1],
+                [5070, 13069, 'CT14nnlo_as_0120', 1],
+                [4000, 13100, 'CT14nlo', 1],
+                [4060, 13163, 'CT14nlo_as_0116', 1],
+                [4070, 13167, 'CT14nlo_as_0120', 1],
+                [4080, 13200, 'CT14lo', 1],
+                [6000, 25200, 'MMHT2014nlo68clas118', 1],
+                [7000, 25300, 'MMHT2014nnlo68cl', 1],
+                [7060, 25000, 'MMHT2014lo68cl', 1],
+                [8000, 42780, 'ABMP16als118_5_nnlo', 1],
+                [8500, 90200, 'PDF4LHC15_nlo_100_pdfas', 1],
+                [9000, 91200, 'PDF4LHC15_nnlo_100_pdfas', 1],
+                [10000, 90400, 'PDF4LHC15_nlo_30_pdfas', 1],
+                [11000, 91400, 'PDF4LHC15_nnlo_30_pdfas', 1],
+                [12000, 61100, 'HERAPDF20_NLO_EIG', 1],
+                [12050, 61130, 'HERAPDF20_NLO_VAR', 1],
+                [13000, 61200, 'HERAPDF20_NNLO_EIG', 1],
+                [13050, 61230, 'HERAPDF20_NNLO_VAR', 1],
+                [14000, 13400, 'CT14qed_inc_proton', 1],
+            ],
+            "PDF_variation2 , replica" :
+            [
+                [3400, 316200, 'NNPDF31_nnlo_as_0118_mc', 1],
+                [1500, 292200, 'NNPDF30_nlo_nf_5_pdfas', 1],
+                [1700, 292600, 'NNPDF30_nnlo_nf_5_pdfas', 1],
+                [1800, 315000, 'NNPDF31_lo_as_0118', 1],
+                [1850, 315200, 'NNPDF31_lo_as_0130', 1],
+                [1900, 262000, 'NNPDF30_lo_as_0118', 1],
+                [1950, 263000, 'NNPDF30_lo_as_0130', 1],
+                [15000, 82200, 'LUXqed17_plus_PDF4LHC15_nnlo_100', 1],
+                [16000, 325100, 'NNPDF31_nnlo_as_0118_luxqed', 1],
+            ],
+        }
+
 ### sets for Run3 start up 
 elif Period == "Run3":
     if int(is5FlavorScheme) == 1:

--- a/bin/Powheg/patches/b_bbar_4l_sameflavour.patch
+++ b/bin/Powheg/patches/b_bbar_4l_sameflavour.patch
@@ -1,0 +1,150 @@
+Index: Born.f
+===================================================================
+--- Born.f	(Revision 4004)
++++ Born.f	(Arbeitskopie)
+@@ -142,10 +142,10 @@
+       implicit none
+       logical, save :: ini = .true.
+       integer, save :: channel
+-      real * 8, save :: brtau2brmu, brtau2bre, mtau
++      real * 8, save :: brtau2brmu, brtau2bre, brmu2bre, mtau
+       real * 8 powheginput
+       real * 8 randomNumber, random
+-      real * 8, save :: weights(6), weightSum
++      real * 8, save :: weights(9), weightSum
+       integer i
+       external random
+       if (ini) then
+@@ -155,15 +155,24 @@
+         if (brtau2brmu < 0) brtau2brmu = 0.999270413
+         brtau2bre = powheginput('#br_tau/br_e')
+         if (brtau2bre < 0) brtau2bre = 0.99926856
++        brmu2bre = brtau2bre / brtau2brmu
+ c       prepare probability partitions
+-        weightSum = 2d0 + 2d0*brtau2brmu + 2d0*brtau2bre
++        if (channel.eq.8) then
++           weightSum = 2d0 + 2d0*brtau2brmu + 2d0*brtau2bre
++     1     + 1d0/brmu2bre + brmu2bre + brtau2brmu*brtau2bre
++        else
++           weightSum = 2d0 + 2d0*brtau2brmu + 2d0*brtau2bre
++        endif
+         weights(1:2) = 1d0
+         weights(3:4) = brtau2brmu
+         weights(5:6) = brtau2bre
+-        do i=2,6
++        weights(7) = 1d0/brmu2bre
++        weights(8) = brmu2bre
++        weights(9) = brtau2brmu*brtau2bre
++        do i=2,9
+            weights(i) = ( weights(i) + weights(i-1) )
+         enddo
+-        do i=1,6
++        do i=1,9
+            weights(i) = weights(i) / weightSum
+         enddo
+         ini = .false.
+@@ -192,6 +201,7 @@
+ c                     5 ... only tau- nu_tau  mu+ nu_mu~ (-15,  16,  13, -14)
+ c                     6 ... only tau+ nu_tau~ mu- nu_mu  ( 15, -16, -13,  14)
+ c                     7 ... options 0,1,3,4,5 or 6
++c                     8 ... full dileptonic ttbar including same flavour
+       elseif (channel == 3) then
+         call mu2tau
+ c       the weight also needs modifying, see above
+@@ -226,6 +236,33 @@
+             call e2tau
+             call flip_flavours
+         end select
++      else if (channel == 8) then
++         do i=1,9
++          if ( randomNumber < weights(i) ) exit
++        enddo
++        select case (i) 
++          case (1) 
++c           do nothing
++          case (2)
++            call flip_flavours
++          case (3)
++            call mu2tau
++          case (4)
++            call mu2tau
++            call flip_flavours
++          case (5)
++            call e2tau
++          case (6)
++            call e2tau
++            call flip_flavours
++          case (7)
++            call mu2e
++          case (8)
++            call e2mu
++          case (9)
++            call e2tau
++            call mu2tau
++        end select
+       else 
+         print*, "finalize_lh: value for channel=",channel,"is not allowed. Exiting!"
+         call exit(-1)
+@@ -303,7 +340,31 @@
+         endif
+       enddo
+       end subroutine
++      subroutine e2mu
++      implicit none
++      include 'LesHouches.h'
++      integer iup, sgn
++      do iup = 1, nup
++        if (abs(idup(iup)) == 13) then
++          idup(iup) = sign(11,idup(iup))
++        else if (abs(idup(iup)) == 14) then
++          idup(iup) = sign(12,idup(iup))
++        endif
++      enddo
++      end subroutine
+       end
++      subroutine mu2e
++      implicit none
++      include 'LesHouches.h'
++      integer iup, sgn
++      do iup = 1, nup
++        if (abs(idup(iup)) == 11) then
++          idup(iup) = sign(13,idup(iup))
++        else if (abs(idup(iup)) == 12) then
++          idup(iup) = sign(14,idup(iup))
++        endif
++      enddo
++      end subroutine
+ 
+ 
+       subroutine complete_resonance_colours(iret)
+Index: init_processes.f
+===================================================================
+--- init_processes.f	(Revision 4004)
++++ init_processes.f	(Arbeitskopie)
+@@ -15,7 +15,7 @@
+       logical openloopsreal,openloopsvirtual
+       common/copenloopsreal/openloopsreal,openloopsvirtual
+       integer channel
+-      real * 8 brtau2brmu, brtau2bre
++      real * 8 brtau2brmu, brtau2bre, brmu2bre
+ 
+       openloopsreal = powheginput("#openloopsreal") /= 0
+       openloopsvirtual = powheginput("#openloopsvirtual") /= 0
+@@ -167,6 +167,7 @@
+       if (brtau2brmu < 0) brtau2brmu = 0.999270413
+       brtau2bre = powheginput('#br_tau/br_e')
+       if (brtau2bre < 0) brtau2bre = 0.99926856
++      brmu2bre = brtau2bre / brtau2brmu
+ c        in which case both e-mu+ and e+mu- channels will be generated
+ c        simply by adding e+mu- channel with the same amplitude 
+ c        (by flipping a signs in an already generated event with the 
+@@ -184,6 +185,9 @@
+           rad_branching = brtau2bre
+         case (7)
+           rad_branching = 2d0 + 2d0*brtau2brmu + 2d0*brtau2bre
++        case (8)
++          rad_branching = 2d0 + 2d0*brtau2brmu + 2d0*brtau2bre
++     1    + 1d0/brmu2bre + brmu2bre + brtau2brmu*brtau2bre
+       end select
+ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+                 

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_hdamp_down.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_hdamp_down.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 150.7305 ! 0.8738 x mtop                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#tmass      172.5d0                              ! (default 172.5) top quark mass (in the matrix ele
+#tmass_phsp 172.5d0                              ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_hdamp_up.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_hdamp_up.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 397.6125 ! 2.305 x mtop                    ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#tmass      172.5d0                              ! (default 172.5) top quark mass (in the matrix ele
+#tmass_phsp 172.5d0                              ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_169p5.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_169p5.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 237.8775                                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+tmass      169.5d0                               ! (default 172.5) top quark mass (in the matrix ele
+tmass_phsp 169.5d0                               ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_171p5.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_171p5.input
@@ -39,6 +39,23 @@ withdamp 1                                       ! Turn on calculation of the re
 channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
 
 
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+tmass      171.5d0                               ! (default 172.5) top quark mass (in the matrix ele
+tmass_phsp 171.5d0                               ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! The following is the minimal settings that we used for the publication of our paper.

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_173p5.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_173p5.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 237.8775                                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+tmass      173.5d0                               ! (default 172.5) top quark mass (in the matrix ele
+tmass_phsp 173.5d0                               ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_175p5.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_mtop_175p5.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 237.8775                                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+tmass      175.5d0                               ! (default 172.5) top quark mass (in the matrix ele
+tmass_phsp 175.5d0                               ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_nominal.input
+++ b/bin/Powheg/production/2017/13TeV/b_bbar_4l/b_bbar_4l_nominal.input
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Standard settings which have the same meaning as in POWHEG-BOX-V2
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+numevts NEVENTS
+iseed SEED
+ih1   1                                          ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6500                                      ! energy of beam 1
+ebeam2 6500                                      ! energy of beam 2
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+
+use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 80000                                     ! number of calls for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
+ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1                                      ! number of folds on csi integration
+foldy     1                                      ! number of folds on  y  integration
+foldphi   1                                      ! number of folds on phi integration
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0                                     ! increase upper bound for radiation generation
+storemintupb 1                                   ! (default 0, do not) Store st2 btilde calls to set up upper bounding envelope
+fastbtlbound 1                                   ! (default 0, do not) Turn on fast calculation of the btilde upper bounding envelope
+
+
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! POWHEG-BOX-RES and bb4l relevant settings
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
+hdamp 237.8775                                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
+withdamp 1                                       ! Turn on calculation of the remnants
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Physics constants
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#tmass      172.5d0                              ! (default 172.5) top quark mass (in the matrix ele
+#tmass_phsp 172.5d0                              ! (default 172.5) top quark mass (in the phase spac
+#twidth                                          ! (default unset) top quark width (calculated from
+#zmass      91.188d0                             ! (default 91.188d0) mass of Z-boson
+#zwidth     2.441d0                              ! (default 2.441d0) width of Z-boson
+#wmass      80.419d0                             ! (default 80.419d0) mass of W-boson
+#wwidth     2.04807d0                            ! (default 2.04807d0) width of W-boson
+#hmass      125d0                                ! (default 125d0) mass of Higgs boson
+#hwidth     0.403d-2                             ! (default 0.403d-2) width of the Higgs boson
+#bmass      4.75d0                               ! (default 4.75d0) mass of the bottom quark
+#ewscheme   2                                    ! (default 2) 1...wmass, zmass, grefmi input; alpha
+#gfermi     1.1658029175194381d-5                ! (default 1.1658029175194381d-5) gfermi
+#alpha      0.007546772                          ! (default 0.007546772) alpha
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! The following is the minimal settings that we used for the publication of our paper.
+! It performs event generation with the `for_reweighting 1` settings (no virtual and modified subtraction), and then it reweights the events with the full, correct cross section.
+! Thus the 'default' weight has the correct cross section for the parameters given in the powheg.input file. The "xwgtup" value in the Les Houches record does not correspond to
+! a useful cross section.
+! If more weights are needed, they should be included in the <initrwgt> section (see README.Compress-And-Weights for explanations).
+! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
+! is always used.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
+
+
+
+

--- a/bin/Powheg/production/2017/13TeV/bbbar_4l/powheg.input
+++ b/bin/Powheg/production/2017/13TeV/bbbar_4l/powheg.input
@@ -7,20 +7,20 @@ ih1   1                                          ! hadron 1 (1 for protons, -1 f
 ih2   1                                          ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 6500                                      ! energy of beam 1
 ebeam2 6500                                      ! energy of beam 2
-lhans1 306000                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
-lhans2 306000                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
+lhans1 325300                                    ! pdf set for hadron 1 (LHA numbering) [if using LHA pdfs]
+lhans2 325300                                    ! pdf set for hadron 2 (LHA numbering) [if using LHA pdfs]
 
 use-old-grid 1                                   ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound 1                                 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
 ncall1 80000                                     ! number of calls for initializing the integration grid
-itmx1    1                                       ! number of iterations for initializing the integration grid
+itmx1    5                                       ! number of iterations for initializing the integration grid
 ncall2 100000                                    ! number of calls for computing the integral and finding upper bound
-itmx2   3                                        ! number of iterations for computing the integral and finding upper bound
+itmx2   5                                        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1                                      ! number of folds on csi integration
 foldy     1                                      ! number of folds on  y  integration
 foldphi   1                                      ! number of folds on phi integration
-nubound 10000                                    ! number of bbarra calls to setup norm of upper bounding function
+nubound 100000                                   ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1                                       ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1                                       ! <= 100, number of y subdivision when computing the upper bounds
 xupbound 2d0                                     ! increase upper bound for radiation generation
@@ -36,7 +36,7 @@ fastbtlbound 1                                   ! (default 0, do not) Turn on f
 allrad 1                                         ! (default 0, single shower scheme) Turns on multiple shower scheme
 hdamp 237.8775                                   ! Using a damping factor h**2/(pt2+h**2) to separate real contributions between Sudakov and remnants (should be set to the mass of the top quark)
 withdamp 1                                       ! Turn on calculation of the remnants
-channel 7                                        ! let top decay leptonically 
+channel 8                                        ! Full dileptonic decay of WbWb including same-flavour leptons
 
 
 
@@ -49,7 +49,7 @@ channel 7                                        ! let top decay leptonically
 ! If weights are added to a previously existing .lhe file, i.e. `rwl_add 1`, the for_reweighting flag is ignored, and the full cross section
 ! is always used.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-for_reweighting 1                                ! (default 0) Modifies subtraction to reduce reweighting factors (for adding the virtual contribution during the reweighing stage only) 
+for_reweighting 0                                ! (default 0) Explicitly do not use the virtual weight, but generate unweighted events from the start
 
 
 


### PR DESCRIPTION
This PR prepares gridpack generation for a CMS official bb4l sample in UL. It consists of three parts:

1. It includes a patch for bb4l enabling generation of same-flavour events (by extending the relabeling functionality already used for etau and mutau events). This was already presented e.g. in the GEN meeting [here](https://indico.cern.ch/event/1293969/). The option can be activated by specifying `channel 8` in the input card.
2. It adds powheg.input cards with up-to-date settings for the nominal case as well as hdamp variations (standard up/down values) and top mass variations (+/- 1 GeV and +/- 3 GeV). Other variations can be added if needed. In addition, these cards also specify the flag `for_reweighting 0`, meaning that bb4l should generate fully unweighted events (as opposed to attaching virtual corrections only as an additional weight that needs to be explicitly taken into account in analyses). I discussed this with @agrohsje and while it is somewhat slower, we feel that having no additional weight is safer for users of the sample in the long run.
3. It reduces the amount of PDF variations for bb4l specifically, since the current amount of variations is not feasible in terms of computational cost. Now, the variations consist of the normal 103 replicas (including the alphaS variation) for the nominal PDF sample, and only the nominals for alternate PDF sets. (Any feedback on whether this is sufficient / still too many is appreciated.)

Note that in order to successfully produce a gridpack with this, PR #3477 will also need to be merged to fix the gridpack production for Powheg Box RES.