### PR TITLE
Synchronise the POWHEG PbPb cards to central gridpack templates

### DIFF
--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_10_50.input
@@ -35,6 +35,19 @@ iseed    SEED    ! initialize random number sequence
 mass_low 10      ! M Z > mass_low in GeV
 mass_high 50     ! M Z < mass_high in GeV	 
 
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information
 withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_10_50.input
@@ -14,17 +14,17 @@ lhans2 904400     ! pdf set for hadron 2 (LHA numbering)
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1 100000   ! number of calls for initializing the integration grid
-itmx1    5     ! number of iterations for initializing the integration grid
-ncall2 100000   ! number of calls for computing the integral and finding upper bound
-itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
-nubound 20000  ! number of bbarra calls to setup norm of upper bounding function
-icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
-iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
-xupbound 2d0   ! increase upper bound for radiation generation
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_50.input
@@ -34,6 +34,19 @@ testplots  1     ! (default 0, do not) do NLO and PWHG distributions
 iseed    SEED    ! initialize random number sequence 
 mass_low 50      ! M Z > mass_low in GeV
 
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information
 withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_50.input
@@ -14,17 +14,17 @@ lhans2 904400     ! pdf set for hadron 2 (LHA numbering)
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1 100000   ! number of calls for initializing the integration grid
-itmx1    5     ! number of iterations for initializing the integration grid
-ncall2 100000   ! number of calls for computing the integral and finding upper bound
-itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
-nubound 20000  ! number of bbarra calls to setup norm of upper bounding function
-icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
-iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
-xupbound 2d0   ! increase upper bound for radiation generation
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 
@@ -32,8 +32,7 @@ renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 testplots  1     ! (default 0, do not) do NLO and PWHG distributions
 iseed    SEED    ! initialize random number sequence 
-mass_low 50       ! M Z > mass_low in GeV
-	 
+mass_low 50      ! M Z > mass_low in GeV
 
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_10_50.input
@@ -35,6 +35,19 @@ iseed    SEED    ! initialize random number sequence
 mass_low 10      ! M Z > mass_low in GeV
 mass_high 50     ! M Z < mass_high in GeV	 
 
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information
 withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_10_50.input
@@ -14,17 +14,17 @@ lhans2 904400     ! pdf set for hadron 2 (LHA numbering)
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1 100000   ! number of calls for initializing the integration grid
-itmx1    5     ! number of iterations for initializing the integration grid
-ncall2 100000   ! number of calls for computing the integral and finding upper bound
-itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
-nubound 20000  ! number of bbarra calls to setup norm of upper bounding function
-icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
-iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
-xupbound 2d0   ! increase upper bound for radiation generation
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_50.input
@@ -34,6 +34,19 @@ testplots  1     ! (default 0, do not) do NLO and PWHG distributions
 iseed    SEED    ! initialize random number sequence 
 mass_low 50      ! M Z > mass_low in GeV
 
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information
 withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_50.input
@@ -14,17 +14,17 @@ lhans2 904400     ! pdf set for hadron 2 (LHA numbering)
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1 100000   ! number of calls for initializing the integration grid
-itmx1    5     ! number of iterations for initializing the integration grid
-ncall2 100000   ! number of calls for computing the integral and finding upper bound
-itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
-nubound 20000  ! number of bbarra calls to setup norm of upper bounding function
-icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
-iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
-xupbound 2d0   ! increase upper bound for radiation generation
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 
@@ -32,8 +32,7 @@ renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 testplots  1     ! (default 0, do not) do NLO and PWHG distributions
 iseed    SEED    ! initialize random number sequence 
-mass_low 50       ! M Z > mass_low in GeV
-	 
+mass_low 50      ! M Z > mass_low in GeV
 
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampDOWN_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampDOWN_EPPS21_NNLO_inclusive.input
@@ -49,14 +49,14 @@ tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
 
-ncall1 10000   ! number of calls for initializing the integration grid
+ncall1 50000   ! number of calls for initializing the integration grid
 itmx1 5        ! number of iterations for initializing the integration grid
-ncall2 100000  ! number of calls for computing the integral and finding upper bound
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
 itmx2 5        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1      ! number of folds on x integration
 foldy   1      ! number of folds on y integration
 foldphi 1      ! number of folds on phi integration
-nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
 iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
 
 xupbound 2      ! increase upper bound for radiation generation

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampDOWN_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampDOWN_EPPS21_NNLO_inclusive.input
@@ -11,7 +11,7 @@ lhans1 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 lhans2 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ebeam1 2681d0  ! energy of beam 1
 ebeam2 2681d0  ! energy of beam 2
