### PR TITLE
Adding genfragments for multiply charged particles - pythia8

### DIFF
--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp12_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 12   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp15_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 15   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp18_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 18   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp21_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 21   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp24_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 24   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp27_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 27   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp30_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 30   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp33_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 33   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp36_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 36   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp39_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 39   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp3_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 3   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp42_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 42   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp45_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 45   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp48_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 48   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp60_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 60   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp6_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 6   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp72_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 72   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp90_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 90   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1000   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_100_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_100_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 100   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1200   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1400   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1600   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_1800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 1800   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2000_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2000_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2000   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_200_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_200_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 200   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2400   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_2800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 2800   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_300_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_300_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 300   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_400_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_400_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 400   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_500_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_500_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 500   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_600_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_600_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 600   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_700_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_700_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 700   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_800_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_800_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 800   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)

--- a/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_900_TuneCP2_13TeV_pythia8_cff.py
+++ b/genfragments/ThirteenTeV/HSCP/mchampPythia8/HSCPmchamp9_M_900_TuneCP2_13TeV_pythia8_cff.py
@@ -1,0 +1,72 @@
+FLAVOR = 'stau'
+COM_ENERGY = 13000. # GeV
+MASS_POINT = 900   # GeV
+CHARGE = 9   # electron charge/3
+ZMASS_POINT = 91.18 # GeV
+PROCESS_FILE = 'SimG4Core/CustomPhysics/data/RhadronProcessList.txt'
+PARTICLE_FILE = 'Configuration/Generator/data/newStau/particles_HIP%d_%s_%d_GeV.txt' % (CHARGE, FLAVOR, MASS_POINT)
+SLHA_FILE = 'None'
+PDT_FILE = 'Configuration/Generator/data/newStau/hscppythiapdtHIP%d%s%d.tbl'  % (CHARGE, FLAVOR, MASS_POINT)
+USE_REGGE = False
+
+hipMass = float (MASS_POINT)
+vectCoupling = float ((CHARGE/3)*0.92) # -2Qsin^2(thetaW)
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP2Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(COM_ENERGY),
+    maxEventsToPrint = cms.untracked.int32(0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP2SettingsBlock,
+        processParameters = cms.vstring(
+          'NewGaugeBoson:ffbar2gmZZprime = on',
+          'Zprime:gmZmode = 5', # full gamma*/Zprime interference
+          '32:m0 = %f' % ZMASS_POINT, # faking the Zprime to be the Z
+          '32:onMode = off',
+          '32:onIfAny = 17',
+          'Zprime:coup2gen4 = on',
+          'Zprime:universality = off',
+          'Zprime:atauPrime = 0',
+          'Zprime:vtauPrime = %f' % vectCoupling,
+          '17:m0 = %f' % hipMass,
+          '17:mWidth = 0',
+          '17:doForceWidth = true',
+          '17:mayDecay = off',
+          '17:chargeType  = %f' % CHARGE,
+          'PhaseSpace:mHatMin = %f' % (2.0*hipMass),
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP2Settings',
+            'processParameters'
+            )
+        )
+)
+
+generator.hscpFlavor = cms.untracked.string(FLAVOR)
+generator.massPoint = cms.untracked.int32(MASS_POINT)
+generator.slhaFile = cms.untracked.string(SLHA_FILE)
+generator.processFile = cms.untracked.string(PROCESS_FILE)
+generator.particleFile = cms.untracked.string(PARTICLE_FILE)
+generator.pdtFile = cms.FileInPath(PDT_FILE)
+generator.useregge = cms.bool(USE_REGGE)
+
+genfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(100., 100.),
+    MinEta = cms.untracked.vdouble(-100, -100),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(17),
+    ParticleID2 = cms.untracked.vint32(17)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*genfilter)


### PR DESCRIPTION
Adding genfragments for multiply charged particles - pythia8 version, to the HSCP repo. 
Charges={1e..16e,20e,24e,30e} 
Masses={100,200,300,400,500,600,700,800,900,1000,1200,1400,1600,1800,2000,2400,2800}GeV