### PR TITLE
Update for `request_fragment_check.py` script

### DIFF
--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -48,7 +48,7 @@ if args.develop is False:
        sys.exit()
 	
 # Use no-id as identification mode in order not to use a SSO cookie
-mcm = McM(id=McM.SSO, dev=args.dev, debug=args.debug)
+mcm = McM(id=None, dev=args.dev, debug=args.debug)
 mcm_link = mcm.server
 
 def get_request(prepid):
@@ -78,11 +78,12 @@ def get_ticket(prepid):
     return result
 
 def get_requests_from_datasetname(dn):
-    result = mcm.get('requests', query='dataset_name=%s' % (dn))
-    if not result:
-        return {}
-
-    return result
+    raw_result = mcm._McM__get(
+        "public/restapi/requests/from_dataset_name/%s" % (dn)
+    )
+    if not raw_result:
+        return []
+    return raw_result.get("results", [])
 
 def find_file(dir_path,patt):
     for root, dirs, files in os.walk(dir_path):

--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -9,11 +9,8 @@ import os.path
 import string
 import glob
 from datetime import datetime
-###########Needed to check for ultra-legacy sample consistency check############################################
-os.system('env -i KRB5CCNAME="$KRB5CCNAME" cern-get-sso-cookie -u https://cms-pdmv.cern.ch/mcm/ -o cookiefile.txt --krb --reprocess')
-################################################################################################################
-sys.path.append('/afs/cern.ch/cms/PPD/PdmV/tools/McM/')
-from rest3 import McM
+sys.path.append('/afs/cern.ch/cms/PPD/PdmV/tools/McM-QA/')
+from rest import McM
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -51,13 +48,8 @@ if args.develop is False:
        sys.exit()
 	
 # Use no-id as identification mode in order not to use a SSO cookie
-mcm = McM(id='no-id', dev=args.dev, debug=args.debug)
-mcm2 = McM(cookie='cookiefile.txt', dev=args.dev, debug=args.debug)
-
-if args.dev is True:
-    mcm_link = "https://cms-pdmv-dev.cern.ch/mcm/"
-else:
-    mcm_link = "https://cms-pdmv.cern.ch/mcm/"
+mcm = McM(id=McM.SSO, dev=args.dev, debug=args.debug)
+mcm_link = mcm.server
 
 def get_request(prepid):
     result = mcm._McM__get('public/restapi/requests/get/%s' % (prepid))
@@ -86,7 +78,7 @@ def get_ticket(prepid):
     return result
 
 def get_requests_from_datasetname(dn):
-    result = mcm2.get('requests', query='dataset_name=%s' % (dn))
+    result = mcm.get('requests', query='dataset_name=%s' % (dn))
     if not result:
         return {}
 
@@ -667,7 +659,7 @@ for num in range(0,len(prepid)):
         os.system('wget -q '+mcm_link+'public/restapi/requests/get_test/'+pi+' -O '+pi+'_get_test')
         gettest = os.popen('grep cff '+pi+'_get_test'+' | grep curl').read()
         if os.path.getsize(pi+'_get_test') == 0:
-            print("public/restapi/requests/get_test/ is not acessible for this request. Exiting! Please contact geovanny.gonzalez@cern.ch")
+            print("public/restapi/requests/get_test/ is not acessible for this request. Exiting! Please send an email to 'cms-ppd-pdmv-dev@cern.ch'")
             sys.exit()
         scram_arch = os.popen('grep SCRAM_ARCH '+pi+'_get_test').read()
         scram_arch = scram_arch.split('=')[1].rstrip()

--- a/bin/utils/test_request_fragment_check.py
+++ b/bin/utils/test_request_fragment_check.py
@@ -102,7 +102,7 @@ class McMFragmentCheckTest(unittest.TestCase):
         """
         test_command = "%s --bypass_status --prepid %s --dev --develop" % (self.script_path, self.mcm_prepid)
         exit_code, stdout = self.__shell_execution(test_command)
-        self.logger.info('Script output: %s', stdout)
+        self.logger.info('Script output:\n%s', stdout)
         number_of_errors = NUMBER_OF_ERRORS.findall(stdout)
         self.assertEqual(
             0, 

--- a/bin/utils/test_request_fragment_check.py
+++ b/bin/utils/test_request_fragment_check.py
@@ -32,12 +32,12 @@ class McMFragmentCheckTest(unittest.TestCase):
         Returns:
             tuple[int, str]: Status code and standard output
         """
-        # INFO: Do not use `stdout=subprocess.PIPE` if you are
+        # INFO: Do not use `stdout=subprocess.PIPE` if you
         # run the script setting `McM(id=McM.OIDC, ...)` for the 
         # McM REST client. That authentication schema requires
         # human intervention to complete the auth flow. Therefore,
         # the subprocess will be blocked and you can not interact 
