### PR TITLE
Add genfragments for PbPb 5.36 TeV Madgraph production

### DIFF
--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
@@ -37,7 +37,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'JetMatching:nQmatch = 5',
             'JetMatching:nJetMax = 2',
             'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.48'
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc11/dyellell012j_5f_NLO_FXFX_M10to50_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/dyellell012j_5f_NLO_FXFX_M10to50
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.48'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc11/dyellell012j_5f_NLO_FXFX_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/dyellell012j_5f_NLO_FXFX
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.48'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
@@ -37,7 +37,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'JetMatching:nQmatch = 5',
             'JetMatching:nJetMax = 2',
             'TimeShower:mMaxGamma = 4.0',
-            'BeamRemnants:primordialKThard=2.48'
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc11/tt012j_5f_ckm_NLO_FXFX_NNLO3p1_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/tt012j_5f_ckm_NLO_FXFX_NNLO3p1
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 40.',
+            'JetMatching:qCutME = 20.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 1.0',#cutting off lepton-pair production
+            'TimeShower:MEcorrections = on'#avoid shifts in the reco top quark mass peak position
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
@@ -36,8 +36,7 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
             'JetMatching:qCutME = 20.',
             'JetMatching:nQmatch = 5',
             'JetMatching:nJetMax = 2',
-            'TimeShower:mMaxGamma = 1.0',#cutting off lepton-pair production
-            'TimeShower:MEcorrections = on'#avoid shifts in the reco top quark mass peak position
+            'TimeShower:mMaxGamma = 4.0'
         ),
         parameterSets = cms.vstring(
             'pythia8CommonSettings',

--- a/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_W012JToLNu_NLO_FXFX-fragment.py
+++ b/genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_W012JToLNu_NLO_FXFX-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc11/wellnu012j_5f_NLO_FXFX_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu012j_5f_NLO_FXFX
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR adds the genfragments for official PbPb 5.36 TeV (Run3) production of Madgraph generator in the directory: genfragments/PbPb_5p36TeV/MadGraph5_aMCatNLO .

The genfragments are created using as templates the central production Powheg genfragments for Run3Summer23 defined in https://github.com/cms-PdmV/GridpackFiles/tree/master/Cards/MadGraph5_aMCatNLO .

The main differences in the process parameters compared to 2018 (Run 2) were:
- TT: Kept the paramaters: "TimeShower:mMaxGamma = 1.0"  to be consistent with the POWHEG gen fragment (the central gridpacks use TimeShower:mMaxGamma = 4.0 for MadGraph while 1.0 is used for Powheg so seems inconsistent).
- TT: Is the parameter "TimeShower:MEcorrections = on" still needed? (kept it from 2018 but I see it is not used in 2023)
- DY: Added the parameter "BeamRemnants:primordialKThard=2.48" (was not in 2018 but appears in 2023 central gridpacks).

@sarteagae @DickyChant @menglu21 @bbilin 