### PR TITLE
Added possibility for herwig tuning in request fragment script

### DIFF
--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -122,12 +122,12 @@ def slha_gp(gridpack_cvmfs_path,slha_flag):
 def tunes_settings_check(dn,fragment,pi,sherpa_flag):
     error_tunes_check = []
     if "Summer22" in pi and "FlatRandomEGunProducer" not in fragment and "FlatRandomPtGunProducer" not in fragment and "Pythia8EGun" not in fragment and "Pythia8PtGun" not in fragment and "FlatRandomPtAndDxyGunProducer" not in fragment and sherpa_flag == 0:
-        if "Configuration.Generator.MCTunesRun3ECM13p6TeV" not in fragment or "from Configuration.Generator.MCTunes2017" in fragment:
-            error_tunes_check.append(" For Summer22 samples, please use from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import * in your fragment instead of from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *")
+        if ("Configuration.Generator.MCTunesRun3ECM13p6TeV" not in fragment) and ("Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi" not in fragment) or ("from Configuration.Generator.MCTunes2017" in fragment):
+            error_tunes_check.append(" For Summer22 samples, please use either:\n from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import * \n from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import * \n in your fragment instead of: from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *")
     if "Run3" in pi and (dn.startswith("DYto") or dn.startswith("Wto")):
         if "ktdard" in fragment and "0.248" not in fragment:
             error_tunes_check.append(" 'kthard = 0.248' not in fragment for DY or Wjets MG5_aMC request for Run3. Please fix.")
-    return error_tunes_check                
+    return error_tunes_check
  
 def concurrency_check(fragment,pi,cmssw_version,mg_gp):
     conc_check = 0


### PR DESCRIPTION
Hi,

This is a small change to allow for herwig tuning in the fragments when doing
local validation in McM. Below is there the quick recipe I've prepared to test it.

Hope it's ok to add this feature. We have a request for a sample that requires
herwig showering but we cannot validate it.

## Testing recipe
```
wget https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_test/TOP-Run3Summer22wmLHEGS-00029
wget https://github.com/Cvico/genproductions/raw/fix_requestScript_forHerwig/bin/utils/request_fragment_check.py
python3 ./request_fragment_check.py --bypass_status --prepid TOP-Run3Summer22wmLHEGS-00029 --develop
```