-        # with it. If you require to run it with this schema for debug
+        # with it. If you require to run it with this schema for debugging
         # something, just comment that line.
         command_args = command.strip().split(EMPTY_SPACE)
         completed_process = subprocess.Popen(
@@ -107,13 +107,13 @@ class McMFragmentCheckTest(unittest.TestCase):
         self.assertEqual(
             0, 
             exit_code, 
-            'The related McM request is already done, it means this should not fail'
+            'The related McM request should not have validation errors'
         )
         self.assertIsNotNone(
             stdout,
             msg=(
-                'Please make sure you are using the authentication schema `McM(id=McM.SSO, ...)` \n'
-                'and enable `stdout=subprocess.PIPE` inside self.__shell_execution(...) function. \n'
+                'Please make sure you capture the standard output \n'
+                '(have enabled `stdout=subprocess.PIPE` inside self.__shell_execution(...) function) \n'
                 'Script output is None.'
             )
         )

--- a/bin/utils/test_request_fragment_check.py
+++ b/bin/utils/test_request_fragment_check.py
@@ -1,0 +1,130 @@
+"""
+This test checks that McM SDK works
+properly when it is being used with CMS GEN's
+`request_fragment_check.py`
+"""
+import unittest
+import sys
+import os
+import logging
+import subprocess
+import re
+
+
+EMPTY_SPACE = " "
+NUMBER_OF_ERRORS_PATTERN = r'Number of errors = ([0-9]{1,3})'
+NUMBER_OF_ERRORS = re.compile(NUMBER_OF_ERRORS_PATTERN)
+
+
+class McMFragmentCheckTest(unittest.TestCase):
+    """
+    Check that McM SDK integrates/works properly with
+    `request_fragment_check.py` module
+    """
+
+    def __shell_execution(self, command):
+        """
+        Executes the desired command as a subprocess
+        and retrieves its output and exit code.
+
+        Args:
+            command (str): Command to execute in a subprocess
+        Returns:
+            tuple[int, str]: Status code and standard output
+        """
+        # INFO: Do not use `stdout=subprocess.PIPE` if you are
+        # run the script setting `McM(id=McM.OIDC, ...)` for the 
+        # McM REST client. That authentication schema requires
+        # human intervention to complete the auth flow. Therefore,
+        # the subprocess will be blocked and you can not interact 
+        # with it. If you require to run it with this schema for debug
+        # something, just comment that line.
+        command_args = command.strip().split(EMPTY_SPACE)
+        completed_process = subprocess.Popen(
+            args=command_args,
+            # Comment the following line if you require it.
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        stdout, _ = completed_process.communicate()
+        exit_code = completed_process.returncode
+        return (exit_code, stdout)
+
+    def build(self):
+        """
+        Prepare the test case.
+        Retrieve the script path, set the McM request to validate
+        and set up the logger.
+        """
+        # Set up logging
+        logging.basicConfig(
+            format="[%(module)s][%(asctime)s][%(levelname)s] %(message)s",
+            level=logging.INFO,
+        )
+        self.logger = logging.getLogger()
+        self.mcm_prepid = "PPD-TestForGENScriptDoNotOperateThis-00001"
+
+        # Retrieve script path
+        script_name = "request_fragment_check.py"
+        path_from_utils = os.path.join(os.getcwd(), script_name)
+        path_from_repo_root = os.path.join(os.getcwd(), "bin", "utils", script_name)
+        if os.path.isfile(path_from_utils):
+            self.script_path = path_from_utils
+        elif os.path.isfile(path_from_repo_root):
+            self.script_path = path_from_repo_root
+        else:
+            raise FileNotFoundError(
+                (
+                    "CMS GEN fragment check script is not available at: %s nor %s"
+                    % (path_from_utils, path_from_repo_root)
+                )
+            )
+
+        # Log the test configuration
+        self.logger.info("Using Python version: %s", sys.version)
+        self.logger.info("Using McM request %s for perfoming the test", self.mcm_prepid)
+        self.logger.info(
+            "CMS GEN fragment check script is available at: %s", self.script_path
+        )
+
+    def setUp(self):
+        """
+        Set up the test case
+        """
+        self.build()
+
+    def test_integration(self):
+        """
+        Checks that `request_fragment_check.py` script
+        works properly with the McM SDK and the integration
+        for McM validation process
+        """
+        test_command = "%s --bypass_status --prepid %s --dev --develop" % (self.script_path, self.mcm_prepid)
+        exit_code, stdout = self.__shell_execution(test_command)
+        self.logger.info('Script output: %s', stdout)
+        number_of_errors = NUMBER_OF_ERRORS.findall(stdout)
+        self.assertEqual(
+            0, 
+            exit_code, 
+            'The related McM request is already done, it means this should not fail'
+        )
+        self.assertIsNotNone(
+            stdout,
+            msg=(
+                'Please make sure you are using the authentication schema `McM(id=McM.SSO, ...)` \n'
+                'and enable `stdout=subprocess.PIPE` inside self.__shell_execution(...) function. \n'
+                'Script output is None.'
+            )
+        )
+        self.assertTrue(number_of_errors, msg='There should be a line in the output stating the number of errors')
+        number_of_errors = int(number_of_errors[0])
+        self.assertEqual(
+            0,
+            number_of_errors,
+            msg='Number of errors should be zero.'
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3535 

### Status

Tested.

This update includes unit tests to verify that the new McM client works properly with the fragment script. Moreover, a little test was carried out in the McM production environment using this version to check that it integrates properly with this application. The artifacts related to the execution of the last validation test in McM production are available at: `/afs/cern.ch/user/p/pdmvserv/public/mcm/gen_script_update/PPD-Run3Summer23GS-00005`

### Is it backward compatible (if not, which system it affect?)

YES

The new version of the McM client supports Python interpreters between versions [2.7, 3.11]. Moreover, the update for the script `request_fragment_check.py` deletes dependencies on external host packages to handle authentication so no backward compatibility issues are expected.


### External dependencies / deployment changes

- McM QA client

This client is available at: `/afs/cern.ch/cms/PPD/PdmV/tools/McM-QA/`. This artifact includes all the changes available until this [commit](https://github.com/cms-PdmV/mcm_scripts/blob/b2c38b86337ce785b247edb4d5b90e0fec3d6a15/rest.py#L40).