### PR TITLE
Use CMSSW area in working directory in Starlight, UPCgen and SuperChic gridpack script

### DIFF
--- a/bin/Starlight/gridpack_generation.sh
+++ b/bin/Starlight/gridpack_generation.sh
@@ -131,11 +131,11 @@ else
     if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
         CMSSW_VERSION=CMSSW_10_3_5
     elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18_HeavyIon
     elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     else
         echo "No default CMSSW for current OS"
         exit 1

--- a/bin/Starlight/runcmsgrid_starlight.sh
+++ b/bin/Starlight/runcmsgrid_starlight.sh
@@ -117,15 +117,6 @@ if [ "$use_gridpack_env" = true ]; then
     export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     source $VO_CMS_SW_DIR/cmsset_default.sh
 
-    # Make a directory that doesn't overlap
-    if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
-        cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p$RANDOM
-        [[ ! -d "${TPD}" ]] && mkdir ${TPD}
-        cd ${TPD}
-        echo "Changed to: "${TPD}
-    fi
-
     eval `scramv1 unsetenv -sh`
     export SCRAM_ARCH=${scram_arch_version}
     scramv1 project CMSSW ${cmssw_version}
@@ -159,9 +150,6 @@ run_starlight
 
 #Perform test
 xmllint --stream --noout ${LHEWORKDIR}/cmsgrid_final.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on cmsgrid_final.lhe"
-
-#Clean up
-[[ -d "${TPD}" ]] && rm -rf ${TPD}
 
 echo "Output ready with cmsgrid_final.lhe at $LHEWORKDIR"
 echo "End of job on "`date`

--- a/bin/Superchic/gridpack_generation.sh
+++ b/bin/Superchic/gridpack_generation.sh
@@ -116,11 +116,11 @@ else
     if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
         CMSSW_VERSION=CMSSW_10_3_5
     elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18_HeavyIon
     elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     else
         echo "No default CMSSW for current OS"
         exit 1

--- a/bin/Superchic/runcmsgrid_superchic.sh
+++ b/bin/Superchic/runcmsgrid_superchic.sh
@@ -63,15 +63,6 @@ if [ "$use_gridpack_env" = true ]; then
     export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     source $VO_CMS_SW_DIR/cmsset_default.sh
 
-    # Make a directory that doesn't overlap
-    if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
-        cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p$RANDOM
-        [[ ! -d "${TPD}" ]] && mkdir ${TPD}
-        cd ${TPD}
-        echo "Changed to: "${TPD}
-    fi
-
     eval `scramv1 unsetenv -sh`
     export SCRAM_ARCH=${scram_arch_version}
     scramv1 project CMSSW ${cmssw_version}
@@ -92,9 +83,6 @@ run_superchic
 
 #Perform test
 xmllint --stream --noout ${LHEWORKDIR}/cmsgrid_final.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on cmsgrid_final.lhe"
-
-#Clean up
-[[ -d "${TPD}" ]] && rm -rf ${TPD}
 
 echo "Output ready with cmsgrid_final.lhe at $LHEWORKDIR"
 echo "End of job on "`date`

--- a/bin/UPCgen/gridpack_generation.sh
+++ b/bin/UPCgen/gridpack_generation.sh
@@ -125,11 +125,11 @@ else
     if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
         CMSSW_VERSION=CMSSW_10_3_5
     elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18_HeavyIon
     elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
-        CMSSW_VERSION=CMSSW_13_0_17
+        CMSSW_VERSION=CMSSW_13_0_18
     else
         echo "No default CMSSW for current OS"
         exit 1

--- a/bin/UPCgen/runcmsgrid_upcgen.sh
+++ b/bin/UPCgen/runcmsgrid_upcgen.sh
@@ -64,15 +64,6 @@ if [ "$use_gridpack_env" = true ]; then
     export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
     source $VO_CMS_SW_DIR/cmsset_default.sh
 
-    # Make a directory that doesn't overlap
-    if [[ -d "${CMSSW_BASE}" ]] && [[ "${LHEWORKDIR}" = "${CMSSW_BASE}"/* ]]; then
-        cd ${CMSSW_BASE}/..
-        TPD=${PWD}/lhe1t2m3p$RANDOM
-        [[ ! -d "${TPD}" ]] && mkdir ${TPD}
-        cd ${TPD}
-        echo "Changed to: "${TPD}
-    fi
-
     eval `scramv1 unsetenv -sh`
     export SCRAM_ARCH=${scram_arch_version}
     scramv1 project CMSSW ${cmssw_version}
@@ -93,9 +84,6 @@ run_upcgen
 
 #Perform test
 xmllint --stream --noout ${LHEWORKDIR}/cmsgrid_final.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on cmsgrid_final.lhe"
-
-#Clean up
-[[ -d "${TPD}" ]] && rm -rf ${TPD}
 
 echo "Output ready with cmsgrid_final.lhe at $LHEWORKDIR"
 echo "End of job on "`date`


### PR DESCRIPTION
This PR updates the gridpack bash script of the Starlight, UPCgen and SuperChic generators to avoid creating a temporary directory and use instead the working directory when creating the CMSSW area. In addition, this PR also updates the default CMSSW release.