### PR TITLE
Revision for VBF H (disable QCD) -- SUS HtoAAto2Mu2Tau

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_customizecards.dat
@@ -1,3 +1,3 @@
 set param_card mass 25 125
 set param_card mass 36 10
-      
+set param_card DECAY 36 2.495587e-04

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
@@ -1,5 +1,5 @@
 import model NMSSMHET --modelname
 
-generate p p  > h01 j j $$ W+ W- Z, (h01 > a01 a01, a01 > tau+ tau-, a01 > mu+ mu-)
+generate p p  > h01 j j $$ W+ W- Z  QCD=0, (h01 > a01 a01, a01 > tau+ tau-, a01 > mu+ mu-)
 
 output SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
@@ -1,5 +1,5 @@
 import model NMSSMHET --modelname
 
-generate p p  > h01 j j $$ W+ W- Z  QCD=0, (h01 > a01 a01, a01 > tau+ tau-, a01 > mu+ mu-)
+generate p p > h01 j j $$ Z W- W+ h01 / a  HIG=0 QCD=0 , (h01 > a01 a01, a01 > tau+ tau- , a01 > mu+ mu-)
 
 output SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/HToAATo2Mu2Tau/SUSY_VBFH_HToAATo2Mu2Tau/VBFH_M125_ToAA_M10/SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau_proc_card.dat
@@ -1,5 +1,5 @@
 import model NMSSMHET --modelname
 
-generate p p > h01 j j $$ Z W- W+ h01 / a  HIG=0 QCD=0 , (h01 > a01 a01, a01 > tau+ tau- , a01 > mu+ mu-)
+generate p p > h01 j j $$ Z W- W+ / a  HIG=0 QCD=0 , (h01 > a01 a01, a01 > tau+ tau- , a01 > mu+ mu-)
 
 output SUSY_VBFH_M125_ToAA_M10_To2Mu2Tau -nojpeg


### PR DESCRIPTION
Following up the pull request "#3625", I double checked and updated the VBFH proc card. QCD is disabled. The diagrams with offshell BSM particles are anomalous gauge boson couplings that are allowed by the NMSSM model.