### PR TITLE
Add genfragments for STARlight, SuperChic and UPCgen

### DIFF
--- a/bin/Starlight/genfragments/gen_fragment.py
+++ b/bin/Starlight/genfragments/gen_fragment.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring(),
+    args = cms.vstring(PATH_TO_TARBALL),
     nEvents = cms.untracked.uint32(1),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),
@@ -16,7 +16,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         ),
         parameterSets = cms.vstring('skip_hadronization')
     ),
-    comEnergy = cms.double(5362.0),
+    comEnergy = cms.double(BEAM_ENERGY),
     filterEfficiency = cms.untracked.double(1.0),
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/bin/Starlight/genfragments/gen_fragment_Tauola.py
+++ b/bin/Starlight/genfragments/gen_fragment_Tauola.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring(),
+    args = cms.vstring(PATH_TO_TARBALL),
     nEvents = cms.untracked.uint32(1),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),
@@ -9,30 +9,28 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
-        exclusive_process = cms.vstring(
-            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
-            # For purely elastic production (diff set to el)
-            'PartonLevel:ISR = off',
-            'PartonLevel:MPI = off',
-            'PartonLevel:Remnants = off',
-            'Check:event = off',
-            'LesHouches:matchInOut = off',
-            'SpaceShower:pTmaxMatch = 2',
-            'SpaceShower:pTdampMatch = 1',
-            'BeamRemnants:primordialKT = off',
-            'BeamRemnants:unresolvedHadron = 3'
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
         ),
-        parameterSets = cms.vstring('pythia8CommonSettings','pythia8CP5Settings','pythia8PSweightsSettings','exclusive_process')
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','skip_hadronization')
     ),
-    comEnergy = cms.double(5362.0),
+    comEnergy = cms.double(BEAM_ENERGY),
     filterEfficiency = cms.untracked.double(1.0),
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/bin/Superchic/genfragments/gen_fragment.py
+++ b/bin/Superchic/genfragments/gen_fragment.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring(),
+    args = cms.vstring(PATH_TO_TARBALL),
     nEvents = cms.untracked.uint32(1),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),
@@ -9,31 +9,28 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
 from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
-        pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
-        semiexclusive_process = cms.vstring(
+        exclusive_process = cms.vstring(
             # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
-            # For semi–exclusive photon–initiated production (diff set to sda, sdb, dd)
-            'Check:event = off',
-            'PDF:pSet = LHAPDF6:MSHT20qed nnlo',
-            'LesHouches:matchInOut = off',
-            'BeamRemnants:primordialKT = off',
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
             'PartonLevel:MPI = off',
-            'SpaceShower:dipoleRecoil = on',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
             'SpaceShower:pTmaxMatch = 2',
-            'SpaceShower:QEDshowerByQ = off',
             'SpaceShower:pTdampMatch = 1',
-            'BeamRemnants:unresolvedHadron = 0' #diff= dd: 0, sdb: 1, sda: 2, el: 3
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
         ),
-        parameterSets = cms.vstring('pythia8CommonSettings','pythia8CP5Settings','pythia8PSweightsSettings','semiexclusive_process')
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
     ),
-    comEnergy = cms.double(5362.0),
+    comEnergy = cms.double(BEAM_ENERGY),
     filterEfficiency = cms.untracked.double(1.0),
     maxEventsToPrint = cms.untracked.int32(1),
     pythiaHepMCVerbosity = cms.untracked.bool(False),

