### PR TITLE
add createCards for UL h->a1a1 and h->a1a2 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_ggh01_M125_Toa01a01_Tobbtautau_2017.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_ggh01_M125_Toa01a01_Tobbtautau_2017.sh
@@ -1,4 +1,4 @@
-masspoints=(12 15 20 25 30 35 40 45 50 55 60)
+masspoints=(11 12 13 14 15 20 25 30 35 40 45 50 55 60)
 
 template_dir="ggh01_M125_Toa01a01_Tobbtautau/" 
 

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_vbfh01_M125_Toa01a01_Tobbtautau_2017.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/bbtautau_final_state/createCards_vbfh01_M125_Toa01a01_Tobbtautau_2017.sh
@@ -1,4 +1,4 @@
-masspoints=(12 15 20 25 30 35 40 45 50 55 60)
+masspoints=(11 12 13 14 15 20 25 30 35 40 45 50 55 60)
 
 template_dir="vbfh01_M125_Toa01a01_Tobbtautau/" 
 


### PR DESCRIPTION
This PR is for our ultralegacy MC sample request for `h->a1a1->bbtautau` and `h->a1a2` (cascade and non-cascade) SUSY samples. The commit adds low-mass points to `h->a1a1->bbtautau`, and the other card creation scripts are unchanged. To summarize, we are targeting the following samples:

1. VBF and ggH `h->a1a1->bbtautau`: `createCards_vbfh01_M125_Toa01a01_Tobbtautau_2017.sh`, `createCards_ggh01_M125_Toa01a01_Tobbtautau_2017.sh`
2. VBF and ggH `h->a1a2` cascade: `createCards_vbfh3_M125_Toh1h2_h2_Toh1h1_2017.sh`, `createCards_ggh3_M125_Toh1h2_h2_Toh1h1_2017.sh`
3. VBF and ggH `h->a1a2` non-cascade: `createCards_vbfh3_M125_Toh1h2_2017.sh`,  `createCards_ggh3_M125_Toh1h2_2017.sh`
