### PR TITLE
Added no spin correlation input cards for preUL

### DIFF
--- a/bin/Powheg/production/pre2017/13TeV/TTTo2L2Nu_hdamp_NNPDF30_13TeV/TTTo2L2Nu_hdamp_NNPDF30_NLO_noSpinCorrelations.input
+++ b/bin/Powheg/production/pre2017/13TeV/TTTo2L2Nu_hdamp_NNPDF30_13TeV/TTTo2L2Nu_hdamp_NNPDF30_NLO_noSpinCorrelations.input
@@ -23,7 +23,7 @@ qmass  172.5     ! mass of heavy quark in GeV
 facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
 renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
 
-hdamp 272.55
+hdamp 272.7225
 
 topdecaymode 22200   ! an integer of 5 digits that are either 0, or 2, representing in 
                      ! the order the maximum number of the following particles(antiparticles)
@@ -74,7 +74,7 @@ xupbound 2      ! increase upper bound for radiation generation
 
 pdfreweight 0
 storeinfo_rwgt 0    ! store weight information
-withnegweights 1    ! default 0
+withnegweights 0    ! default 0
 nospincorr 1       ! remove spin correlation
 
 

--- a/bin/Powheg/production/pre2017/13TeV/TTTo2L2Nu_hdamp_NNPDF30_13TeV/TTTo2L2Nu_hdamp_NNPDF30_NLO_noSpinCorrelations.input
+++ b/bin/Powheg/production/pre2017/13TeV/TTTo2L2Nu_hdamp_NNPDF30_13TeV/TTTo2L2Nu_hdamp_NNPDF30_NLO_noSpinCorrelations.input
@@ -1,0 +1,80 @@
+! TTbar production parameters
+!randomseed 352345 ! uncomment to set the random seed to a value of your choice.
+                   ! It generates the call RM48IN(352345,0,0) (see the RM48 manual).
+                   ! THIS MAY ONLY AFFECTS THE GENERATION OF POWHEG EVENTS!
+                   ! If POWHEG is interfaced to a shower MC, refer to the shower MC
+                   ! documentation to set its seed.
+
+
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 260000
+lhans2 260000
+! NNPDF30_nlo_as_0118
+ebeam1 6500    ! energy of beam 1
+ebeam2 6500    ! energy of beam 2
+qmass  172.5     ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 272.55
+
+topdecaymode 22200   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into b l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+!semileptonic 1      ! uncomment if you want to filter out only semileptonic events. For example,
+                     ! with topdecaymode 10011 and semileptonic 1 you get only events with one top going
+                     ! to an electron or positron, and the other into any hadron.
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.4  ! W mass for top decay
+tdec/wwidth 2.141
+tdec/bmass 4.8
+tdec/twidth  1.31 ! 1.33 using PDG LO formula
+tdec/elbranching 0.108
+tdec/emass 0.00051
+tdec/mumass 0.1057
+tdec/taumass 1.777
+tdec/dmass   0.100
+tdec/umass   0.100
+tdec/smass   0.200
+tdec/cmass   1.5
+tdec/sin2cabibbo 0.051
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 10000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1    ! default 0
+nospincorr 1       ! remove spin correlation
+
+


### PR DESCRIPTION
Dear GEN experts,
I have discovered an issue in the 2016 preUL ttbar no spin correlation samples. It appears that the spin correlations are still present. I have created new cards as I could not find the previous cards in this repository. Below is a comparison of a spin observable that should have been flat in the no spin corr MC and a comparison with a sample I produced privately with these cards.

[no_spincorr_comparison-1-1.pdf](https://github.com/cms-sw/genproductions/files/13072209/no_spincorr_comparison-1-1.pdf)

This sample is required for the TOP-23-001 analysis and is considered a high priority. @menglu21 @bbilin @agrohsje 
Thanks,
AJ