### PR TITLE
adding decay and filter for ttH using JHUGen config

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ttH_ZZ_NNPDF31_13TeV/JHUGen.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ttH_ZZ_NNPDF31_13TeV/JHUGen.input
@@ -1,0 +1,1 @@
+DecayMode1=8 DecayMode2=9 NLepMin=4 WriteFailedEvents=2


### PR DESCRIPTION
Previous ttH samples were missing the 4l filter and the decay chain. We want to produce ttH samples with decay  H->ZZ->2l 2X, and then apply a 4l filter. So adding the decay setting in the JHUGen.input