### PR TITLE
Fix for generic X->YH->HHH cards for Run 3

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/NMSSM_XToYH_YToHH/getAllMassPoints_YH_YToHH.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/NMSSM_XToYH_YToHH/getAllMassPoints_YH_YToHH.py
@@ -20,7 +20,7 @@ Y_mass = [50, 60, 70, 80, 90, 95, 100, 125, 150, 170, 200, 250, 300, 350, 400, 4
 
 
 def is_mass_ok(m_x,m_y):
-    return m_y < (m_x-125.)
+    return m_y >= 250. and m_y < (m_x-125.)
 
 Ngridpacks=0
 for X_m in X_mass:


### PR DESCRIPTION
This is a follow-up to https://github.com/cms-sw/genproductions/pull/3646 which had an incomplete requirement on m_Y in the card generation script (m_Y >= 2*m_H requirement was missing).