### PR TITLE
LHAPDF workaround for el8_amd64 to gridpack_generation.sh

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -213,6 +213,25 @@ make_gridpack () {
     
       LHAPDFINCLUDES=`$LHAPDFCONFIG --incdir`
       LHAPDFLIBS=`$LHAPDFCONFIG --libdir`
+
+      # workaround for el8
+      LHAPDFPYTHONVER=`find $LHAPDFLIBS -name "python*" -type d -exec basename {} \;`
+      LHAPDFPYTHONLIB=`find $LHAPDFLIBS/$LHAPDFPYTHONVER/site-packages -name "*.egg" -type d -exec basename {} \;`
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LHAPDFLIBS
+
+      if [ ! -z "${LHAPDFPYTHONLIB}" ] ; then
+        if [ ! -z "${PYTHONPATH+x}" ] ; then
+          export PYTHONPATH=$PYTHONPATH:$LHAPDFLIBS/$LHAPDFPYTHONVER/site-packages/$LHAPDFPYTHONLIB
+        else
+          export PYTHONPATH=$LHAPDFLIBS/$LHAPDFPYTHONVER/site-packages/$LHAPDFPYTHONLIB
+        fi
+      else
+        if [ ! -z "${PYTHONPATH+x}" ] ; then
+          export PYTHONPATH=$PYTHONPATH:$LHAPDFLIBS/$LHAPDFPYTHONVER/site-packages
+        else
+          export PYTHONPATH=$LHAPDFLIBS/$LHAPDFPYTHONVER/site-packages
+        fi
+      fi
     
       echo "set auto_update 0" > mgconfigscript
       echo "set automatic_html_opening False" >> mgconfigscript


### PR DESCRIPTION
The lhapdf python interface is not working while initializing the Madgraph3.5 workspace, in el8_amd64 environment.
There has been a workaround in the `runcmsgrid_*.sh`, but this had to be also added in the `gridpack_generation.sh`. 

Otherwise, `import lhapdf` fails in executing madgraph and alpha_s parameter is not corrected in the initial steps such as compiling, madspingrid generation, etc. But event generation from the gridpack tarball file fails due to inconsistent alpha_s choice where the value is taken from the lhapdf since the lhapdf workaround is in the `runcmsgrid.sh` in the tarball file.

In this PR, I copied the `el8` workaround in the `runcmsgrid.sh` to the `gridpack_generation.sh` (with minor additions)

Related cmstalk: https://cms-talk.web.cern.ch/t/madspin-error-incompatible-alpha-s/29941/8