### PR TITLE
Fix the case when filter eff is negative in the fragement

### DIFF
--- a/bin/utils/request_fragment_check.py
+++ b/bin/utils/request_fragment_check.py
@@ -635,7 +635,7 @@ for num in range(0,len(prepid)):
         print("Filter efficiency in fragment =" + str(filter_eff_fragment))
         print("Filter efficiency from generator parameters field = "+str(filter_eff))
         # see https://github.com/cms-sw/genproductions/issues/3269
-        if len(filter_eff_fragment) > 0 and float(filter_eff_fragment) < 1.0:
+        if len(filter_eff_fragment) > 0 and float(filter_eff_fragment) < 1.0 and float(filter_eff_fragment) > 0:
             if filter_eff_fragment and filter_eff and int(ext) == 0 and float(filter_eff_fragment) != float(filter_eff):
                 errors.append("In general, filter efficiency in the fragment is not taken into accout. Please make sure that the filter efficiency in the generator parameters field is correct!")
 	


### PR DESCRIPTION
Sometimes the filter eff is set to -1 to show that it is not used, currently the script does not let the validation pass. 