### PR TITLE
Harmonise Run-3 cards for tHq and tHW with previous MR

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_customizecards.dat
@@ -1,4 +1,4 @@
 #put card customizations here (change top and higgs mass for example)
 set param_card mass 6 172.5
 set param_card mass 25 125
-set param_card yukawa 6 -172.5
+set param_card yukawa 6 172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_proc_card.dat
@@ -1,9 +1,13 @@
-import model HC_NLO_X0_UFO
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
 define wdec = u c d s u~ c~ d~ s~ l+ l- vl vl~
+import model HC_NLO_X0_UFO
 generate p p > x0 t~ b j $$ w+ w-, (t~ > b~ w-, w- > wdec wdec)
 add process p p > x0 t b~ j $$ w+ w-, (t > b w+, w+ > wdec wdec)
 output thq_4f_ckm_LO_ctcvcp -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
@@ -60,7 +60,7 @@
   91.188	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
   91.188	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
   -1	=  dynamical_scale_choice  ! Select one of the preselect dynamical choice
-  0.33 =  scalefact         ! scale factor for event-by-event scales
+  1 =  scalefact         ! scale factor for event-by-event scales
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
@@ -70,7 +70,7 @@
   1	=  alpsfact          ! scale factor for QCD emission vx
   False	=  chcluster         ! cluster only according to channel diag
   True	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
-  5	=  asrwgtflavor      ! highest quark flavor for a_s reweight
+  4	=  asrwgtflavor      ! highest quark flavor for a_s reweight
   True	=  clusinfo          ! include clustering tag in output
   3.0	=  lhe_version        ! Change the way clustering information pass to shower.        
 #*********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
@@ -1,3 +1,17 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
 #*******************                                                 
 # Running parameters
 #*******************                                                 
@@ -56,7 +70,7 @@
   1	=  alpsfact          ! scale factor for QCD emission vx
   False	=  chcluster         ! cluster only according to channel diag
   True	=  pdfwgt            ! for ickkw=1, perform pdf reweighting
-  4	=  asrwgtflavor      ! highest quark flavor for a_s reweight
+  5	=  asrwgtflavor      ! highest quark flavor for a_s reweight
   True	=  clusinfo          ! include clustering tag in output
   3.0	=  lhe_version        ! Change the way clustering information pass to shower.        
 #*********************************************************************
@@ -77,7 +91,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-  False	=  cut_decays     ! Cut decay products 
+  True	=  cut_decays     ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for
@@ -252,5 +266,3 @@
 #          reweighting into account!                                 *
 #*********************************************************************
   True	=  use_syst       ! Enable systematics studies
-
-

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_customizecards.dat
@@ -1,4 +1,4 @@
 #put card customizations here (change top and higgs mass for example)
 set param_card mass 6 172.5
 set param_card mass 25 125
-set param_card yukawa 6 -172.5
+set param_card yukawa 6 172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_proc_card.dat
@@ -1,10 +1,12 @@
-import model HC_NLO_X0_UFO-no_b_mass
-define p = p b b~
-define j = j b b~
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set complex_mass_scheme False
 define l+ = e+ mu+ ta+
 define l- = e- mu- ta-
 define vl = ve vm vt
 define vl~ = ve~ vm~ vt~
+import model HC_NLO_X0_UFO-no_b_mass
 define wdec = u c d s u~ c~ d~ s~ l+ l- vl vl~
 generate p p > x0 t w-, (t > w+ b, w+ > wdec wdec), w- > wdec wdec @1
 add process p p > x0 t~ w+, (t~ > w- b~, w- > wdec wdec), w+ > wdec wdec @2

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
@@ -1,3 +1,17 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
 #*******************                                                 
 # Running parameters
 #*******************                                                 
@@ -40,8 +54,8 @@
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
-  True	=  fixed_ren_scale   ! if .true. use fixed ren scale
-  True	=  fixed_fac_scale   ! if .true. use fixed fac scale
+  False	=  fixed_ren_scale   ! if .true. use fixed ren scale
+  False	=  fixed_fac_scale   ! if .true. use fixed fac scale
   40	=  scale             ! fixed ren scale
   40	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
   40	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
@@ -77,7 +91,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-  False	=  cut_decays     ! Cut decay products 
+  True	=  cut_decays     ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for


### PR DESCRIPTION
Harmonise the Run-3 MG cards for tHq and tHW using what we had in the [previous, still open MR](https://github.com/cms-sw/genproductions/pull/3413/).

In particular, the nominal top Yukawa coupling is set to be positive here and the low, fixed scales for tHW are changed to dynamic scales. 

Tagging @menglu21 