### PR TITLE
Update hadronizer for Run3 Hgg

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_GluGluHToGG_.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_GluGluHToGG_.py
@@ -1,0 +1,42 @@
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13600.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'SLHA:useDecayTable = off',
+            '25:m0 = <MASS>',
+            '25:onMode = off',
+            '25:onIfMatch = 22 22',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)

--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VBFHToGG_.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VBFHToGG_.py
@@ -1,0 +1,31 @@
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+	                     maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+     pythia8CommonSettingsBlock,
+     pythia8CP5SettingsBlock,
+     pythia8PSweightsSettingsBlock,
+     pythia8aMCatNLOSettingsBlock,
+     processParameters = cms.vstring(
+         'TimeShower:nPartonsInBorn = 2', #number of coloured particles (before resonance decays) in born matrix element
+         'SLHA:useDecayTable = off',
+         '25:m0 = <MASS>',
+         '25:onMode = off',
+         '25:onIfMatch = 22 22',
+         ),
+     parameterSets = cms.vstring('pythia8CommonSettings',
+                                 'pythia8CP5Settings',
+                                 'pythia8PSweightsSettings',
+                                 'pythia8aMCatNLOSettings',
+                                 'processParameters',
+                                 )
+     )
+)

--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VHToGG_.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VHToGG_.py
@@ -1,0 +1,42 @@
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+  maxEventsToPrint = cms.untracked.int32(1),
+  pythiaPylistVerbosity = cms.untracked.int32(1),
+  filterEfficiency = cms.untracked.double(1.0),
+  pythiaHepMCVerbosity = cms.untracked.bool(False),
+  comEnergy = cms.double(13600.),
+  PythiaParameters = cms.PSet(
+       pythia8CommonSettingsBlock,
+       pythia8CP5SettingsBlock,
+       pythia8PSweightsSettingsBlock,
+       pythia8aMCatNLOSettingsBlock,
+       processParameters = cms.vstring(
+             'JetMatching:setMad = off',
+             'JetMatching:scheme = 1',
+             'JetMatching:merge = on',
+             'JetMatching:jetAlgorithm = 2',
+             'JetMatching:etaJetMax = 999.',
+             'JetMatching:coneRadius = 1.',
+             'JetMatching:slowJetPower = 1',
+             'JetMatching:qCut = 30.', #this is the actual merging scale
+             'JetMatching:doFxFx = on',
+             'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+             'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+             'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+             'SLHA:useDecayTable = off',
+             '25:m0 = <MASS>',
+             '25:onMode = off',
+             '25:onIfMatch = 22 22',
+           ),
+          parameterSets = cms.vstring('pythia8CommonSettings',
+             'pythia8CP5Settings',
+             'pythia8PSweightsSettings',
+             'pythia8aMCatNLOSettings',
+             'processParameters',
+           )
+     )
+)

--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_ttHToGG_.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/Hadronizer_TuneCP5_13p6TeV_aMCatNLO_ttHToGG_.py
@@ -1,0 +1,44 @@
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+	maxEventsToPrint = cms.untracked.int32(1),
+	pythiaPylistVerbosity = cms.untracked.int32(1),
+	filterEfficiency = cms.untracked.double(1.0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	comEnergy = cms.double(13600.),
+	PythiaParameters = cms.PSet(
+	pythia8CommonSettingsBlock,
+	pythia8CP5SettingsBlock,
+	pythia8PSweightsSettingsBlock,
+	pythia8aMCatNLOSettingsBlock,
+  	processParameters = cms.vstring(
+  		'JetMatching:setMad = off',
+  		'JetMatching:scheme = 1',
+  		'JetMatching:merge = on',
+  		'JetMatching:jetAlgorithm = 2',
+  		'JetMatching:etaJetMax = 999.',
+  		'JetMatching:coneRadius = 1.',
+  		'JetMatching:slowJetPower = 1',
+  		'JetMatching:qCut = 40.', #this is the actual merging scale
+  		'JetMatching:doFxFx = on',
+  		'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+  		'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+  		'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+  		'SLHA:useDecayTable = off',  # Use pythia8s own decay mode instead of decays defined in LH accord
+  		'25:m0 = <MASS>',
+	  	'23:mMin = 0.05',       # Solve problem with mZ cut
+  		'24:mMin = 0.05',       # Solve problem with mW cut
+  		'25:onMode = off',
+  		'25:onIfMatch = 22 22',    # Decay only higgs to gamma gamma, note onIfMatch is used instead of onIfAny since otherwise H->Gamma Z, Z-> Gamma is also possible.
+  ),
+	parameterSets = cms.vstring('pythia8CommonSettings',
+		'pythia8CP5Settings',
+		'pythia8PSweightsSettings',
+		'pythia8aMCatNLOSettings',
+		'processParameters',
+	)
+  )
+)

--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/README.md
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/README.md
@@ -1,0 +1,13 @@
+### Introduction
+
+To generate Hadronizer fragmments for different masses of the Higgs in the process `GluGluHToGG`, `VBFHToGG`, `VHToGG`, `ttHToGG`.
+
+Just run the command:
+```
+./fragment_producer.sh
+```
+
+Then, the fragments for the following mass points will be generated:
+```
+masses=(60 65 70 75 80 85 90 95 100 105 110 115 120 123 124 125 126 127 130)
+```

--- a/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/fragment_producer.sh
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HtoGG/fragment_producer.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+masses=(60 65 70 75 80 85 90 95 100 105 110 115 120 123 124 125 126 127 130)
+
+echo ${masses[*]}
+
+sample=Hadronizer_TuneCP5_13p6TeV_aMCatNLO_GluGluHToGG_
+echo "---> sample:"$sample
+for mass in ${masses[*]}; do
+    echo generating fragment for M = $mass GeV
+	sed "s/<MASS>/${mass}/g" ${sample}.py > ${sample}M-${mass}_LHE_pythia8_cff.py
+done
+
+sample=Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VBFHToGG_
+echo "---> sample:"$sample
+for mass in ${masses[*]}; do
+    echo generating fragment for M = $mass GeV
+	sed "s/<MASS>/${mass}/g" ${sample}.py > ${sample}M-${mass}_LHE_pythia8_cff.py
+done
+
+sample=Hadronizer_TuneCP5_13p6TeV_aMCatNLO_VHToGG_
+echo "---> sample:"$sample
+for mass in ${masses[*]}; do
+    echo generating fragment for M = $mass GeV
+	sed "s/<MASS>/${mass}/g" ${sample}.py > ${sample}M-${mass}_LHE_pythia8_cff.py
+done
+
+sample=Hadronizer_TuneCP5_13p6TeV_aMCatNLO_ttHToGG_
+echo "---> sample:"$sample
+for mass in ${masses[*]}; do
+    echo generating fragment for M = $mass GeV
+	sed "s/<MASS>/${mass}/g" ${sample}.py > ${sample}M-${mass}_LHE_pythia8_cff.py
+done


### PR DESCRIPTION
Update the hadronizer for Run3 `SM Hgg` and `low mass Hgg` searches. The template hadronizer fragments are taken from the 2022 Run3 SM samples: [GluGluHToGG](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-Run3Summer22EEwmLHEGS-00010&page=0&shown=127), [ttHtoGG](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-Run3Summer22EEwmLHEGS-00021&page=0&shown=127), [VBFHtoGG](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-Run3Summer22EEwmLHEGS-00007&page=0&shown=127), [VHtoGG](https://cms-pdmv.cern.ch/mcm/requests?prepid=HIG-Run3Summer22EEwmLHEGS-00024&page=0&shown=127).