### PR TITLE
Update SuperChic to v5.1

### DIFF
--- a/bin/Starlight/runcmsgrid_starlight.sh
+++ b/bin/Starlight/runcmsgrid_starlight.sh
@@ -120,7 +120,7 @@ if [ "$use_gridpack_env" = true ]; then
     # Make a directory that doesn't overlap
     if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
         cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p
+        TPD=${PWD}/lhe1t2m3p$RANDOM
         [[ ! -d "${TPD}" ]] && mkdir ${TPD}
         cd ${TPD}
         echo "Changed to: "${TPD}

--- a/bin/Superchic/gen_fragment.py
+++ b/bin/Superchic/gen_fragment.py
@@ -18,7 +18,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         exclusive_process = cms.vstring(
-            # Recomendation from SuperChic v5.0
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
             'PartonLevel:ISR = off',
             'PartonLevel:MPI = off',
             'PartonLevel:Remnants = off',

--- a/bin/Superchic/gen_fragment_semiexclusive.py
+++ b/bin/Superchic/gen_fragment_semiexclusive.py
@@ -18,7 +18,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         exclusive_process = cms.vstring(
-            # Recomendation from https://superchic.hepforge.org/superchic4.pdf
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
             # For photon–initiated lepton pair production
             'Check:event = off',
             'PDF:pSet = LHAPDF6:MSHT20qed nnlo',

--- a/bin/Superchic/gridpack_generation.sh
+++ b/bin/Superchic/gridpack_generation.sh
@@ -24,31 +24,19 @@ create_setup(){
 }
 
 install_superchic(){
-    SUPERCHIC=SuperChic-v.5.0
-    APFEL=APFEL_3.1.0
+    SUPERCHIC=SuperChic-5.1
     cd ${WORKDIR}
-
-    echo "Downloading "${APFEL}
-    APFELDIR=${WORKDIR}/apfel_v${APFEL//[!0-9]/}
-    wget --no-verbose --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/superchic/${APFEL}.tar.gz
-    tar -xzf ${APFEL}.tar.gz && mv apfel-${APFEL#*_} ${APFELDIR}
-    rm -f ${APFEL}.tar.gz
 
     echo "Downloading "${SUPERCHIC}
     SUPERCHICDIR=${WORKDIR}/superchic_v${SUPERCHIC//[!0-9]/}
-    wget --no-verbose --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/superchic/${SUPERCHIC}.tar.gz
+    wget --no-verbose --no-check-certificate https://anstahll.web.cern.ch/anstahll/superchic/${SUPERCHIC}.tar.gz
     tar -xzf ${SUPERCHIC}.tar.gz && mv ${SUPERCHIC} ${SUPERCHICDIR}
     rm -f ${SUPERCHIC}.tar.gz
 
-    echo "Compiling ${APFEL}"
-    cd ${APFELDIR}
-    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
-    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${APFELDIR}/build -DAPFEL_ENABLE_PYTHON=OFF -DAPFEL_ENABLE_TESTS=OFF -DCMAKE_Fortran_FLAGS="-std=legacy -cpp" -DCMAKE_CXX_FLAGS="-Wno-catch-value"
-    ${CMAKE} --build BUILD --target install --parallel $(nproc)
-
     echo "Compiling ${SUPERCHIC}"
     cd ${SUPERCHICDIR}
-    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${SUPERCHICDIR}/build -DAPFEL_DIR=${APFELDIR}/build -DLHAPDF_DIR=$(scram tool tag lhapdf LHAPDF_BASE) -DSUPERCHIC_ENABLE_TESTS=OFF -DSUPERCHIC_ENABLE_FPES=OFF -DSUPERCHIC_ENABLE_DOCS=OFF -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_Fortran_FLAGS="-O2 -g -ffree-line-length-512 -Wno-unused-label -Wno-integer-division -Wno-conversion -Wno-function-elimination"
+    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
+    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${SUPERCHICDIR}/build -DLHAPDF_DIR=$(scram tool tag lhapdf LHAPDF_BASE) -DSUPERCHIC_ENABLE_TESTS=OFF -DSUPERCHIC_ENABLE_FPES=OFF -DSUPERCHIC_ENABLE_DOCS=OFF -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_Fortran_FLAGS="-O2 -g -ffree-line-length-512 -Wno-unused-label -Wno-integer-division -Wno-conversion -Wno-function-elimination"
     ${CMAKE} --build BUILD --target install --parallel $(nproc)
 
     echo "Compiling macros"
@@ -60,7 +48,6 @@ install_superchic(){
     sed -i 's/SCRAM_ARCH_VERSION_REPLACE/'${SCRAM_ARCH}'/g' ${WORKDIR}/runcmsgrid.sh
     sed -i 's/CMSSW_VERSION_REPLACE/'${CMSSW_VERSION}'/g' ${WORKDIR}/runcmsgrid.sh
     sed -i 's/SUPERCHICDIR_REPLACE/'${SUPERCHICDIR##*/}'/g' ${WORKDIR}/runcmsgrid.sh
-    sed -i 's/APFELDIR_REPLACE/'${APFELDIR##*/}'/g' ${WORKDIR}/runcmsgrid.sh
 }
 
 init_superchic(){
@@ -68,7 +55,6 @@ init_superchic(){
     wget --no-verbose https://superchic.hepforge.org/SF_MSHT20qed_nnlo.tar.gz
     tar -xzf SF_MSHT20qed_nnlo.tar.gz && rm SF_MSHT20qed_nnlo.tar.gz
     LHAPDF_DATA_PATH=${LHAPDF_DATA_PATH}:${SUPERCHICDIR}/lhapdf
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${APFELDIR}/build/lib64
 
     cd ${SUPERCHICDIR}/build/bin/
     cp ${INPUTFILE} input.DAT
@@ -82,7 +68,7 @@ make_tarball(){
 
     echo "Creating tarball"
     cd ${WORKDIR}
-    tar -czf ${TARBALL} ${SUPERCHICDIR##*/} ${APFELDIR##*/} macros runcmsgrid.sh
+    tar -czf ${TARBALL} ${SUPERCHICDIR##*/} macros runcmsgrid.sh
     mv ${WORKDIR}/${TARBALL} ${PRODDIR}/
     echo "Tarball created successfully at ${PRODDIR}/${TARBALL}"
 }

--- a/bin/Superchic/runcmsgrid_superchic.sh
+++ b/bin/Superchic/runcmsgrid_superchic.sh
@@ -14,12 +14,10 @@ set_superchic_config(){
 run_superchic(){
     echo "*** STARTING SUPERCHIC PRODUCTION ***"
     LHAPDF_DATA_PATH=${LHAPDF_DATA_PATH}:${LHEWORKDIR}/${SUPERCHICDIR}/lhapdf
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LHEWORKDIR}/${APFELDIR}/build/lib64
     export SUPERCHIC_DATA_PATH=${LHEWORKDIR}/${SUPERCHICDIR}/build/share/SuperChic
     cd ${LHEWORKDIR}/${SUPERCHICDIR}/build/bin
     ./superchic < input.DAT 2>&1 | tee input.log; test ${PIPESTATUS[0]} -eq 0 || fail_exit "superchic error: exit code not 0"
     ${LHEWORKDIR}/macros/convert_SCLHE2LHE evrecs/evrecout.dat 2>&1 | tee upcgen.log; test ${PIPESTATUS[0]} -eq 0 || fail_exit "convert_SCLHE2LHE error: exit code not 0"
-    sed -i '/SUPERCHIC/a '${APFELDIR} evrecout_proc.lhe
     sed -i '/SUPERCHIC/a '${SUPERCHICDIR} evrecout_proc.lhe
     sed -i 's/--/- -/' ${CONFIG}
     sed -i '/SUPERCHIC/r'${CONFIG} evrecout_proc.lhe
@@ -68,7 +66,7 @@ if [ "$use_gridpack_env" = true ]; then
     # Make a directory that doesn't overlap
     if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
         cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p
+        TPD=${PWD}/lhe1t2m3p$RANDOM
         [[ ! -d "${TPD}" ]] && mkdir ${TPD}
         cd ${TPD}
         echo "Changed to: "${TPD}
@@ -83,7 +81,6 @@ fi
 
 cd $LHEWORKDIR
 
-APFELDIR=APFELDIR_REPLACE
 SUPERCHICDIR=SUPERCHICDIR_REPLACE
 CONFIG=${LHEWORKDIR}/${SUPERCHICDIR}/build/bin/input.DAT
 

--- a/bin/UPCgen/runcmsgrid_upcgen.sh
+++ b/bin/UPCgen/runcmsgrid_upcgen.sh
@@ -67,7 +67,7 @@ if [ "$use_gridpack_env" = true ]; then
     # Make a directory that doesn't overlap
     if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
         cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p
+        TPD=${PWD}/lhe1t2m3p$RANDOM
         [[ ! -d "${TPD}" ]] && mkdir ${TPD}
         cd ${TPD}
         echo "Changed to: "${TPD}


### PR DESCRIPTION
This PR updates the SuperChic generator to version 5.1, released recently in the SuperChic [github](https://github.com/LucianHL/SuperChic/tags) repository. In addition, it also makes a minor change to the tmp directory used to run the CMSSW directory during production.

It was tested on SL7, SL8 and SL9 releases using CMSSW_13_0_X (used for HIN MC).

The source file will need to be copied from: https://anstahll.web.cern.ch/anstahll/superchic/SuperChic-5.1.tar.gz   to:  
https://cms-project-generators.web.cern.ch/cms-project-generators/superchic/
and once this is done, I will update the website path from my personal website to the cms-project-generators website.