### PR TITLE
Add SuperChic 4.2

### DIFF
--- a/bin/Superchic/gen_fragment.py
+++ b/bin/Superchic/gen_fragment.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(ADD_PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(ADD_BEAM_ENERGY),
+                         PythiaParameters = cms.PSet(
+                                parameterSets = cms.vstring('skip_hadronization'),
+                                skip_hadronization = cms.vstring('ProcessLevel:all = off',
+                                        'Check:event = off')
+                        )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/bin/Superchic/gridpack_generation.sh
+++ b/bin/Superchic/gridpack_generation.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+
+fail_exit() { echo "$@"; exit 1; }
+
+create_setup(){
+    echo "Using scram_arch: ${SCRAM_ARCH}"
+    echo "Using cmssw_version: ${CMSSW_VERSION}"
+
+    GENDIR=${PRODDIR}/tarball_$RANDOM
+    [[ -d "${GENDIR}" ]] && rm -rf ${GENDIR}
+    mkdir -p ${GENDIR} && cd ${GENDIR}
+
+    #Set up environment and working directory 
+    export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+    source ${VO_CMS_SW_DIR}/cmsset_default.sh
+    scram project -n ${CMSSW_VERSION} CMSSW ${CMSSW_VERSION} 
+    cd ${CMSSW_VERSION} && mkdir -p work && cd work
+    eval `scram runtime -sh`
+    WORKDIR=`pwd -P`
+
+    #Copy relevant scripts and code
+    cp ${PRODDIR}/runcmsgrid_superchic.sh ${WORKDIR}/runcmsgrid.sh
+    chmod 755 ${WORKDIR}/runcmsgrid.sh
+}
+
+install_superchic(){
+    SUPERCHIC=superchic4.2
+    SCRAMREL6OR7=$("$SYSTEM_RELEASE" 2>&1 | grep -i -c -E *"release ([6-7]\.)")
+    APFEL=$([[ $SCRAMREL6OR7 -ne 0 ]] && echo APFEL_3.0.6 || echo APFEL_3.1.0)
+    cd ${WORKDIR}
+
+    echo "Downloading "${APFEL}
+    APFELDIR=${WORKDIR}/apfel_v${APFEL//[!0-9]/}
+    wget --no-verbose --no-check-certificate https://anstahll.web.cern.ch/anstahll/superchic/${APFEL}.tar.gz
+    tar -xzf ${APFEL}.tar.gz && mv apfel-${APFEL#*_} ${APFELDIR}
+    rm -f ${APFEL}.tar.gz
+
+    echo "Downloading "${SUPERCHIC}
+    SUPERCHICDIR=${WORKDIR}/superchic_v${SUPERCHIC//[!0-9]/}
+    wget --no-verbose --no-check-certificate http://cms-project-generators.web.cern.ch/cms-project-generators/superchic/${SUPERCHIC}.tar.gz
+    tar -xzf ${SUPERCHIC}.tar.gz && mv ${SUPERCHIC} ${SUPERCHICDIR}
+    rm -f ${SUPERCHIC}.tar.gz
+
+    echo "Patching "${SUPERCHIC}
+    patch -ufZs -p1 -i ${PRODDIR}/patches/superchic.patch -d ${SUPERCHICDIR}
+
+    echo "Compiling ${APFEL}"
+    cd ${APFELDIR}
+    if [[ "$SCRAMREL6OR7" -ne 0 ]]; then
+        export FFLAGS="-std=legacy -cpp" CXXFLAGS="-Wno-catch-value -Wno-register"
+        ./configure --prefix=${APFELDIR}/build --disable-pywrap
+        make -j $(nproc) && make install -j $(nproc)
+    else
+        cmake -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${APFELDIR}/build -DAPFEL_ENABLE_PYTHON=OFF -DAPFEL_ENABLE_TESTS=OFF -DCMAKE_Fortran_FLAGS="-std=legacy -cpp" -DCMAKE_CXX_FLAGS="-Wno-catch-value"
+        cmake --build BUILD --target install --parallel $(nproc)
+    fi
+    export APFEL_LIBRARY_PATH=${APFELDIR}/build/$([[ $SCRAMREL6OR7 -ne 0 ]] && echo lib || echo lib64)
+
+    echo "Compiling ${SUPERCHIC}"
+    cd ${SUPERCHICDIR}
+    make -j $(nproc)
+
+    #Set installation parameters
+    sed -i 's/SCRAM_ARCH_VERSION_REPLACE/'${SCRAM_ARCH}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/CMSSW_VERSION_REPLACE/'${CMSSW_VERSION}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/SUPERCHICDIR_REPLACE/'${SUPERCHICDIR##*/}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/APFELDIR_REPLACE/'${APFELDIR##*/}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/APFELLIB_REPLACE/'$(printf '%s\n' "${APFEL_LIBRARY_PATH##*work/}" | sed -e 's/[\/&]/\\&/g')'/g' ${WORKDIR}/runcmsgrid.sh
+}
+
+init_superchic(){
+    mkdir ${SUPERCHICDIR}/lhapdf && cd ${SUPERCHICDIR}/lhapdf
+    wget --no-verbose https://superchic.hepforge.org/SF_MSHT20qed_nnlo.tar.gz
+    tar -xzf SF_MSHT20qed_nnlo.tar.gz && rm SF_MSHT20qed_nnlo.tar.gz
+    LHAPDF_DATA_PATH=${LHAPDF_DATA_PATH}:${SUPERCHICDIR}/lhapdf
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${APFEL_LIBRARY_PATH}
+
+    cd ${SUPERCHICDIR}/bin/
+    cp ${INPUTFILE} input.DAT
+    ./init < input.DAT 2>&1 | tee init.log; test $? -eq 0 || fail_exit "superchic error: exit code not 0"
+}
+
+make_tarball(){
+    #Set tarball name
+    prefix=${INPUTFILE##*/} ; prefix=${prefix%%.*} ; prefix=${prefix#*superchic_}
+    TARBALL=superchic_${prefix}_${SCRAM_ARCH}_${CMSSW_VERSION}_tarball.tgz
+
+    echo "Creating tarball"
+    cd ${WORKDIR}
+    tar -czf ${TARBALL} ${SUPERCHICDIR##*/} ${APFELDIR##*/} runcmsgrid.sh
+    mv ${WORKDIR}/${TARBALL} ${PRODDIR}/
+    echo "Tarball created successfully at ${PRODDIR}/${TARBALL}"
+}
+
+#Set main directory
+PRODDIR=`pwd`
+if [[ ! -f "${PRODDIR}/gridpack_generation.sh" ]] ; then
+    echo "Cannot locate gridpack_generation.sh in current path"
+    exit 1
+fi
+
+#Set input file
+INPUTFILE=${1}
+if ! [[ "${INPUTFILE}" = "${PRODDIR}"* ]]; then
+    INPUTFILE=${PRODDIR}/${1}
+fi
+if [[ ! -f "${INPUTFILE}" ]]; then
+    echo "Configuration file ${INPUTFILE} is not valid"
+    exit 1
+fi
+echo "Configuration file: ${INPUTFILE}"
+
+#Set scram_arch
+if [ -n "$2" ]; then
+    SCRAM_ARCH=${2}
+else
+    # sync default cmssw with the current OS
+    export SYSTEM_RELEASE=`cat /etc/redhat-release`
+    if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+        SCRAM_ARCH=slc6_amd64_gcc700
+    elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+        SCRAM_ARCH=slc7_amd64_gcc11
+    elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
+        SCRAM_ARCH=el8_amd64_gcc11
+    elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
+        SCRAM_ARCH=el9_amd64_gcc11
+    else
+        echo "No default scram_arch for current OS"
+        exit 1
+    fi
+fi
+export SCRAM_ARCH=${SCRAM_ARCH}
+
+#Set cmssw
+if [ -n "$3" ]; then
+    CMSSW_VERSION=${3}
+else
+    if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+        CMSSW_VERSION=CMSSW_10_3_5
+    elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_16
+    elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_16
+    elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_16
+    else
+        echo "No default CMSSW for current OS"
+        exit 1
+    fi
+fi
+export CMSSW_VERSION=${CMSSW_VERSION}
+
+#Create set up
+create_setup
+
+#Install SuperChic
+install_superchic
+
+#Initialize SuperChic
+init_superchic
+
+#Create tarball
+make_tarball
+
+#Clean up
+echo "Removing "${GENDIR}
+rm -rf ${GENDIR}
+
+echo "End of job on " `date`
+exit 0

--- a/bin/Superchic/patches/superchic.patch
+++ b/bin/Superchic/patches/superchic.patch
@@ -1,0 +1,12 @@
+diff -ruN ./makefile ../superchic_v42_patch/makefile
+--- ./makefile	2023-03-08 10:57:13.000000001 +0100
++++ ../superchic_v42_patch/makefile	2023-12-06 23:36:57.000000001 +0100
+@@ -1,7 +1,7 @@
+ LIBFLAGlha = -lLHAPDF
+ LIBFLAGapfel = -lAPFEL -lAPFELevol
+ LHAPDFLIB = `lhapdf-config --prefix`/lib
+-APFELLIB = `apfel-config --prefix`/lib
++APFELLIB = ${APFEL_LIBRARY_PATH}
+ FC = gfortran -g -w -Wall -fbacktrace -fcheck=all -fPIC -ffixed-line-length-132
+ 
+ #####################

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_LbyL.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_LbyL.dat
@@ -1,0 +1,161 @@
+****************************************************************************************
+******  RE-RUN ./init IF FIRST FIVE PARAMETERS ARE CHANGED (and beam = 'prot'):  *******
+****************************************************************************************
+5.36d3           !  [rts] : CMS collision energy (GeV)
+4	       !  [isurv] : Model of soft survival (from 1 -> 4, corresponding to arXiv:1306.2149)
+'in13'         !  [intag] for input files 
+****************************************************************************************
+****************************************************************************************
+'MSHT20qed_nnlo'   ! [PDFname] : PDF set
+0                    ! [PDFmember] : PDF member
+****************************************************************************************
+59      !  [proc] : Process number (see manual for labelling)
+'ion'  ! [beam] : Beam type ('prot', 'ion', 'ionp' or 'el')
+'test'          ! [outtg]
+.true.  !  [sfaci] : Include soft survival effects
+****************************************************************************************
+************************* Dissociation parameters for PI  ******************************
+****************************************************************************************
+'el'    !  [diff] : elastic ('el'), single ('sd','sda','sdb') and double ('dd') dissociation. NB - modes other than 'el' only available for PI lepton pair production!
+****************************************************************************************
+208d0   !  [an] : Ion mass number
+82d0    !  [az] : Ion atomic number
+6.68d0  !  [rz] : Ion proton density - radius
+0.447d0 !  [dz] : Ion proton density - skin thickness
+6.7d0 	!  [rn] : Ion neutron density - radius
+0.55d0  !  [dn] : Ion neutron density - skin thickness
+'coh'   !  [ionqcd] : Coherent ('coh') or incoherent ('incoh') for QCD-induced (ion-ion) processes
+.false.  ! [ionbreakup] : set to .true. if include ion breakup, false if inclusive
+'00'    ! [fAA] : if ionbreakup=.true. then specifies breakup type
+1d0     ! [fracsigX] : multiply sig_(gamA) by this factor (1d0 - default)
+****************************************************************************************
+************************* Integration parameters ***************************************
+****************************************************************************************
+10000       ! [ncall] : Number of calls for preconditioning
+10          ! [itmx] : Number of iterations for preconditioning
+1d0          ! [prec]
+10000       ! [ncall1] : Number of calls in first iteration
+10000       ! [inccall] : Number of increase calls per iteration
+1000        ! [itend] : Maximum number of iterations
+6           ! [iseed] : Random number seed (integer > 0)
+****************************************************************************************
+******************************* Unweighted events **************************************
+****************************************************************************************
+.false.       ! [genunw] : Generate unweighted events
+10           ! [nev] : Number of events ( < 1000000 recommended)
+'lhe'	     ! [erec] : Event record format ('hepmc','lhe','hepevt')
+.false.	     ! [readwt] : Set to true to read in pre-calculated maxium weight below
+0d0          ! [wtmax] : Maximum weight
+****************************************************************************************
+*******************************   general cuts    **************************************
+****************************************************************************************
+-8.0d0          ! [ymin]
+8.0d0          ! [ymax]
+2d0          ! [mmin]
+202d0          ! [mmax]
+.false.        ! [gencuts] : Generate cuts below
+.true.        ! [scorr] : Include spin correlations
+.true.	      ! [fwidth] : Include finite width 
+****************************************************************************************
+************************ See manual for momentum assignments ***************************
+****************************************************************************************
+*********************************** Proton Cuts  ***************************************
+****************************************************************************************
+10d0     ! [ptxmax]
+****************************************************************************************
+************************* 2 body final states : p(a) + p(b) ****************************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+-10d0       ! [etaamin]
+10d0        ! [etaamax]
+-10d0       ! [etabmin]
+10d0        ! [etabmax]
+10d0        ! [acoabmax]
+****************************************************************************************
+********************** 3 body final states : p(a) + p(b) + p(c) ************************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+****************************************************************************************
+****************** 4 body final states : p(a) + p(b) + p(c)+ p(d) **********************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+0d0         ! [ptdmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+-2.5d1      ! [etadmin]
+2.5d1       ! [etadmax]
+****************************************************************************************
+*********** 6 body final states : p(a) + p(b) + p(c)+ p(d) + p(e) + p(f) ***************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+0d0         ! [ptdmin]
+0d0         ! [ptemin]
+0d0         ! [ptfmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+-2.5d1      ! [etadmin]
+2.5d1       ! [etadmax]
+-2.5d1      ! [etaemin]
+2.5d1       ! [etaemax]
+-2.5d1      ! [etafmin]
+2.5d1       ! [etafmax]
+****************************************************************************************
+*******   Jet algorithm parameters
+****************************************************************************************
+0.6d0      ! [rjet] : Jet Radius
+'antikt'   ! [jalg] : Jet algorithm ('antikt','kt')
+****************************************************************************************
+******  chi_c/b two-body decays
+****************************************************************************************
+0.133d0	     ! [m2b] : mass of decay particles
+211          ! [pdgid1] : PDG number particle 1
+-211         ! [pdgid2] : PDG number particle 2
+****************************************************************************************
+****** ALP parameters
+****************************************************************************************
+5d-2        ! [malp] : ALP mass (GeV)
+1d-4        ! [gax] : ALP coupling (GeV^-1)
+'ps'        ! [alpt] : AlP type (scalar - 'sc', pseudoscalar - 'ps')
+****************************************************************************************
+******  Monopole parameters
+****************************************************************************************
+500d0        ! [mpol] : Monopole mass
+933d0        ! [mmon] : Monopolium mass
+10d0         ! [gamm] : Monopolium width
+****************************************************************************************
+******  SUSY parameters
+****************************************************************************************
+100d0   ! [mcharg] : Chargino/Slepton mass
+80d0    ! [mneut]  : Neutralino mass
+****************************************************************************************
+******  W+W- decays
+****************************************************************************************
+'mu'    ! [wlp] : W+ leptonic channel (mu or el)
+'el'    ! [wlm] : W- leptoinc channel (mu or el)
+****************************************************************************************
+******  V+X simplified model
+****************************************************************************************
+0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
+100d0    ! [mxs] : mass of MX
+****************************************************************************************

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_chiC.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_chiC.dat
@@ -1,0 +1,161 @@
+****************************************************************************************
+******  RE-RUN ./init IF FIRST FIVE PARAMETERS ARE CHANGED (and beam = 'prot'):  *******
+****************************************************************************************
+5.36d3           !  [rts] : CMS collision energy (GeV)
+4	       !  [isurv] : Model of soft survival (from 1 -> 4, corresponding to arXiv:1306.2149)
+'in13'         !  [intag] for input files 
+****************************************************************************************
+****************************************************************************************
+'MSHT20qed_nnlo'   ! [PDFname] : PDF set
+0                    ! [PDFmember] : PDF member
+****************************************************************************************
+22      !  [proc] : Process number (see manual for labelling)
+'ion'  ! [beam] : Beam type ('prot', 'ion', 'ionp' or 'el')
+'test'          ! [outtg]
+.false.  !  [sfaci] : Include soft survival effects
+****************************************************************************************
+************************* Dissociation parameters for PI  ******************************
+****************************************************************************************
+'el'    !  [diff] : elastic ('el'), single ('sd','sda','sdb') and double ('dd') dissociation. NB - modes other than 'el' only available for PI lepton pair production!
+****************************************************************************************
+208d0   !  [an] : Ion mass number
+82d0    !  [az] : Ion atomic number
+6.68d0  !  [rz] : Ion proton density - radius
+0.447d0 !  [dz] : Ion proton density - skin thickness
+6.7d0 	!  [rn] : Ion neutron density - radius
+0.55d0  !  [dn] : Ion neutron density - skin thickness
+'coh'   !  [ionqcd] : Coherent ('coh') or incoherent ('incoh') for QCD-induced (ion-ion) processes
+.false.  ! [ionbreakup] : set to .true. if include ion breakup, false if inclusive
+'00'    ! [fAA] : if ionbreakup=.true. then specifies breakup type
+1d0     ! [fracsigX] : multiply sig_(gamA) by this factor (1d0 - default)
+****************************************************************************************
+************************* Integration parameters ***************************************
+****************************************************************************************
+10000       ! [ncall] : Number of calls for preconditioning
+10          ! [itmx] : Number of iterations for preconditioning
+1d0          ! [prec]
+10000       ! [ncall1] : Number of calls in first iteration
+10000       ! [inccall] : Number of increase calls per iteration
+1000        ! [itend] : Maximum number of iterations
+6           ! [iseed] : Random number seed (integer > 0)
+****************************************************************************************
+******************************* Unweighted events **************************************
+****************************************************************************************
+.false.       ! [genunw] : Generate unweighted events
+10           ! [nev] : Number of events ( < 1000000 recommended)
+'lhe'	     ! [erec] : Event record format ('hepmc','lhe','hepevt')
+.false.	     ! [readwt] : Set to true to read in pre-calculated maxium weight below
+0d0          ! [wtmax] : Maximum weight
+****************************************************************************************
+*******************************   general cuts    **************************************
+****************************************************************************************
+-3.0d0          ! [ymin]
+3.0d0          ! [ymax]
+2d0          ! [mmin]
+90d0          ! [mmax]
+.true.        ! [gencuts] : Generate cuts below
+.true.        ! [scorr] : Include spin correlations
+.true.	      ! [fwidth] : Include finite width 
+****************************************************************************************
+************************ See manual for momentum assignments ***************************
+****************************************************************************************
+*********************************** Proton Cuts  ***************************************
+****************************************************************************************
+10d0     ! [ptxmax]
+****************************************************************************************
+************************* 2 body final states : p(a) + p(b) ****************************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+2.5d1       ! [acoabmax]
+****************************************************************************************
+********************** 3 body final states : p(a) + p(b) + p(c) ************************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+-2.5d0      ! [etaamin]
+2.5d0       ! [etaamax]
+-2.5d0      ! [etabmin]
+2.5d0       ! [etabmax]
+-2.5d0      ! [etacmin]
+2.5d0       ! [etacmax]
+****************************************************************************************
+****************** 4 body final states : p(a) + p(b) + p(c)+ p(d) **********************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+0d0         ! [ptdmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+-2.5d1      ! [etadmin]
+2.5d1       ! [etadmax]
+****************************************************************************************
+*********** 6 body final states : p(a) + p(b) + p(c)+ p(d) + p(e) + p(f) ***************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+0d0         ! [ptdmin]
+0d0         ! [ptemin]
+0d0         ! [ptfmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+-2.5d1      ! [etadmin]
+2.5d1       ! [etadmax]
+-2.5d1      ! [etaemin]
+2.5d1       ! [etaemax]
+-2.5d1      ! [etafmin]
+2.5d1       ! [etafmax]
+****************************************************************************************
+*******   Jet algorithm parameters
+****************************************************************************************
+0.6d0      ! [rjet] : Jet Radius
+'antikt'   ! [jalg] : Jet algorithm ('antikt','kt')
+****************************************************************************************
+******  chi_c/b two-body decays
+****************************************************************************************
+0.133d0	     ! [m2b] : mass of decay particles
+211          ! [pdgid1] : PDG number particle 1
+-211         ! [pdgid2] : PDG number particle 2
+****************************************************************************************
+****** ALP parameters
+****************************************************************************************
+5d-2        ! [malp] : ALP mass (GeV)
+1d-4        ! [gax] : ALP coupling (GeV^-1)
+'ps'        ! [alpt] : AlP type (scalar - 'sc', pseudoscalar - 'ps')
+****************************************************************************************
+******  Monopole parameters
+****************************************************************************************
+500d0        ! [mpol] : Monopole mass
+933d0        ! [mmon] : Monopolium mass
+10d0         ! [gamm] : Monopolium width
+****************************************************************************************
+******  SUSY parameters
+****************************************************************************************
+100d0   ! [mcharg] : Chargino/Slepton mass
+80d0    ! [mneut]  : Neutralino mass
+****************************************************************************************
+******  W+W- decays
+****************************************************************************************
+'mu'    ! [wlp] : W+ leptonic channel (mu or el)
+'el'    ! [wlm] : W- leptoinc channel (mu or el)
+****************************************************************************************
+******  V+X simplified model
+****************************************************************************************
+0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
+100d0    ! [mxs] : mass of MX
+****************************************************************************************

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_dimuon.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_dimuon.dat
@@ -1,0 +1,161 @@
+****************************************************************************************
+******  RE-RUN ./init IF FIRST FIVE PARAMETERS ARE CHANGED (and beam = 'prot'):  *******
+****************************************************************************************
+5.36d3           !  [rts] : CMS collision energy (GeV)
+4	       !  [isurv] : Model of soft survival (from 1 -> 4, corresponding to arXiv:1306.2149)
+'in13'         !  [intag] for input files 
+****************************************************************************************
+****************************************************************************************
+'MSHT20qed_nnlo'   ! [PDFname] : PDF set
+0                    ! [PDFmember] : PDF member
+****************************************************************************************
+57      !  [proc] : Process number (see manual for labelling)
+'ion'  ! [beam] : Beam type ('prot', 'ion', 'ionp' or 'el')
+'test'          ! [outtg]
+.false.  !  [sfaci] : Include soft survival effects
+****************************************************************************************
+************************* Dissociation parameters for PI  ******************************
+****************************************************************************************
+'el'    !  [diff] : elastic ('el'), single ('sd','sda','sdb') and double ('dd') dissociation. NB - modes other than 'el' only available for PI lepton pair production!
+****************************************************************************************
+208d0   !  [an] : Ion mass number
+82d0    !  [az] : Ion atomic number
+6.68d0  !  [rz] : Ion proton density - radius
+0.447d0 !  [dz] : Ion proton density - skin thickness
+6.7d0 	!  [rn] : Ion neutron density - radius
+0.55d0  !  [dn] : Ion neutron density - skin thickness
+'coh'   !  [ionqcd] : Coherent ('coh') or incoherent ('incoh') for QCD-induced (ion-ion) processes
+.false.  ! [ionbreakup] : set to .true. if include ion breakup, false if inclusive
+'00'    ! [fAA] : if ionbreakup=.true. then specifies breakup type
+1d0     ! [fracsigX] : multiply sig_(gamA) by this factor (1d0 - default)
+****************************************************************************************
+************************* Integration parameters ***************************************
+****************************************************************************************
+10000       ! [ncall] : Number of calls for preconditioning
+10          ! [itmx] : Number of iterations for preconditioning
+1d0          ! [prec]
+10000       ! [ncall1] : Number of calls in first iteration
+10000       ! [inccall] : Number of increase calls per iteration
+1000        ! [itend] : Maximum number of iterations
+6           ! [iseed] : Random number seed (integer > 0)
+****************************************************************************************
+******************************* Unweighted events **************************************
+****************************************************************************************
+.false.       ! [genunw] : Generate unweighted events
+10           ! [nev] : Number of events ( < 1000000 recommended)
+'lhe'	     ! [erec] : Event record format ('hepmc','lhe','hepevt')
+.false.	     ! [readwt] : Set to true to read in pre-calculated maxium weight below
+0d0          ! [wtmax] : Maximum weight
+****************************************************************************************
+*******************************   general cuts    **************************************
+****************************************************************************************
+-2.5d0          ! [ymin]
+2.5d0          ! [ymax]
+2d0          ! [mmin]
+90d0          ! [mmax]
+.false.        ! [gencuts] : Generate cuts below
+.true.        ! [scorr] : Include spin correlations
+.true.	      ! [fwidth] : Include finite width 
+****************************************************************************************
+************************ See manual for momentum assignments ***************************
+****************************************************************************************
+*********************************** Proton Cuts  ***************************************
+****************************************************************************************
+2d0     ! [ptxmax]
+****************************************************************************************
+************************* 2 body final states : p(a) + p(b) ****************************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+-2.5d0       ! [etaamin]
+2.5d0        ! [etaamax]
+-2.5d0       ! [etabmin]
+2.5d0        ! [etabmax]
+1d10        ! [acoabmax]
+****************************************************************************************
+********************** 3 body final states : p(a) + p(b) + p(c) ************************
+****************************************************************************************
+3d0         ! [ptamin]
+3d0         ! [ptbmin]
+3d0         ! [ptcmin]
+-2.5d0      ! [etaamin]
+2.5d0       ! [etaamax]
+-2.5d0      ! [etabmin]
+2.5d0       ! [etabmax]
+-2.5d0      ! [etacmin]
+2.5d0       ! [etacmax]
+****************************************************************************************
+****************** 4 body final states : p(a) + p(b) + p(c)+ p(d) **********************
+****************************************************************************************
+2d0         ! [ptamin]
+2d0         ! [ptbmin]
+2d0         ! [ptcmin]
+2d0         ! [ptdmin]
+-2.5d0      ! [etaamin]
+2.5d0       ! [etaamax]
+-2.5d0      ! [etabmin]
+2.5d0       ! [etabmax]
+-2.5d0      ! [etacmin]
+2.5d0       ! [etacmax]
+-2.5d0      ! [etadmin]
+2.5d0       ! [etadmax]
+****************************************************************************************
+*********** 6 body final states : p(a) + p(b) + p(c)+ p(d) + p(e) + p(f) ***************
+****************************************************************************************
+0d0         ! [ptamin]
+0d0         ! [ptbmin]
+0d0         ! [ptcmin]
+0d0         ! [ptdmin]
+0d0         ! [ptemin]
+0d0         ! [ptfmin]
+-2.5d1      ! [etaamin]
+2.5d1       ! [etaamax]
+-2.5d1      ! [etabmin]
+2.5d1       ! [etabmax]
+-2.5d1      ! [etacmin]
+2.5d1       ! [etacmax]
+-2.5d1      ! [etadmin]
+2.5d1       ! [etadmax]
+-2.5d1      ! [etaemin]
+2.5d1       ! [etaemax]
+-2.5d1      ! [etafmin]
+2.5d1       ! [etafmax]
+****************************************************************************************
+*******   Jet algorithm parameters
+****************************************************************************************
+0.6d0      ! [rjet] : Jet Radius
+'antikt'   ! [jalg] : Jet algorithm ('antikt','kt')
+****************************************************************************************
+******  chi_c/b two-body decays
+****************************************************************************************
+0.133d0	     ! [m2b] : mass of decay particles
+211          ! [pdgid1] : PDG number particle 1
+-211         ! [pdgid2] : PDG number particle 2
+****************************************************************************************
+****** ALP parameters
+****************************************************************************************
+1200d0        ! [malp] : ALP mass (GeV)
+4d-4        ! [gax] : ALP coupling (GeV^-1)
+'ps'        ! [alpt] : AlP type (scalar - 'sc', pseudoscalar - 'ps')
+****************************************************************************************
+******  Monopole parameters
+****************************************************************************************
+500d0        ! [mpol] : Monopole mass
+933d0        ! [mmon] : Monopolium mass
+10d0         ! [gamm] : Monopolium width
+****************************************************************************************
+******  SUSY parameters
+****************************************************************************************
+100d0   ! [mcharg] : Chargino/Slepton mass
+80d0    ! [mneut]  : Neutralino mass
+****************************************************************************************
+******  W+W- decays
+****************************************************************************************
+'mu'    ! [wlp] : W+ leptonic channel (mu or el)
+'el'    ! [wlm] : W- leptoinc channel (mu or el)
+****************************************************************************************
+******  V+X simplified model
+****************************************************************************************
+0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
+100d0    ! [mxs] : mass of MX
+****************************************************************************************

--- a/bin/Superchic/run_generic_tarball_cvmfs.sh
+++ b/bin/Superchic/run_generic_tarball_cvmfs.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+#script to run generic lhe generation tarballs
+#kept as simply as possible to minimize need
+#to update the cmssw release
+#(all the logic goes in the run script inside the tarball
+# on frontier)
+#J.Bendavid
+
+#exit on first error
+set -e
+
+echo "   ______________________________________     "
+echo "         Running Generic Tarball/Gridpack     "
+echo "   ______________________________________     "
+
+path=${1}
+echo "gridpack tarball path = $path"
+
+nevt=${2}
+echo "%MSG-MG5 number of events requested = $nevt"
+
+rnum=${3}
+echo "%MSG-MG5 random seed used for the run = $rnum"
+
+ncpu=${4}
+echo "%MSG-MG5 thread count requested = $ncpu"
+
+echo "%MSG-MG5 residual/optional arguments = ${@:5}"
+
+if [ -n "${5}" ]; then
+  use_gridpack_env=${5}
+  echo "%MSG-MG5 use_gridpack_env = $use_gridpack_env"
+fi
+
+if [ -n "${6}" ]; then
+  scram_arch_version=${6}
+  echo "%MSG-MG5 override scram_arch_version = $scram_arch_version"
+fi
+
+if [ -n "${7}" ]; then
+  cmssw_version=${7}
+  echo "%MSG-MG5 override cmssw_version = $cmssw_version"
+fi
+
+LHEWORKDIR=`pwd`
+
+if [ "$use_gridpack_env" = false -a -n "$scram_arch_version" -a -n  "$cmssw_version" ]; then
+  echo "%MSG-MG5 CMSSW version = $cmssw_version"
+  export SCRAM_ARCH=${scram_arch_version}
+  scramv1 project CMSSW ${cmssw_version}
+  cd ${cmssw_version}/src
+  eval `scramv1 runtime -sh`
+  cd $LHEWORKDIR
+fi
+
+if [[ -d lheevent ]]
+    then
+    echo 'lheevent directory found'
+    echo 'Setting up the environment'
+    rm -rf lheevent
+fi
+mkdir lheevent; cd lheevent
+
+#untar the tarball directly from cvmfs
+if [[ ! -f "${path}" ]]; then
+    path=${LHEWORKDIR}/${path##*/}
+fi
+tar -xaf ${path} 
+
+# If TMPDIR is unset, set it to the condor scratch area if present
+# and fallback to /tmp
+export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
+
+#generate events
+./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+
+mv cmsgrid_final.lhe $LHEWORKDIR/
+
+cd $LHEWORKDIR
+
+#cleanup working directory (save space on worker node for edm output)
+rm -rf lheevent
+
+exit 0

--- a/bin/Superchic/runcmsgrid_superchic.sh
+++ b/bin/Superchic/runcmsgrid_superchic.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+fail_exit() { echo "$@"; exit 1; }
+
+set_superchic_config(){
+    cp ${CONFIG} ${CONFIG}.orig
+    sed -i "/^\*/! s/.*\[out.*/\'out\'  \!  \[outtg\] for input files/" ${CONFIG}
+    sed -i "/^\*/! s/.*\[iseed\].*/${rnum}  \! \[iseed\] : Random number seed/" ${CONFIG}
+    sed -i "/^\*/! s/.*\[genunw\].*/\.true\.  \! [genunw] : Generate unweighted events/" ${CONFIG}
+    sed -i "/^\*/! s/.*\[nev\].*/${nevt}  \! \[nev\] : Number of events/" ${CONFIG}
+    sed -i "/^\*/! s/.*\[erec\].*/\'lhe\'  \! [erec] : Event record format/" ${CONFIG}
+}
+
+run_superchic(){
+    echo "*** STARTING SUPERCHIC PRODUCTION ***"
+    LHAPDF_DATA_PATH=${LHAPDF_DATA_PATH}:${LHEWORKDIR}/${SUPERCHICDIR}/lhapdf
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LHEWORKDIR}/${APFELLIB}
+    cd ${LHEWORKDIR}/${SUPERCHICDIR}/bin
+    ./superchic < input.DAT 2>&1 | tee input.log; test $? -eq 0 || fail_exit "superchic error: exit code not 0"
+    mv evrecs/evrecout.dat out.lhe
+    sed -i '/.*<LesHouchesEvents.*/,/.*<\/header>.*/d' out.lhe
+    sed -i '1 i\<LesHouchesEvents version="3.0">\n<!--\nProduced using SUPERCHIC generator\n-->' out.lhe
+    sed -i '/SUPERCHIC/a '${APFELDIR} out.lhe
+    sed -i '/SUPERCHIC/a '${SUPERCHICDIR} out.lhe
+    sed -i 's/--/- -/' ${CONFIG}
+    sed -i '/SUPERCHIC/r'${CONFIG} out.lhe
+    mv out.lhe ${LHEWORKDIR}/cmsgrid_final.lhe
+    echo "***SUPERCHIC COMPLETE***"
+}
+
+echo "   ______________________________________     "
+echo "         Running SuperChic                    "
+echo "   ______________________________________     "
+
+nevt=${1}
+echo "%MSG-SUPERCHIC number of events requested = $nevt"
+
+rnum=${2}
+echo "%MSG-SUPERCHIC random seed used for the run = $rnum"
+
+ncpu=${3}
+echo "%MSG-SUPERCHIC number of cputs for the run = $ncpu"
+
+LHEWORKDIR=`pwd -P`
+
+use_gridpack_env=true
+if [ "$4" = false ]; then
+    use_gridpack_env=$4
+fi
+
+if [ "$use_gridpack_env" = true ]; then
+    if [[ "$5" == *[_]* ]]; then
+        scram_arch_version=${5}
+    else
+        scram_arch_version=SCRAM_ARCH_VERSION_REPLACE
+    fi
+    echo "%MSG-SUPERCHIC SCRAM_ARCH version = $scram_arch_version"
+
+    if [[ "$6" == CMSSW_* ]]; then
+        cmssw_version=${6}
+    else
+        cmssw_version=CMSSW_VERSION_REPLACE
+    fi
+    echo "%MSG-SUPERCHIC CMSSW version = $cmssw_version"
+
+    export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+    source $VO_CMS_SW_DIR/cmsset_default.sh
+
+    # Make a directory that doesn't overlap
+    if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
+        cd ${CMSSW_BASE}/..
+        TPD=${PWD}/lhe1t2m3p
+        [[ ! -d "${TPD}" ]] && mkdir ${TPD}
+        cd ${TPD}
+        echo "Changed to: "${TPD}
+    fi
+
+    eval `scramv1 unsetenv -sh`
+    export SCRAM_ARCH=${scram_arch_version}
+    scramv1 project CMSSW ${cmssw_version}
+    cd ${cmssw_version}/src
+    eval `scramv1 runtime -sh`
+fi
+
+cd $LHEWORKDIR
+
+APFELDIR=APFELDIR_REPLACE
+APFELLIB=APFELLIB_REPLACE
+SUPERCHICDIR=SUPERCHICDIR_REPLACE
+CONFIG=${LHEWORKDIR}/${SUPERCHICDIR}/bin/input.DAT
+
+#Set SuperChic settings
+set_superchic_config
+
+#Run SuperChic generator
+run_superchic
+
+#Perform test
+xmllint --stream --noout ${LHEWORKDIR}/cmsgrid_final.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on cmsgrid_final.lhe"
+
+#Clean up
+[[ -d "${TPD}" ]] && rm -rf ${TPD}
+
+echo "Output ready with cmsgrid_final.lhe at $LHEWORKDIR"
+echo "End of job on "`date`
+exit 0


### PR DESCRIPTION
This PR adds the setup to run vmLHE production using the [SuperChic](https://superchic.hepforge.org/) 4.2 generator, used to simulate photon-photon and photon-nucleus interactions in ultra-peripheral heavy-ion collisions.

The setup was tested locally using 3 input cards (light-by-light, QED dimuon and ChiC production, included in this PR) for scram arch releases el7, el8 and el9.