-qmass  172.5     ! mass of heavy quark in GeV
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
 facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
 renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
 
@@ -35,6 +35,7 @@ topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, represent
 tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
 tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
@@ -45,6 +46,10 @@ tdec/umass   0.100 !
 tdec/smass   0.200 ! 
 tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 ! Parameters to allow-disallow use of stored data
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampUP_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampUP_EPPS21_NNLO_inclusive.input
@@ -49,14 +49,14 @@ tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
 
-ncall1 10000   ! number of calls for initializing the integration grid
+ncall1 50000   ! number of calls for initializing the integration grid
 itmx1 5        ! number of iterations for initializing the integration grid
-ncall2 100000  ! number of calls for computing the integral and finding upper bound
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
 itmx2 5        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1      ! number of folds on x integration
 foldy   1      ! number of folds on y integration
 foldphi 1      ! number of folds on phi integration
-nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
 iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
 
 xupbound 2      ! increase upper bound for radiation generation

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampUP_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdampUP_EPPS21_NNLO_inclusive.input
@@ -11,7 +11,7 @@ lhans1 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 lhans2 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ebeam1 2681d0  ! energy of beam 1
 ebeam2 2681d0  ! energy of beam 2
-qmass  172.5     ! mass of heavy quark in GeV
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
 facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
 renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
 
@@ -35,6 +35,7 @@ topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, represent
 tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
 tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
@@ -45,6 +46,10 @@ tdec/umass   0.100 !
 tdec/smass   0.200 ! 
 tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 ! Parameters to allow-disallow use of stored data
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_EPPS21_NNLO_inclusive.input
@@ -49,14 +49,14 @@ tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
 
-ncall1 10000   ! number of calls for initializing the integration grid
+ncall1 50000   ! number of calls for initializing the integration grid
 itmx1 5        ! number of iterations for initializing the integration grid
-ncall2 100000  ! number of calls for computing the integral and finding upper bound
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
 itmx2 5        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1      ! number of folds on x integration
 foldy   1      ! number of folds on y integration
 foldphi 1      ! number of folds on phi integration
-nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
 iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
 
 xupbound 2      ! increase upper bound for radiation generation

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_EPPS21_NNLO_inclusive.input
@@ -11,7 +11,7 @@ lhans1 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 lhans2 904400  ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ebeam1 2681d0  ! energy of beam 1
 ebeam2 2681d0  ! energy of beam 2
-qmass  172.5     ! mass of heavy quark in GeV
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
 facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
 renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
 
@@ -35,6 +35,7 @@ topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, represent
 tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
 tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
@@ -45,6 +46,10 @@ tdec/umass   0.100 !
 tdec/smass   0.200 ! 
 tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 ! Parameters to allow-disallow use of stored data
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop166p5_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop166p5_EPPS21_NNLO_inclusive.input
@@ -35,6 +35,7 @@ topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, represent
 tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/twidth  1.173 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
 tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
@@ -45,6 +46,10 @@ tdec/umass   0.100 !
 tdec/smass   0.200 ! 
 tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 ! Parameters to allow-disallow use of stored data
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop166p5_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop166p5_EPPS21_NNLO_inclusive.input
@@ -49,14 +49,14 @@ tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
 
-ncall1 10000   ! number of calls for initializing the integration grid
+ncall1 50000   ! number of calls for initializing the integration grid
 itmx1 5        ! number of iterations for initializing the integration grid
-ncall2 100000  ! number of calls for computing the integral and finding upper bound
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
 itmx2 5        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1      ! number of folds on x integration
 foldy   1      ! number of folds on y integration
 foldphi 1      ! number of folds on phi integration
-nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
 iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
 
 xupbound 2      ! increase upper bound for radiation generation

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop178p5_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop178p5_EPPS21_NNLO_inclusive.input
@@ -35,6 +35,7 @@ topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, represent
 tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 tdec/twidth  1.498 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
 tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
 tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
@@ -45,6 +46,10 @@ tdec/umass   0.100 !
 tdec/smass   0.200 ! 
 tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 ! Parameters to allow-disallow use of stored data
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop178p5_EPPS21_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_mtop178p5_EPPS21_NNLO_inclusive.input
@@ -49,14 +49,14 @@ tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.
 use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
 use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
 
-ncall1 10000   ! number of calls for initializing the integration grid
+ncall1 50000   ! number of calls for initializing the integration grid
 itmx1 5        ! number of iterations for initializing the integration grid
