### PR TITLE
 added input cards for WH inclusive samples for HWW for Run3 

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HWMinJ_HToWW_M-125_13p6TeV/JHUGen.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HWMinJ_HToWW_M-125_13p6TeV/JHUGen.input
@@ -1,0 +1,2 @@
+DecayMode1=11 DecayMode2=11 WriteFailedEvents=2
+

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HWMinJ_HToWW_M-125_13p6TeV/powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HWMinJ_HToWW_M-125_13p6TeV/powheg.input
@@ -1,0 +1,87 @@
+idvecbos          -24   !    24:    W+  boson,    -24:    W-  boson
+vdecaymode        10    ! 1: e-nu, 2: mu-nu, 3: tau-nu, 0: hadronic, 10: inclusive, 11: inclusive leptons
+hdecaymode        -1    ! undecayed Higgs boson (for PYTHIA and HERWIG)
+
+hmass  125d0        ! Higgs boson mass
+hwidth 0.00407d0     ! Higgs boson width
+
+min_h_mass  12d0
+max_h_mass  1250d0
+
+min_w_mass     10d0
+max_w_mass   1000d0
+
+
+numevts NEVENTS
+ih1 1             ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2 1             ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+bornktmin 0.26d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
+
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+! the typical call uses 1/1400 seconds (1400 calls per second)
+ncall1 400000      ! Number of calls for the construction of the importance sampling grid
+itmx1 1           ! Number of iterations for grid
+ncall2 400000      ! Number of calls for the computation of the upper bounding envelope
+                  ! for the generation of radiation
+itmx2 1           ! Number of iterations for the above
+! Notice: the total number of calls is ncall2*itmx2*foldcsi*foldy*foldphi
+foldcsi 2         ! number of folds on csi integration
+foldy   5         ! number of folds on  y  integration
+foldphi 2         ! number of folds on phi integration
+
+nubound 600000 ! number of calls to set up the upper bounding norms for radiation
+               ! This is performed using only the Born cross section (fast)
+
+
+! OPTIONAL PARAMETERS
+
+#withnegweights 1 1  ! (default 0) if on (1) use negative weights
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+iseed SEED
+
+fastbtlbound 1
+storemintupb 1
+
+minlo 1
+minlo_nnll 1
+
+# if running with minlo, set the following to 0
+massivetop   0
+
+sudscalevar   1
+
+doublefsr 1
+
+nohad   1
+
+
+
+#parallelstage 4
+#xgriditeration 1 1
+#manyseeds 1
+
+
+#pdfreweight 0
+
+#storeinfo_rwgt 0
+rwl_group_events 2000
+lhapdf6maxsets 50
+rwl_file 'pwg-rwl.dat'
+rwl_format_rwgt 1
+                      
+
+

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HWPlusJ_HToWW_M-125_13p6TeV/JHUGen.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HWPlusJ_HToWW_M-125_13p6TeV/JHUGen.input
@@ -1,0 +1,1 @@
+DecayMode1=11 DecayMode2=11 WriteFailedEvents=2 

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HWPlusJ_HToWW_M-125_13p6TeV/powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HWPlusJ_HToWW_M-125_13p6TeV/powheg.input
@@ -1,0 +1,85 @@
+idvecbos          24    !    24:    W+  boson,    -24:    W-  boson
+vdecaymode        10    ! 1: e-nu, 2: mu-nu, 3: tau-nu, 0: hadronic, 10: inclusive, 11: inclusive leptons
+hdecaymode        -1    ! undecayed Higgs boson (for PYTHIA and HERWIG)
+
+hmass  125d0        ! Higgs boson mass 
+hwidth 0.00407d0     ! Higgs boson width 
+
+min_h_mass  12d0      
+max_h_mass  1250d0      
+
+min_w_mass     10d0
+max_w_mass   1000d0
+
+
+numevts NEVENTS
+ih1 1             ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2 1             ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0     ! energy of beam 1
+ebeam2 6800d0     ! energy of beam 2
+
+bornktmin 0.26d0      ! (default 0d0) generation cut. Minimum kt in underlying Born
+bornsuppfact 0d0 ! (default 0d0)  mass param for Born suppression factor. If < 0 suppfact = 1
+
+lhans1  325300         ! pdf set for hadron 1 (LHA numbering)
+lhans2  325300         ! pdf set for hadron 2 (LHA numbering)	
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+! the typical call uses 1/1400 seconds (1400 calls per second)
+ncall1 400000      ! Number of calls for the construction of the importance sampling grid
+itmx1 1           ! Number of iterations for grid
+ncall2 400000      ! Number of calls for the computation of the upper bounding envelope
+                  ! for the generation of radiation
+itmx2 1           ! Number of iterations for the above
+! Notice: the total number of calls is ncall2*itmx2*foldcsi*foldy*foldphi
+foldcsi 2         ! number of folds on csi integration
+foldy   5         ! number of folds on  y  integration
+foldphi 2         ! number of folds on phi integration
+
+nubound 600000 ! number of calls to set up the upper bounding norms for radiation
+               ! This is performed using only the Born cross section (fast)
+
+
+! OPTIONAL PARAMETERS
+
+#withnegweights 1 1  ! (default 0) if on (1) use negative weights
+testplots  1      ! (default 0, do not) do NLO and PWHG distributions
+
+
+
+iseed SEED
+fastbtlbound 1
+storemintupb 1
+
+minlo 1    
+minlo_nnll 1  
+
+# if running with minlo, set the following to 0
+massivetop   0 
+
+sudscalevar   1
+
+doublefsr 1 
+
+nohad   1
+
+
+
+#parallelstage 4
+#xgriditeration 1 1
+#manyseeds 1
+
+
+#pdfreweight 0
+
+#storeinfo_rwgt 0
+rwl_group_events 2000
+lhapdf6maxsets 50
+rwl_file 'pwg-rwl.dat'
+rwl_format_rwgt 1


### PR DESCRIPTION

Dear experts !

I have prepared powheg input cards for /HWplusJ_HToWW_M-125_TuneCP5_13TeV_powheg-jhugen727-pythia8 and   /HWMinusJ_HToWW_M-125_TuneCP5_13TeV_powheg-jhugen727-pythia8 sample. The only change is the energy from 13 to 13.6 TeV. Kindly have a look at it at your convenience.

Thanks and Regards,
Sadhana Verma
adding @amanagrawal1280
