### PR TITLE
to make Phantom v1.3 runnable in slc7

### DIFF
--- a/bin/Phantom/cards/examples/phantomProduction_slc7_example.cfg
+++ b/bin/Phantom/cards/examples/phantomProduction_slc7_example.cfg
@@ -1,0 +1,205 @@
+# ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ---- #
+#                                                                                        #
+#           template cfg file for the usage of the phantom generator in CMS              #
+#                                                                                        #
+# see https://twiki.cern.ch/twiki/bin/view/CMS/PhantomGeneratorCMS for more details      #
+#                                                                                        #
+# ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ----  ---- ---- #
+
+
+[general]
+# where the zipped version of the compiled phantom code can be found
+# and where the gridpacks will be created
+
+# CMSSW environment for the gridpack creation
+# this is NOT necessarily the one used in the detector simulation and reconstruction,
+# it just sets the environment for the phantom running
+# CMSSW = CMSSW_9_2_11
+CMSSW = CMSSW_10_6_19
+
+# phantom version to be used
+#package = /afs/cern.ch/cms/generators/www/phantom/compiled/phantom_1_6_slc7_amd64_gcc700.tar.gz
+package = /afs/cern.ch/user/c/choij/public/phantom_1_3_p1_slc7_amd64_gcc700.tar.gz
+# this page should give a reasonable association between architecture and CMSSW release:
+# https://cmssdt.cern.ch/SDT/cgi-bin/ReleasesXML?anytype=1
+# ARCH = slc6_amd64_gcc530
+ARCH = slc7_amd64_gcc700
+
+# phantom r.in file to be used (provided in the genproduction github)
+# this is expected to be found in the same folder from where the submission script
+# is launched.
+# If not found, the one in the phantom release is used
+# template = template_phantom_1_2_8_nc1_lowopt_r.in
+
+# folder name containing the gridpack, the gridpack name will be
+# foldername.tgz
+foldername = gridpackTesting_SS_CMSSW_10_6_19
+
+
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+
+[submission]
+# parameters for the job submission 
+# (for the time being with LSF oron LXPLUS, CONDOR being tested)
+scheduler = CONDOR
+queue     = workday
+
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+
+[generation]
+# what generation has to be done, with which configuration parameters
+# production channel, the list of leptons is expected
+channel            = mu e vm_ ve_
+# channel            = mu e_ vm_ ve
+
+# number of top/antitop quarks required in the
+# final state. If the option is not set any number of
+# tops is accepted. If the option is of the form
+# n+ with n an integer any reaction with at least
+# n tops are accepted.
+# -1 means no restrictions
+topnumber          = -1
+
+
+# This option excludes processes with external gluon legs from the Phantom generation.
+# Set to 0 to keep the external gluons for QCD processes, set 1 to disable them. 
+excludegluons = 0
+
+# ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+
+[parameters]
+# parameters for the phantom config file
+# parameters in this cfg file will be replaced in the phantom cfg template.
+
+# NECESSARY PARAMETER
+# the full list of available pdf is found in the folder stored 
+# in the $LHAPDF_DATA_PATH environment variable of the CMSSW release setup
+# working with LHAPDF6 only
+# PDFname        = NNPDF30_nnlo_as_0118
+PDFname        = NNPDF31_nnlo_hessian_pdfas
+
+# CALCULATION TYPE
+# = 1 alpha_em^6 with dedicated amp
+# = 2 alpha_s^2alpha_em^4
+# = 3 alpha_em^6 + alpha_s^2alpha_em^4
+# = 0 alpha_em^6 with amp8fqcd (for test only)
+perturbativeorder = 1
+
+# Higgs boson mass, GeV
+rmh            = 125
+# Higgs boson width, GeV
+# from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+gamh           = 0.004088
+# squared Higgs couplings modifier, expected less than 1
+ghfactor       = 1
+
+# leptons minimum energy, GeV
+e_min_lep      = 20.d0
+
+# leptons minimum pT, GeV
+pt_min_lep     = 20.d0
+
+# leptons maximum rapidity
+eta_max_lep    = 4d0
+
+# minimum ptMiss, GeV
+ptmiss_min     = 20.d0
+
+# minimum jet energy, GeV
+e_min_j        = 20.d0
+
+# minimum jet pT, GeV.
+# This number should be kept larger than zero, 
+# to avoid divergences when the tag jet gets produced along the beam direction
+pt_min_j       = 20.d0
+
+# maximum jet eta
+eta_max_j      = 6.5d0
+
+# minimum invariant mass between jets
+# This number should be kept larger than zero, 
+# to avoid divergences when the tag jet gets produced along the beam direction
+rm_min_jj      = 30.d0
+
+# minimum invariant mass between oppositely charged leptons, GeV.
+# This number should be kept away from zero all times, to avoid divergences
+# in the calculation. While Phantom well behaves down to 2 GeV,
+# the lower the cut the slower is the production, since the cross-section
+# needs to be calculated for very low m(ll), therefore, if not needed,
+# it's recommended to keep this cut high
+rm_min_ll      = 4
+
+# SCALE CHOICE
+# = 1  for all processes, based on pT's of ALL OUTGOING PARTICLES
+# = 2  process by process, based on pT of the (RECONSTRUCTED) TOP
+#      if possible, otherwise as done in option 1
+# = 3  Q a fixed numerical scale given in this file
+# = 4  Q = m4l/sqrt(2)  (invariant mass of the 4 leptons)/sqrt(2) 
+#      (valid only for processes with four outgoing leptons)
+i_PDFscale     = 4
+
+# FIXED SCALE VALUE
+# in case of option 3 above, this is the value of the fixed scale
+fixed_PDFscale = 125
+
+# CENTRE-OF-MASS energy (in GeV)
+ecoll = 13000
+
+# WHETHER TO GENERATE SIGNAL ONLY (not gauge-invariant)
+i_signal = 0 
+#  = 0 full computation 
+#  > 0 Higgs signal only 
+#    (only for i_pertorder = 1, alpha_em^6 and i_unitarize = 0)
+#  = 1 s channel contributions to boson boson scattering (boson boson-> Higgs -> boson boson)
+#  = 2 all contributions (s+t+u channels) to boson boson scattering 
+#  = 3 all contributions (s+t+u channels) to boson boson scattering and Higgstrahlung with H -> boson boson
+
+# if this is 1, the singlet model of arXiv:1303.1150 is simulated,
+# with the parameters here below
+i_singlet = 0
+
+# mass of the heavier higgs
+rmhh = 600.d0
+
+# parameter cos alfa of arXiv:1303.1150
+rcosa = 0.9
+
+# parameter  tg beta of arXiv:1303.1150
+tgbeta = 2.d0
+
+# heavier Higgs width (GeV)
+# <0 means computed by phantom
+# in this last case SM gamh is multiplied
+# by (1-rcosa**2) + decay of heavy higgs 
+#     to 2 light ones: hh-> h+h 
+gamhh = -12
+
+# HEAVY HIGGS NOT IN THE SINGLET CONTEST (for test only)
+# yes/no singlet implementation 
+i_hh = 0
+
+# from now on parameters regarding a second heavier higgs scalar
+# hh stays for heavy higgs. 
+  
+# heavier higgs mass (GeV) (not singlet)
+rmhh_ns = 500.d0
+
+# factor for second higgs, 
+# which multiplies SM higgs
+# couplings 
+# if ghhfactor is negative, ghhfactor=sqrt(1-ghfactor**2)  
+ghhfactor = -1.d0
+
+# heavier Higgs width (GeV) (not singlet)
+# <0 means computed by phantom
+# in this last case SM gamh is multiplied
+# by ghhfactor**2 
+gamhh_ns = -41.62d0
+
+# cut on the invariant mass of all triplets of
+# particles who could form a top
+# to avoid top contributions
+# The corresponding deltacuttop fixes the
+# interval excluded : topmas +- deltatacuttop
+i_deltacuttop = 1
+deltacuttop = 10.d0


### PR DESCRIPTION
Made submit_phantom.py runnable in slc7. Also attached example configuration to generate a gridpack.
Major changes:
- LSF job submission depreciated.
- While running condor jobs, managed unfinished jobs to be countable in the local script.
- Changed environment setup to be applicable to condor setups.