--- a/bin/Superchic/genfragments/gen_fragment_Tauola.py
+++ b/bin/Superchic/genfragments/gen_fragment_Tauola.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        exclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
+            'PartonLevel:MPI = off',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
+    ),
+    comEnergy = cms.double(BEAM_ENERGY),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/bin/Superchic/genfragments/gen_fragment_semiexclusive.py
+++ b/bin/Superchic/genfragments/gen_fragment_semiexclusive.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        semiexclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For semi–exclusive photon–initiated production (diff set to sda, sdb, dd)
+            'Check:event = off',
+            'PDF:pSet = LHAPDF6:MSHT20qed nnlo',
+            'LesHouches:matchInOut = off',
+            'BeamRemnants:primordialKT = off',
+            'PartonLevel:MPI = off',
+            'SpaceShower:dipoleRecoil = on',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:QEDshowerByQ = off',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:unresolvedHadron = 0' #diff= dd: 0, sdb: 1, sda: 2, el: 3
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','semiexclusive_process')
+    ),
+    comEnergy = cms.double(BEAM_ENERGY),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/bin/UPCgen/genfragments/gen_fragment.py
+++ b/bin/UPCgen/genfragments/gen_fragment.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(BEAM_ENERGY),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/bin/UPCgen/genfragments/gen_fragment_Tauola.py
+++ b/bin/UPCgen/genfragments/gen_fragment_Tauola.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','skip_hadronization')
+    ),
+    comEnergy = cms.double(BEAM_ENERGY),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_elec-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_elec-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_dielectron_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_dielectron.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+elelgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.0, 3.0),
+    MinEta = cms.untracked.vdouble(-3.0, -3.0),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(11),
+    ParticleID2 = cms.untracked.vint32(11)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*elelgenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_muon-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_muon-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_dimuon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_dimuon.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_tau-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_QED_tau-fragment.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_ditau_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_ditau.in
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_jpsi_diel-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_jpsi_diel-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_coherent_jpsi_dielectron_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_jpsi_dielectron.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+elelgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.0, 3.0),
+    MinEta = cms.untracked.vdouble(-3.0, -3.0),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(11),
+    ParticleID2 = cms.untracked.vint32(11)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*elelgenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_jpsi_dimu-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_jpsi_dimu-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_coherent_jpsi_dimuon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_jpsi_dimuon.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_phi_dika-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_phi_dika-fragment.py
@@ -26,15 +26,4 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
     pythiaPylistVerbosity = cms.untracked.int32(1)
 )
 
-kkgenfilter = cms.EDFilter("MCParticlePairFilter",
-    Status = cms.untracked.vint32(1, 1),
-    MinPt = cms.untracked.vdouble(0.0, 0.0),
-    MinP = cms.untracked.vdouble(0.0, 0.0),
-    MaxEta = cms.untracked.vdouble(2.5, 2.5),
-    MinEta = cms.untracked.vdouble(-2.5, -2.5),
-    ParticleCharge = cms.untracked.int32(-1),
-    ParticleID1 = cms.untracked.vint32(321),
-    ParticleID2 = cms.untracked.vint32(321)
-)
-
-ProductionFilterSequence = cms.Sequence(generator*kkgenfilter)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_phi_dika-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_coh_phi_dika-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_coherent_phi_dikaon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_phi_dikaon.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+kkgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.0, 0.0),
+    MinP = cms.untracked.vdouble(0.0, 0.0),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(321),
+    ParticleID2 = cms.untracked.vint32(321)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*kkgenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_double_diff-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_double_diff-fragment.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_double_diffraction_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_double_diffraction.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_incoh_jpsi_diel-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_incoh_jpsi_diel-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_incoherent_jpsi_dielectron_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_jpsi_dielectron.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+elelgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.0, 3.0),
+    MinEta = cms.untracked.vdouble(-3.0, -3.0),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(11),
+    ParticleID2 = cms.untracked.vint32(11)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*elelgenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_incoh_jpsi_dimu-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_incoh_jpsi_dimu-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_incoherent_jpsi_dimuon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_jpsi_dimuon.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)

--- a/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_single_diff-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Starlight/STARLIGHT_single_diff-fragment.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/starlight/starlight_single_diffraction_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Starlight/production/PbPb_5p36TeV/starlight_single_diffraction.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_LbyL-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_LbyL-fragment.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/superchic/superchic_LbyL_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Superchic/production/PbPb_5p36TeV/superchic_LbyL.dat
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        exclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
+            'PartonLevel:MPI = off',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+phophogenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.1, 3.1),
+    MinEta = cms.untracked.vdouble(-3.1, -3.1),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(22),
+    ParticleID2 = cms.untracked.vint32(22)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*phophogenfilter)

--- a/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_elec-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_elec-fragment.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/superchic/superchic_dielectron_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Superchic/production/PbPb_5p36TeV/superchic_dielectron.dat
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        exclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
+            'PartonLevel:MPI = off',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+elelgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.0, 3.0),
+    MinEta = cms.untracked.vdouble(-3.0, -3.0),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(11),
+    ParticleID2 = cms.untracked.vint32(11)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*elelgenfilter)