-ncall2 100000  ! number of calls for computing the integral and finding upper bound
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
 itmx2 5        ! number of iterations for computing the integral and finding upper bound
 foldcsi   1      ! number of folds on x integration
 foldy   1      ! number of folds on y integration
 foldphi 1      ! number of folds on phi integration
-nubound 100000  ! number of bbarra calls to setup norm of upper bounding function
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
 iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
 
 xupbound 2      ! increase upper bound for radiation generation

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WWTo2L2Nu/WWTo2L2Nu_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WWTo2L2Nu/WWTo2L2Nu_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ leptonic 1
 renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WWTo2L2Nu/WWTo2L2Nu_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WWTo2L2Nu/WWTo2L2Nu_EPPS21_5p36TeV.input
@@ -13,14 +13,17 @@ lhans2   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1  400000   ! number of calls for initializing the integration grid
-itmx1    5       ! number of iterations for initializing the integration grid
-ncall2   1000000     ! number of calls for computing the integral and finding upper bound
-itmx2    5  ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1     ! number of folds on  y  integration
-foldphi   1      ! number of folds on phi integration
-nubound  1000000    ! number of bbarra calls to setup norm of upper bounding function
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 leptonic 1

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WWToLNu2Q/WWToLNu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WWToLNu2Q/WWToLNu2Q_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ semileptonic 1
 renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WWToLNu2Q/WWToLNu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WWToLNu2Q/WWToLNu2Q_EPPS21_5p36TeV.input
@@ -1,14 +1,14 @@
-! WZ boson production parameters
-mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+! WW boson production parameters
 
-numevts NEVENTS
+
+numevts NEVENTS    ! number of events to be generated
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 2681d0     ! energy of beam 1
 ebeam2 2681d0     ! energy of beam 2
 ! To be set only if using LHA pdfs
-lhans1   904400   ! nPDF: EPPS21nlo_CT18Anlo_Pb208
-lhans2   904400   ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+lhans1   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+lhans2   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
@@ -26,13 +26,13 @@ iymax    1        ! <= 100, number of y subdivision when computing the upper bou
 xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
-lll 1
+semileptonic 1
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
-renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
-facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
 
-iseed SEED
-
-pdfreweight 0
+pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0
-withnegweights 1 
+withnegweights 1
+

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo2L2Q/WZTo2L2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo2L2Q/WZTo2L2Q_EPPS21_5p36TeV.input
@@ -26,7 +26,7 @@ iymax    1        ! <= 100, number of y subdivision when computing the upper bou
 xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
-lll 1
+hll 1
 
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo2L2Q/WZTo2L2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo2L2Q/WZTo2L2Q_EPPS21_5p36TeV.input
@@ -31,6 +31,11 @@ hll 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed SEED
 
 pdfreweight 0

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo3lNu/WZTo3lNu_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo3lNu/WZTo3lNu_EPPS21_5p36TeV.input
@@ -31,6 +31,11 @@ lll 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed SEED
 
 pdfreweight 0

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WZToLNu2Q/WZToLNu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WZToLNu2Q/WZToLNu2Q_EPPS21_5p36TeV.input
@@ -26,7 +26,7 @@ iymax    1        ! <= 100, number of y subdivision when computing the upper bou
 xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
-lll 1
+lhh 1
 
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/WZToLNu2Q/WZToLNu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/WZToLNu2Q/WZToLNu2Q_EPPS21_5p36TeV.input
@@ -31,6 +31,11 @@ lhh 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed SEED
 
 pdfreweight 0

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_EPPS21_5p36TeV.input
@@ -13,14 +13,17 @@ lhans2   904400   ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1   1000000   ! number of calls for initializing the integration grid
-itmx1    4        ! number of iterations for initializing the integration grid
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
 ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
 itmx2    5        ! number of iterations for computing the integral and finding upper bound
-foldcsi   2       ! number of folds on csi integration
-foldy     5       ! number of folds on  y  integration
-foldphi   2       ! number of folds on phi integration
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
 nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 leptons-nu 1

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ leptons-nu 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Q/ZZ_2L2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Q/ZZ_2L2Q_EPPS21_5p36TeV.input
@@ -1,7 +1,7 @@
-! WZ boson production parameters
+! ZZ boson production parameters
 mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
 
-numevts NEVENTS
+numevts NEVENTS   ! number of events to be generated
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 2681d0     ! energy of beam 1
@@ -15,7 +15,7 @@ use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 rege
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 ncall1   1000000  ! number of calls for initializing the integration grid
 itmx1    5        ! number of iterations for initializing the integration grid
-ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
 itmx2    5        ! number of iterations for computing the integral and finding upper bound
 foldcsi  2        ! number of folds on csi integration
 foldy    5        ! number of folds on  y  integration
