### PR TITLE
Add genfragments for PbPb 5.36 TeV Powheg production

### DIFF
--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/Z_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_DYToEE_M_10_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_10_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
@@ -27,8 +27,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
@@ -27,7 +27,8 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0'
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/Z_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_DYToEE_M_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToEE_EPPS21_MllBinned_M_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
@@ -27,8 +27,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
@@ -27,7 +27,8 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0'
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/Z_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_DYToMuMu_M_10_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_10_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
@@ -27,8 +27,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
@@ -27,7 +27,8 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0'
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/Z_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_DYToMuMu_M_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/DYToLL/DYToMuMu_EPPS21_MllBinned_M_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
@@ -27,8 +27,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
@@ -27,7 +27,8 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 1', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 4.0'
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/hvq_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_TT.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/TT_hvq/TT_hdamp_EPPS21_NNLO_inclusive.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 1.0',#cutting off lepton-pair production
+            ##in the electromagnetic shower
+            ##to not overlap with ttZ/gamma* samples
+            '6:m0 = 172.5'    # top mass'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
@@ -27,10 +27,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 2', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            'TimeShower:mMaxGamma = 1.0',#cutting off lepton-pair production
-            ##in the electromagnetic shower
-            ##to not overlap with ttZ/gamma* samples
-            '6:m0 = 172.5'    # top mass'
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WWTo2L2Nu-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WWTo2L2Nu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/WW_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_WWTo2L2Nu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/WWTo2L2Nu/WWTo2L2Nu_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WWToLNu2Q-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WWToLNu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/WW_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_WWToLNu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/WWToLNu2Q/WWToLNu2Q_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZTo2L2Q-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZTo2L2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/WZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_WZTo2L2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo2L2Q/WZTo2L2Q_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZTo3lNu-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZTo3lNu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/WZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_WZTo3lNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/WZTo3lNu/WZTo3lNu_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZToLNu2Q-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_WZToLNu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/WZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_WZToLNu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/WZToLNu2Q/WZToLNu2Q_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2L2Nu-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2L2Nu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ZZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ZZ2L2Nu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2L2Q-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2L2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ZZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ZZ2L2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2L2Q/ZZ_2L2Q_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2Nu2Q-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo2Nu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ZZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ZZ2Nu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo4L-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_ZZTo4L-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ZZ_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ZZ4L.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/ZZTo4L/ZZ_4L_EPPS21_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
@@ -27,7 +27,6 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 2', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            '6:m0 = 172.5',    # top mass'
             'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
@@ -43,11 +43,4 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
     pythiaPylistVerbosity = cms.untracked.int32(1),
 )
 
-lheGenericFilter = cms.EDFilter("LHEGenericFilter",
-    src = cms.InputTag("externalLHEProducer"),
-    NumRequired = cms.int32(0),
-    ParticleID = cms.vint32(11,13,15),
-    AcceptLogic = cms.string("GT") # LT meaning < NumRequired, GT >, EQ =, NE !=
-)          
-
-ProductionFilterSequence = cms.Sequence(lheGenericFilter+generator)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ST_wtch_DR_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ST_atop.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            '6:m0 = 172.5',    # top mass'
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+lheGenericFilter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("externalLHEProducer"),
+    NumRequired = cms.int32(0),
+    ParticleID = cms.vint32(11,13,15),
+    AcceptLogic = cms.string("GT") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)          
+
+ProductionFilterSequence = cms.Sequence(lheGenericFilter+generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
@@ -27,7 +27,6 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'POWHEG:nFinal = 2', ## Number of final state particles
             ## (BEFORE THE DECAYS) in the LHE
             ## other than emitted extra parton
-            '6:m0 = 172.5',    # top mass'
             'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
@@ -43,11 +43,4 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
     pythiaPylistVerbosity = cms.untracked.int32(1),
 )
 
-lheGenericFilter = cms.EDFilter("LHEGenericFilter",
-    src = cms.InputTag("externalLHEProducer"),
-    NumRequired = cms.int32(0),
-    ParticleID = cms.vint32(11,13,15),
-    AcceptLogic = cms.string("GT") # LT meaning < NumRequired, GT >, EQ =, NE !=
-)
-
-ProductionFilterSequence = cms.Sequence(lheGenericFilter+generator)
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ST_wtch_DR_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ST_top.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            '6:m0 = 172.5',    # top mass'
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+lheGenericFilter = cms.EDFilter("LHEGenericFilter",
+    src = cms.InputTag("externalLHEProducer"),
+    NumRequired = cms.int32(0),
+    ParticleID = cms.vint32(11,13,15),
+    AcceptLogic = cms.string("GT") # LT meaning < NumRequired, GT >, EQ =, NE !=
+)
+
+ProductionFilterSequence = cms.Sequence(lheGenericFilter+generator)


### PR DESCRIPTION
This PR adds the genfragments for official PbPb 5.36 TeV (Run3) production of Powheg generator in the directory: genfragments/PbPb_5p36TeV/Powheg .

The genfragments are created using as templates the central production Powheg genfragments for Run3Summer23 defined in https://github.com/cms-PdmV/GridpackFiles/tree/master/Cards/Powheg .

@sarteagae @DickyChant @menglu21 @bbilin 