--- a/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_muon-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_muon-fragment.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/superchic/superchic_dimuon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Superchic/production/PbPb_5p36TeV/superchic_dimuon.dat
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        exclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
+            'PartonLevel:MPI = off',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)

--- a/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_tau-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Superchic/SUPERCHIC_QED_tau-fragment.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/superchic/superchic_ditau_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Superchic/production/PbPb_5p36TeV/superchic_ditau.dat
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        exclusive_process = cms.vstring(
+            # Recomendation from https://anstahll.web.cern.ch/anstahll/superchic/SuperChic_5_1.pdf
+            # For purely elastic production (diff set to el)
+            'PartonLevel:ISR = off',
+            'PartonLevel:MPI = off',
+            'PartonLevel:Remnants = off',
+            'Check:event = off',
+            'LesHouches:matchInOut = off',
+            'SpaceShower:pTmaxMatch = 2',
+            'SpaceShower:pTdampMatch = 1',
+            'BeamRemnants:primordialKT = off',
+            'BeamRemnants:unresolvedHadron = 3'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','exclusive_process')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_LbyL-fragment.py
+++ b/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_LbyL-fragment.py
@@ -1,12 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring(),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/upcgen/upcgen_LbyL_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
     nEvents = cms.untracked.uint32(1),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
 )
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/UPCgen/production/PbPb_5p36TeV/upcgen_LbyL.in
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     PythiaParameters = cms.PSet(
@@ -24,3 +27,16 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
 )
 
 ProductionFilterSequence = cms.Sequence(generator)
+
+phophogenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0., 0.),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.1, 3.1),
+    MinEta = cms.untracked.vdouble(-3.1, -3.1),
+    ParticleCharge = cms.untracked.int32(0),
+    ParticleID1 = cms.untracked.vint32(22),
+    ParticleID2 = cms.untracked.vint32(22)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*phophogenfilter)

--- a/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_elec-fragment.py
+++ b/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_elec-fragment.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/upcgen/upcgen_dielectron_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/UPCgen/production/PbPb_5p36TeV/upcgen_dielectron.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+elelgenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(0., 0.),
+    MaxEta = cms.untracked.vdouble(3.0, 3.0),
+    MinEta = cms.untracked.vdouble(-3.0, -3.0),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(11),
+    ParticleID2 = cms.untracked.vint32(11)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*elelgenfilter)

--- a/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_muon-fragment.py
+++ b/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_muon-fragment.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/upcgen/upcgen_dimuon_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/UPCgen/production/PbPb_5p36TeV/upcgen_dimuon.in
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+mumugenfilter = cms.EDFilter("MCParticlePairFilter",
+    Status = cms.untracked.vint32(1, 1),
+    MinPt = cms.untracked.vdouble(0.5, 0.5),
+    MinP = cms.untracked.vdouble(2.5, 2.5),
+    MaxEta = cms.untracked.vdouble(2.5, 2.5),
+    MinEta = cms.untracked.vdouble(-2.5, -2.5),
+    ParticleCharge = cms.untracked.int32(-1),
+    ParticleID1 = cms.untracked.vint32(13),
+    ParticleID2 = cms.untracked.vint32(13)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*mumugenfilter)

--- a/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_tau-fragment.py
+++ b/genfragments/PbPb_5p36TeV/UPCgen/UPCGEN_QED_tau-fragment.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/upcgen/upcgen_ditau_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tgz'),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/UPCgen/production/PbPb_5p36TeV/upcgen_ditau.in
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        skip_hadronization = cms.vstring(
+            'ProcessLevel:all = off',
+            'Check:event = off'
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings','pythia8PSweightsSettings','skip_hadronization')
+    ),
+    comEnergy = cms.double(5362.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR adds the genfragments for official PbPb 5.36 TeV (Run3) production of STARlight, SuperChic and UPCgen generators in the directory: genfragments/PbPb_5p36TeV/ .

The PYTHIA8 tune "pythia8CP5Settings" is excluded from the UPC gen fragments since this is tuned for hadronic events.

@sarteagae @DickyChant @menglu21 @bbilin 