### PR TITLE
Update JHUGen to v7.5.4

### DIFF
--- a/bin/JHUGen/install.py
+++ b/bin/JHUGen/install.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import textwrap
 
-JHUGenversion = "v7.5.3"
+JHUGenversion = "v7.5.4"
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Make JHUGen gridpack")


### PR DESCRIPTION
A new version of JHUGenerator was released yesterday [here](https://spin.pha.jhu.edu/Generator/JHUGenerator.v7.5.4.tar.gz). This PR is to update the version in the install script.