### PR TITLE
Input card for Run 3 ggH to diphoton with example 60 GeV mass point

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_customizecards.dat
@@ -1,0 +1,1 @@
+set param_card mass 25 60.

--- a/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_extramodels.dat
@@ -1,0 +1,1 @@
+HC_NLO_X0_UFO-v1.3.zip

--- a/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_proc_card.dat
@@ -1,0 +1,7 @@
+import model HC_NLO_X0_UFO-heft
+
+generate p p > x0 / t [QCD] @0
+add process p p > x0 j / t [QCD] @1
+add process p p > x0 j j / t [QCD] @2
+
+output ggh012j_5f_NLO_FXFX_60 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_run_card.dat
@@ -1,0 +1,131 @@
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#
+#***********************************************************************
+# Tag name for the run (one word)                                      *
+#***********************************************************************
+  tag_1     = run_tag ! name of the run 
+#***********************************************************************
+# Number of events (and their normalization) and the required          *
+# (relative) accuracy on the Xsec.                                     *
+# These values are ignored for fixed order runs                        *
+#***********************************************************************
+  1500 = nevents ! Number of unweighted events requested 
+    -1 = req_acc ! Required accuracy (-1=auto determined from nevents)
+    -1 = nevt_job! Max number of events per job in event generation. 
+                 !  (-1= no split).
+average = event_norm ! Normalize events to sum or average to the X sect.
+#***********************************************************************
+# Number of points per itegration channel (ignored for aMC@NLO runs)   *
+#***********************************************************************
+ 0.01   = req_acc_FO       ! Required accuracy (-1=ignored, and use the 
+ 	                   ! number of points and iter. below)
+# These numbers are ignored except if req_acc_FO is equal to -1
+ 5000   = npoints_FO_grid  ! number of points to setup grids
+ 4      = niters_FO_grid   ! number of iter. to setup grids
+ 10000  = npoints_FO       ! number of points to compute Xsec
+ 6      = niters_FO        ! number of iter. to compute Xsec
+#***********************************************************************
+# Random number seed                                                   *
+#***********************************************************************
+     0    = iseed       ! rnd seed (0=assigned automatically=default))
+#***********************************************************************
+# Collider type and energy                                             *
+#***********************************************************************
+    1   = lpp1    ! beam 1 type (0 = no PDF)
+    1   = lpp2    ! beam 2 type (0 = no PDF)
+ 6800   = ebeam1  ! beam 1 energy in GeV
+ 6800   = ebeam2  ! beam 2 energy in GeV
+#***********************************************************************
+# PDF choice: this automatically fixes also alpha_s(MZ) and its evol.  *
+#***********************************************************************
+ lhapdf    = pdlabel   ! PDF set                                     
+ $DEFAULT_PDF_SETS = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+#***********************************************************************
+# Include the NLO Monte Carlo subtr. terms for the following parton    *
+# shower (HERWIG6 | HERWIGPP | PYTHIA6Q | PYTHIA6PT | PYTHIA8)         *
+# WARNING: PYTHIA6PT works only for processes without FSR!!!!          *
+#***********************************************************************
+  PYTHIA8   = parton_shower
+#***********************************************************************
+# Renormalization and factorization scales                             *
+# (Default functional form for the non-fixed scales is the sum of      *
+# the transverse masses of all final state particles and partons. This *
+# can be changed in SubProcesses/set_scales.f)                         *
+#***********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188   = muR_ref_fixed    ! fixed ren reference scale 
+ 91.188   = muF1_ref_fixed   ! fixed fact reference scale for pdf1
+ 91.188   = muF2_ref_fixed   ! fixed fact reference scale for pdf2
+#***********************************************************************
+# Renormalization and factorization scales (advanced and NLO options)  *
+#***********************************************************************
+ F        = fixed_QES_scale  ! if .true. use fixed Ellis-Sexton scale
+ 91.188   = QES_ref_fixed    ! fixed Ellis-Sexton reference scale
+ 1        = muR_over_ref     ! ratio of current muR over reference muR
+ 1        = muF1_over_ref    ! ratio of current muF1 over reference muF1
+ 1        = muF2_over_ref    ! ratio of current muF2 over reference muF2
+ 1        = QES_over_ref     ! ratio of current QES over reference QES
+#*********************************************************************** 
+# Reweight flags to get scale dependence and PDF uncertainty           *
+# For scale dependence: factor rw_scale_up/down around central scale   *
+# For PDF uncertainty: use LHAPDF with supported set                   *
+#***********************************************************************
+ .true.   = reweight_scale   ! reweight to get scale dependence
+  0.5     = rw_Rscale_down   ! lower bound for ren scale variations
+  2.0     = rw_Rscale_up     ! upper bound for ren scale variations
+  0.5     = rw_Fscale_down   ! lower bound for fact scale variations
+  2.0     = rw_Fscale_up     ! upper bound for fact scale variations
+ $DEFAULT_PDF_MEMBERS = reweight_PDF     ! reweight to get PDF uncertainty
+ True = store_rwgt_info ! Store info for reweighting in LHE file
+#***********************************************************************
+# Merging - WARNING! Applies merging only at the hard-event level.     *
+# After showering an MLM-type merging should be applied as well.       *
+# See http://amcatnlo.cern.ch/FxFx_merging.htm for more details.       *
+#***********************************************************************
+ 3        = ickkw            ! 0 no merging, 3 FxFx merging
+#***********************************************************************
+#
+#***********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma)                                       *
+#***********************************************************************
+ 15  = bwcutoff
+#***********************************************************************
+# Cuts on the jets                                                     *
+# Jet clustering is performed by FastJet.
+# When matching to a parton shower, these generation cuts should be    *
+# considerably softer than the analysis cuts.                          *
+# (more specific cuts can be specified in SubProcesses/cuts.f)         *
+#***********************************************************************
+   1  = jetalgo   ! FastJet jet algorithm (1=kT, 0=C/A, -1=anti-kT)
+ 1.0  = jetradius ! The radius parameter for the jet algorithm
+  10  = ptj       ! Min jet transverse momentum
+  -1  = etaj      ! Max jet abs(pseudo-rap) (a value .lt.0 means no cut)
+#***********************************************************************
+# Cuts on the charged leptons (e+, e-, mu+, mu-, tau+ and tau-)        *
+# (more specific gen cuts can be specified in SubProcesses/cuts.f)     *
+#***********************************************************************
+   0  = ptl     ! Min lepton transverse momentum
+  -1  = etal    ! Max lepton abs(pseudo-rap) (a value .lt.0 means no cut)
+   0  = drll    ! Min distance between opposite sign lepton pairs
+   0  = drll_sf ! Min distance between opp. sign same-flavor lepton pairs
+   0  = mll     ! Min inv. mass of all opposite sign lepton pairs
+  30  = mll_sf  ! Min inv. mass of all opp. sign same-flavor lepton pairs
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+#***********************************************************************
+  20  = ptgmin    ! Min photon transverse momentum
+  -1  = etagamma  ! Max photon abs(pseudo-rap)
+ 0.4  = R0gamma   ! Radius of isolation code
+ 1.0  = xn        ! n parameter of eq.(3.4) in hep-ph/9801442
+ 1.0  = epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ .true.  = isoEM  ! isolate photons from EM energy (photons and leptons)
+#***********************************************************************
+# Maximal PDG code for quark to be considered a jet when applying cuts.*
+# At least all massless quarks of the model should be included here.   *
+#***********************************************************************
+ 5 = maxjetflavor
+#***********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/masspoint_gen.sh
+++ b/bin/MadGraph5_aMCatNLO/cards/13p6TeV/ggh012j_5f_NLO_FXFX_60/masspoint_gen.sh
@@ -1,0 +1,9 @@
+cd ..
+mkdir ggh012j_5f_NLO_FXFX_$1
+cp ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_customizecards.dat ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_customizecards.dat
+cp ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_extramodels.dat ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_extramodels.dat
+cp ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_proc_card.dat ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_proc_card.dat
+cp ggh012j_5f_NLO_FXFX_60/ggh012j_5f_NLO_FXFX_60_run_card.dat ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_run_card.dat
+
+sed -i 's|set param_card mass 25 60.|set param_card mass 25 '"$1"'.|g' ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_customizecards.dat
+sed -i 's|output ggh012j_5f_NLO_FXFX_60 -nojpeg|output ggh012j_5f_NLO_FXFX_'"$1"' -nojpeg|g' ggh012j_5f_NLO_FXFX_$1/ggh012j_5f_NLO_FXFX_$1_proc_card.dat


### PR DESCRIPTION
This PR is the Run 3 version of https://github.com/cms-sw/genproductions/pull/2937, in which I created Run 2 cards. The only difference is the COM energy, changed from 6500 to 6800. As a reminder, the shell script I commit takes the mass value as its argument. Typing in "./masspoint_gen.sh 50" in the command line will generate the new directory and input cards to be used.

I am happy to change naming conventions of the card directories if need be.