### PR TITLE
Added cards for VBSVVH production with C2V madgraph reweighting scan

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card NEW 1 1.0
+set param_card NEW 2 2.0
+set param_card NEW 3 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_extramodels.dat
@@ -1,0 +1,1 @@
+HHVBF_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_proc_card.dat
@@ -1,0 +1,5 @@
+import model HHVBF_UFO-vbf_hh_4f
+
+generate p p > w+ w- h j j QCD=0
+
+output VBSWWH_OS_VBSCuts_4f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_reweight_card.dat
@@ -1,0 +1,226 @@
+change mode NLO       # Define type of Reweighting. For LO sample this command
+                      # has no effect since only LO mode is allowed.
+change helicity False # has also been done in the example I got from Kenneth
+change rwgt_dir rwgt
+
+#[1/37] CV:1.0 C2V:-2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[2/37] CV:1.0 C2V:-1.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.75 # C2V
+set NEW 3 1.0 # C3
+
+#[3/37] CV:1.0 C2V:-1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[4/37] CV:1.0 C2V:-1.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.25 # C2V
+set NEW 3 1.0 # C3
+
+#[5/37] CV:1.0 C2V:-1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[6/37] CV:1.0 C2V:-0.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.75 # C2V
+set NEW 3 1.0 # C3
+
+#[7/37] CV:1.0 C2V:-0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[8/37] CV:1.0 C2V:-0.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.25 # C2V
+set NEW 3 1.0 # C3
+
+#[9/37] CV:1.0 C2V:0.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.0 # C2V
+set NEW 3 1.0 # C3
+
+#[10/37] CV:1.0 C2V:0.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.1 # C2V
+set NEW 3 1.0 # C3
+
+#[11/37] CV:1.0 C2V:0.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.2 # C2V
+set NEW 3 1.0 # C3
+
+#[12/37] CV:1.0 C2V:0.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.3 # C2V
+set NEW 3 1.0 # C3
+
+#[13/37] CV:1.0 C2V:0.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.4 # C2V
+set NEW 3 1.0 # C3
+
+#[14/37] CV:1.0 C2V:0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[15/37] CV:1.0 C2V:0.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.6 # C2V
+set NEW 3 1.0 # C3
+
+#[16/37] CV:1.0 C2V:0.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.7 # C2V
+set NEW 3 1.0 # C3
+
+#[17/37] CV:1.0 C2V:0.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.8 # C2V
+set NEW 3 1.0 # C3
+
+#[18/37] CV:1.0 C2V:0.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.9 # C2V
+set NEW 3 1.0 # C3
+
+#[19/37] CV:1.0 C2V:1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[20/37] CV:1.0 C2V:1.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.1 # C2V
+set NEW 3 1.0 # C3
+
+#[21/37] CV:1.0 C2V:1.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.2 # C2V
+set NEW 3 1.0 # C3
+
+#[22/37] CV:1.0 C2V:1.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.3 # C2V
+set NEW 3 1.0 # C3
+
+#[23/37] CV:1.0 C2V:1.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.4 # C2V
+set NEW 3 1.0 # C3
+
+#[24/37] CV:1.0 C2V:1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[25/37] CV:1.0 C2V:1.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.6 # C2V
+set NEW 3 1.0 # C3
+
+#[26/37] CV:1.0 C2V:1.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.7 # C2V
+set NEW 3 1.0 # C3
+
+#[27/37] CV:1.0 C2V:1.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.8 # C2V
+set NEW 3 1.0 # C3
+
+#[28/37] CV:1.0 C2V:1.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.9 # C2V
+set NEW 3 1.0 # C3
+
+#[29/37] CV:1.0 C2V:2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[30/37] CV:1.0 C2V:2.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.25 # C2V
+set NEW 3 1.0 # C3
+
+#[31/37] CV:1.0 C2V:2.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.5 # C2V
+set NEW 3 1.0 # C3
+
+#[32/37] CV:1.0 C2V:2.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.75 # C2V
+set NEW 3 1.0 # C3
+
+#[33/37] CV:1.0 C2V:3.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.0 # C2V
+set NEW 3 1.0 # C3
+
+#[34/37] CV:1.0 C2V:3.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.25 # C2V
+set NEW 3 1.0 # C3
+
+#[35/37] CV:1.0 C2V:3.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.5 # C2V
+set NEW 3 1.0 # C3
+
+#[36/37] CV:1.0 C2V:3.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.75 # C2V
+set NEW 3 1.0 # C3
+
+#[37/37] CV:1.0 C2V:4.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_4p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 4.0 # C2V
+set NEW 3 1.0 # C3

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_OS_VBSCuts_4f_LO/VBSWWH_OS_VBSCuts_4f_LO_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.   = gridpack ! True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+   0  = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel                ! PDF set                                  
+  $DEFAULT_PDF_SETS = lhaid           ! if pdlabel=lhapdf, this is the lhapdf number 
+  $DEFAULT_PDF_MEMBERS = reweight_PDF ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version      ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5 = etaj     ! max rap for the jets 
+  -1  = etab     ! max rap for the b
+  -1  = etaa     ! max rap for the photons 
+  -1  = etal     ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin  ! min rap for the jets
+   0  = etabmin  ! min rap for the b
+   0  = etaamin  ! min rap for the photons
+   0  = etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+100  = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin !inclusive Ht for all partons (including b)
+ -1  = ihtmax !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin   ! Min photon transverse momentum
+ 0.4 = R0gamma  ! Radius of isolation code
+ 1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin  ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1   =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card NEW 1 1.0
+set param_card NEW 2 2.0
+set param_card NEW 3 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_extramodels.dat
@@ -1,0 +1,1 @@
+HHVBF_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_proc_card.dat
@@ -1,0 +1,6 @@
+import model HHVBF_UFO-vbf_hh_4f
+
+generate p p > w+ w+ h j j QCD=0
+add process p p > w- w- h j j QCD=0
+
+output VBSWWH_SS_VBSCuts_4f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_reweight_card.dat
@@ -1,0 +1,226 @@
+change mode NLO       # Define type of Reweighting. For LO sample this command
+                      # has no effect since only LO mode is allowed.
+change helicity False # has also been done in the example I got from Kenneth
+change rwgt_dir rwgt
+
+#[1/37] CV:1.0 C2V:-2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[2/37] CV:1.0 C2V:-1.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.75 # C2V
+set NEW 3 1.0 # C3
+
+#[3/37] CV:1.0 C2V:-1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[4/37] CV:1.0 C2V:-1.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.25 # C2V
+set NEW 3 1.0 # C3
+
+#[5/37] CV:1.0 C2V:-1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[6/37] CV:1.0 C2V:-0.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.75 # C2V
+set NEW 3 1.0 # C3
+
+#[7/37] CV:1.0 C2V:-0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[8/37] CV:1.0 C2V:-0.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.25 # C2V
+set NEW 3 1.0 # C3
+
+#[9/37] CV:1.0 C2V:0.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.0 # C2V
+set NEW 3 1.0 # C3
+
+#[10/37] CV:1.0 C2V:0.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.1 # C2V
+set NEW 3 1.0 # C3
+
+#[11/37] CV:1.0 C2V:0.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.2 # C2V
+set NEW 3 1.0 # C3
+
+#[12/37] CV:1.0 C2V:0.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.3 # C2V
+set NEW 3 1.0 # C3
+
+#[13/37] CV:1.0 C2V:0.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.4 # C2V
+set NEW 3 1.0 # C3
+
+#[14/37] CV:1.0 C2V:0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[15/37] CV:1.0 C2V:0.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.6 # C2V
+set NEW 3 1.0 # C3
+
+#[16/37] CV:1.0 C2V:0.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.7 # C2V
+set NEW 3 1.0 # C3
+
+#[17/37] CV:1.0 C2V:0.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.8 # C2V
+set NEW 3 1.0 # C3
+
+#[18/37] CV:1.0 C2V:0.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.9 # C2V
+set NEW 3 1.0 # C3
+
+#[19/37] CV:1.0 C2V:1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[20/37] CV:1.0 C2V:1.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.1 # C2V
+set NEW 3 1.0 # C3
+
+#[21/37] CV:1.0 C2V:1.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.2 # C2V
+set NEW 3 1.0 # C3
+
+#[22/37] CV:1.0 C2V:1.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.3 # C2V
+set NEW 3 1.0 # C3
+
+#[23/37] CV:1.0 C2V:1.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.4 # C2V
+set NEW 3 1.0 # C3
+
+#[24/37] CV:1.0 C2V:1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[25/37] CV:1.0 C2V:1.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.6 # C2V
+set NEW 3 1.0 # C3
+
+#[26/37] CV:1.0 C2V:1.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.7 # C2V
+set NEW 3 1.0 # C3
+
+#[27/37] CV:1.0 C2V:1.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.8 # C2V
+set NEW 3 1.0 # C3
+
+#[28/37] CV:1.0 C2V:1.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.9 # C2V
+set NEW 3 1.0 # C3
+
+#[29/37] CV:1.0 C2V:2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[30/37] CV:1.0 C2V:2.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.25 # C2V
+set NEW 3 1.0 # C3
+
+#[31/37] CV:1.0 C2V:2.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.5 # C2V
+set NEW 3 1.0 # C3
+
+#[32/37] CV:1.0 C2V:2.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.75 # C2V
+set NEW 3 1.0 # C3
+
+#[33/37] CV:1.0 C2V:3.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.0 # C2V
+set NEW 3 1.0 # C3
+
+#[34/37] CV:1.0 C2V:3.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.25 # C2V
+set NEW 3 1.0 # C3
+
+#[35/37] CV:1.0 C2V:3.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.5 # C2V
+set NEW 3 1.0 # C3
+
+#[36/37] CV:1.0 C2V:3.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.75 # C2V
+set NEW 3 1.0 # C3
+
+#[37/37] CV:1.0 C2V:4.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_4p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 4.0 # C2V
+set NEW 3 1.0 # C3

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWWH_SS_VBSCuts_4f_LO/VBSWWH_SS_VBSCuts_4f_LO_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.   = gridpack ! True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+   0  = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel                ! PDF set                                  
+  $DEFAULT_PDF_SETS = lhaid           ! if pdlabel=lhapdf, this is the lhapdf number 
+  $DEFAULT_PDF_MEMBERS = reweight_PDF ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version      ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5 = etaj     ! max rap for the jets 
+  -1  = etab     ! max rap for the b
+  -1  = etaa     ! max rap for the photons 
+  -1  = etal     ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin  ! min rap for the jets
+   0  = etabmin  ! min rap for the b
+   0  = etaamin  ! min rap for the photons
+   0  = etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+100  = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin !inclusive Ht for all partons (including b)
+ -1  = ihtmax !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin   ! Min photon transverse momentum
+ 0.4 = R0gamma  ! Radius of isolation code
+ 1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin  ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1   =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card NEW 1 1.0
+set param_card NEW 2 2.0
+set param_card NEW 3 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_extramodels.dat
@@ -1,0 +1,1 @@
+HHVBF_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_proc_card.dat
@@ -1,0 +1,7 @@
+import model HHVBF_UFO-vbf_hh_4f
+
+define w = w+ w-
+
+generate p p > w z h j j QCD=0
+
+output VBSWZH_VBSCuts_4f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_reweight_card.dat
@@ -1,0 +1,226 @@
+change mode NLO       # Define type of Reweighting. For LO sample this command
+                      # has no effect since only LO mode is allowed.
+change helicity False # has also been done in the example I got from Kenneth
+change rwgt_dir rwgt
+
+#[1/37] CV:1.0 C2V:-2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[2/37] CV:1.0 C2V:-1.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.75 # C2V
+set NEW 3 1.0 # C3
+
+#[3/37] CV:1.0 C2V:-1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[4/37] CV:1.0 C2V:-1.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.25 # C2V
+set NEW 3 1.0 # C3
+
+#[5/37] CV:1.0 C2V:-1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[6/37] CV:1.0 C2V:-0.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.75 # C2V
+set NEW 3 1.0 # C3
+
+#[7/37] CV:1.0 C2V:-0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[8/37] CV:1.0 C2V:-0.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.25 # C2V
+set NEW 3 1.0 # C3
+
+#[9/37] CV:1.0 C2V:0.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.0 # C2V
+set NEW 3 1.0 # C3
+
+#[10/37] CV:1.0 C2V:0.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.1 # C2V
+set NEW 3 1.0 # C3
+
+#[11/37] CV:1.0 C2V:0.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.2 # C2V
+set NEW 3 1.0 # C3
+
+#[12/37] CV:1.0 C2V:0.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.3 # C2V
+set NEW 3 1.0 # C3
+
+#[13/37] CV:1.0 C2V:0.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.4 # C2V
+set NEW 3 1.0 # C3
+
+#[14/37] CV:1.0 C2V:0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[15/37] CV:1.0 C2V:0.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.6 # C2V
+set NEW 3 1.0 # C3
+
+#[16/37] CV:1.0 C2V:0.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.7 # C2V
+set NEW 3 1.0 # C3
+
+#[17/37] CV:1.0 C2V:0.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.8 # C2V
+set NEW 3 1.0 # C3
+
+#[18/37] CV:1.0 C2V:0.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.9 # C2V
+set NEW 3 1.0 # C3
+
+#[19/37] CV:1.0 C2V:1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[20/37] CV:1.0 C2V:1.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.1 # C2V
+set NEW 3 1.0 # C3
+
+#[21/37] CV:1.0 C2V:1.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.2 # C2V
+set NEW 3 1.0 # C3
+
+#[22/37] CV:1.0 C2V:1.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.3 # C2V
+set NEW 3 1.0 # C3
+
+#[23/37] CV:1.0 C2V:1.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.4 # C2V
+set NEW 3 1.0 # C3
+
+#[24/37] CV:1.0 C2V:1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[25/37] CV:1.0 C2V:1.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.6 # C2V
+set NEW 3 1.0 # C3
+
+#[26/37] CV:1.0 C2V:1.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.7 # C2V
+set NEW 3 1.0 # C3
+
+#[27/37] CV:1.0 C2V:1.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.8 # C2V
+set NEW 3 1.0 # C3
+
+#[28/37] CV:1.0 C2V:1.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.9 # C2V
+set NEW 3 1.0 # C3
+
+#[29/37] CV:1.0 C2V:2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[30/37] CV:1.0 C2V:2.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.25 # C2V
+set NEW 3 1.0 # C3
+
+#[31/37] CV:1.0 C2V:2.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.5 # C2V
+set NEW 3 1.0 # C3
+
+#[32/37] CV:1.0 C2V:2.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.75 # C2V
+set NEW 3 1.0 # C3
+
+#[33/37] CV:1.0 C2V:3.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.0 # C2V
+set NEW 3 1.0 # C3
+
+#[34/37] CV:1.0 C2V:3.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.25 # C2V
+set NEW 3 1.0 # C3
+
+#[35/37] CV:1.0 C2V:3.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.5 # C2V
+set NEW 3 1.0 # C3
+
+#[36/37] CV:1.0 C2V:3.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.75 # C2V
+set NEW 3 1.0 # C3
+
+#[37/37] CV:1.0 C2V:4.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_4p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 4.0 # C2V
+set NEW 3 1.0 # C3

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSWZH_VBSCuts_4f_LO/VBSWZH_VBSCuts_4f_LO_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.   = gridpack ! True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+   0  = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel                ! PDF set                                  
+  $DEFAULT_PDF_SETS = lhaid           ! if pdlabel=lhapdf, this is the lhapdf number 
+  $DEFAULT_PDF_MEMBERS = reweight_PDF ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version      ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5 = etaj     ! max rap for the jets 
+  -1  = etab     ! max rap for the b
+  -1  = etaa     ! max rap for the photons 
+  -1  = etal     ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin  ! min rap for the jets
+   0  = etabmin  ! min rap for the b
+   0  = etaamin  ! min rap for the photons
+   0  = etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+100  = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin !inclusive Ht for all partons (including b)
+ -1  = ihtmax !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin   ! Min photon transverse momentum
+ 0.4 = R0gamma  ! Radius of isolation code
+ 1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin  ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1   =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card NEW 1 1.0
+set param_card NEW 2 2.0
+set param_card NEW 3 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_extramodels.dat
@@ -1,0 +1,1 @@
+HHVBF_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_proc_card.dat
@@ -1,0 +1,5 @@
+import model HHVBF_UFO-vbf_hh_4f
+
+generate p p > z z h j j QCD=0
+
+output VBSZZH_VBSCuts_4f_LO -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_reweight_card.dat
@@ -1,0 +1,226 @@
+change mode NLO       # Define type of Reweighting. For LO sample this command
+                      # has no effect since only LO mode is allowed.
+change helicity False # has also been done in the example I got from Kenneth
+change rwgt_dir rwgt
+
+#[1/37] CV:1.0 C2V:-2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[2/37] CV:1.0 C2V:-1.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.75 # C2V
+set NEW 3 1.0 # C3
+
+#[3/37] CV:1.0 C2V:-1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[4/37] CV:1.0 C2V:-1.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.25 # C2V
+set NEW 3 1.0 # C3
+
+#[5/37] CV:1.0 C2V:-1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[6/37] CV:1.0 C2V:-0.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.75 # C2V
+set NEW 3 1.0 # C3
+
+#[7/37] CV:1.0 C2V:-0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[8/37] CV:1.0 C2V:-0.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_m0p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 -0.25 # C2V
+set NEW 3 1.0 # C3
+
+#[9/37] CV:1.0 C2V:0.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.0 # C2V
+set NEW 3 1.0 # C3
+
+#[10/37] CV:1.0 C2V:0.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.1 # C2V
+set NEW 3 1.0 # C3
+
+#[11/37] CV:1.0 C2V:0.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.2 # C2V
+set NEW 3 1.0 # C3
+
+#[12/37] CV:1.0 C2V:0.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.3 # C2V
+set NEW 3 1.0 # C3
+
+#[13/37] CV:1.0 C2V:0.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.4 # C2V
+set NEW 3 1.0 # C3
+
+#[14/37] CV:1.0 C2V:0.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.5 # C2V
+set NEW 3 1.0 # C3
+
+#[15/37] CV:1.0 C2V:0.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.6 # C2V
+set NEW 3 1.0 # C3
+
+#[16/37] CV:1.0 C2V:0.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.7 # C2V
+set NEW 3 1.0 # C3
+
+#[17/37] CV:1.0 C2V:0.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.8 # C2V
+set NEW 3 1.0 # C3
+
+#[18/37] CV:1.0 C2V:0.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_0p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 0.9 # C2V
+set NEW 3 1.0 # C3
+
+#[19/37] CV:1.0 C2V:1.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.0 # C2V
+set NEW 3 1.0 # C3
+
+#[20/37] CV:1.0 C2V:1.1 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p1_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.1 # C2V
+set NEW 3 1.0 # C3
+
+#[21/37] CV:1.0 C2V:1.2 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p2_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.2 # C2V
+set NEW 3 1.0 # C3
+
+#[22/37] CV:1.0 C2V:1.3 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p3_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.3 # C2V
+set NEW 3 1.0 # C3
+
+#[23/37] CV:1.0 C2V:1.4 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p4_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.4 # C2V
+set NEW 3 1.0 # C3
+
+#[24/37] CV:1.0 C2V:1.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.5 # C2V
+set NEW 3 1.0 # C3
+
+#[25/37] CV:1.0 C2V:1.6 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p6_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.6 # C2V
+set NEW 3 1.0 # C3
+
+#[26/37] CV:1.0 C2V:1.7 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p7_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.7 # C2V
+set NEW 3 1.0 # C3
+
+#[27/37] CV:1.0 C2V:1.8 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p8_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.8 # C2V
+set NEW 3 1.0 # C3
+
+#[28/37] CV:1.0 C2V:1.9 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_1p9_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 1.9 # C2V
+set NEW 3 1.0 # C3
+
+#[29/37] CV:1.0 C2V:2.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.0 # C2V
+set NEW 3 1.0 # C3
+
+#[30/37] CV:1.0 C2V:2.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.25 # C2V
+set NEW 3 1.0 # C3
+
+#[31/37] CV:1.0 C2V:2.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.5 # C2V
+set NEW 3 1.0 # C3
+
+#[32/37] CV:1.0 C2V:2.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_2p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 2.75 # C2V
+set NEW 3 1.0 # C3
+
+#[33/37] CV:1.0 C2V:3.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.0 # C2V
+set NEW 3 1.0 # C3
+
+#[34/37] CV:1.0 C2V:3.25 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p25_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.25 # C2V
+set NEW 3 1.0 # C3
+
+#[35/37] CV:1.0 C2V:3.5 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p5_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.5 # C2V
+set NEW 3 1.0 # C3
+
+#[36/37] CV:1.0 C2V:3.75 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_3p75_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 3.75 # C2V
+set NEW 3 1.0 # C3
+
+#[37/37] CV:1.0 C2V:4.0 C3:1.0
+launch --rewgt_name=scan_CV_1p0_C2V_4p0_C3_1p0
+set NEW 1 1.0 # CV
+set NEW 2 4.0 # C2V
+set NEW 3 1.0 # C3

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/VBSZZH_VBSCuts_4f_LO/VBSZZH_VBSCuts_4f_LO_run_card.dat
@@ -1,0 +1,271 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .false.   = gridpack ! True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  250 = nevents ! Number of unweighted events requested 
+   0  = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1     = lpp1    ! beam 1 type 
+        1     = lpp2    ! beam 2 type
+     6500     = ebeam1  ! beam 1 total energy in GeV
+     6500     = ebeam2  ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel                ! PDF set                                  
+  $DEFAULT_PDF_SETS = lhaid           ! if pdlabel=lhapdf, this is the lhapdf number 
+  $DEFAULT_PDF_MEMBERS = reweight_PDF ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 0        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 4        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ T        = clusinfo         ! include clustering tag in output
+ 3.0      = lhe_version      ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   F  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+   T  = cut_decays    ! Cut decay products 
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 10  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+  0  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+  0  = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  6.5 = etaj     ! max rap for the jets 
+  -1  = etab     ! max rap for the b
+  -1  = etaa     ! max rap for the photons 
+  -1  = etal     ! max rap for the charged leptons 
+  -1  = etaonium ! max rap for the quarkonium states
+   0  = etajmin  ! min rap for the jets
+   0  = etabmin  ! min rap for the b
+   0  = etaamin  ! min rap for the photons
+   0  = etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.1 = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0   = drll    ! min distance between leptons 
+ 0   = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.1 = draj    ! min distance between gamma and jet 
+ 0   = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.1 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+100  = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0  = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin !inclusive Ht for all partons (including b)
+ -1  = ihtmax !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+   0 = ptgmin   ! Min photon transverse momentum
+ 0.4 = R0gamma  ! Radius of isolation code
+ 1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true. = isoEM ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin  ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+ -1   =  ktdurham        
+ 0.4  =  dparameter 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 0   = xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst ! Enable systematics studies
+#
+#**************************************


### PR DESCRIPTION
Adding MadGraph cards for VBS VVH production. The latest update on this analysis, along with links to previous updates, can be found [here](https://indico.cern.ch/event/1319569/contributions/5626641/attachments/2736684/4759226/Hbb_VVH_October18.pdf). The model is available here:
```
/afs/cern.ch/user/j/jguiang/public/models/HHVBF_UFO.tar.gz
```

All samples use the same run card as #3287.