@@ -26,13 +26,12 @@ iymax    1        ! <= 100, number of y subdivision when computing the upper bou
 xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
-lll 1
-
+semileptonic 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
-iseed SEED
+iseed    SEED    ! initialize random number sequence 
 
-pdfreweight 0
+pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0
-withnegweights 1 
+withnegweights 1

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Q/ZZ_2L2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Q/ZZ_2L2Q_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ semileptonic 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ hadrons-nu 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_EPPS21_5p36TeV.input
@@ -1,7 +1,7 @@
-! WZ boson production parameters
+! ZZ boson production parameters
 mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
 
-numevts NEVENTS
+numevts NEVENTS   ! number of events to be generated
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 2681d0     ! energy of beam 1
@@ -15,7 +15,7 @@ use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 rege
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 ncall1   1000000  ! number of calls for initializing the integration grid
 itmx1    5        ! number of iterations for initializing the integration grid
-ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
 itmx2    5        ! number of iterations for computing the integral and finding upper bound
 foldcsi  2        ! number of folds on csi integration
 foldy    5        ! number of folds on  y  integration
@@ -26,13 +26,12 @@ iymax    1        ! <= 100, number of y subdivision when computing the upper bou
 xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
-lll 1
-
+hadrons-nu 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
-iseed SEED
+iseed    SEED    ! initialize random number sequence 
 
-pdfreweight 0
+pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0
-withnegweights 1 
+withnegweights 1

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo4L/ZZ_4L_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo4L/ZZ_4L_EPPS21_5p36TeV.input
@@ -30,6 +30,11 @@ leptonic 1
 renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
 facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
 
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
 iseed    SEED    ! initialize random number sequence 
 
 pdfreweight 0       ! PDF reweighting

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo4L/ZZ_4L_EPPS21_5p36TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo4L/ZZ_4L_EPPS21_5p36TeV.input
@@ -13,14 +13,17 @@ lhans2   904400   ! nPDF: EPPS21nlo_CT18Anlo_Pb208
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
-ncall1   1000000   ! number of calls for initializing the integration grid
-itmx1    4        ! number of iterations for initializing the integration grid
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
 ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
 itmx2    5        ! number of iterations for computing the integral and finding upper bound
-foldcsi   2       ! number of folds on csi integration
-foldy     5       ! number of folds on  y  integration
-foldphi   2       ! number of folds on phi integration
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
 nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
 
 ! OPTIONAL PARAMETERS
 leptonic 1

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
@@ -22,10 +22,12 @@ ncall1 50000   ! number of calls for initializing the integration grid
 itmx1    5     ! number of iterations for initializing the integration grid
 ncall2 50000   ! number of calls for computing the integral and finding upper bound
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
 foldphi   1    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
 xupbound 2d0   ! increase upper bound for radiation generation
 
 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
@@ -32,7 +32,7 @@ xupbound 2d0   ! increase upper bound for radiation generation
 
 
 withdamp       1
-hdamp  237.8775
+hdamp 237.8775
 
 
 ! mandatory production parameters
@@ -54,6 +54,20 @@ topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (p
 wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 
 
 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
@@ -54,6 +54,20 @@ topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (p
 wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
 alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
 
 
 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
@@ -22,10 +22,12 @@ ncall1 50000   ! number of calls for initializing the integration grid
 itmx1    5     ! number of iterations for initializing the integration grid
 ncall2 50000   ! number of calls for computing the integral and finding upper bound
 itmx2    5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
 foldphi   1    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
 xupbound 2d0   ! increase upper bound for radiation generation
 
 


### PR DESCRIPTION
This PR synchronize the settings (i.e. ncall, itmx, fold, icsimax, iymax and xupbound) of each POWHEG PbPb card to those in the central gridpack POWHEG templates specified in: https://github.com/cms-PdmV/GridpackFiles/tree/master/Campaigns/Run3Summer23/Powheg/Templates for the Run3Summer23 campaign according to each POWHEG-BOX process. The main change is an increase in the values of these parameters. Moreover, the cards also use the same model parameters as [Run3Summer23 central gridpacks](https://github.com/cms-PdmV/GridpackFiles/tree/master/Campaigns/Run3Summer23/Powheg/ModelParams) with their values updated to 2023 PDG.

In addition, this PR also adds 5 new POWHEG cards for PbPb corresponding to the processes: WWToLNu2Q, WZTo2L2Q, WZToLNu2Q, ZZTo2L2Q and ZZTo2Nu2Q

@DickyChant @sihyunjeon 