### PR TITLE
New Monopole Datacards for Run3

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 4110000 1000
+set param_card mass 25 125
+set param_card decay 4110000 0.000000e+0
+set param_card gch 1 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_proc_card.dat
@@ -1,0 +1,3 @@
+import model mono_spinhalf
+generate a a > mm+ mm-
+output monopole_SpinHalf_PhotonFusion_M1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/cards/SpinHalf_PhotonFusion_1000/monopole_SpinHalf_PhotonFusion_M1000_run_card.dat
@@ -1,0 +1,129 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  100000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                3=photon from electron, 4=photon from muon          *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6800.0	= ebeam1 ! beam 1 total energy in GeV
+  6800.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+  324900	= lhaid ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False	= gridpack !True = setting up the grid pack
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+  2	= sde_strategy ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  4	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  False	= use_syst ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/make_cards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinHalf_PhotonFusion/make_cards.py
@@ -1,0 +1,61 @@
+"""
+Owner: Matheus Macedo, UERJ-RIO / Brazil
+
+This script automates the generation of configuration files for particle simulation processes, specifically focusing on simulations of different particle masses. It creates a directory structure and files necessary for each mass value specified in the 'masses' list. The script generates three main types of files for each mass:
+1. 'customizecards.dat' for setting particle mass and decay parameters.
+2. 'proc_card.dat' for specifying the simulation process and model.
+3. 'run_card.dat' for simulation run configurations, copied from a template if available.
+
+How to Use:
+- Ensure Python is installed on your system.
+- Save this script in your desired directory.
+- Run the script using Python (e.g., 'python3 make_cards.py').
+- The script will create a 'cards' directory with subdirectories and files for each mass.
+"""
+
+import os
+
+# List of particle masses for which configuration files will be generated.
+masses = [1000, 1500, 2000, 2500, 3000, 3500, 3600, 3700, 3800, 3900, 4000, 4100, 4200, 4300, 4400, 4500]
+
+# Creates the main 'cards' directory if it does not exist. 'exist_ok=True' prevents error if the directory already exists.
+os.makedirs("cards", exist_ok=True)
+
+# Iterates over each mass value in the list.
+for mass in masses:
+    # Creates a specific directory for each mass inside the 'cards' directory.
+    output_card_dir = f"cards/SpinHalf_PhotonFusion_{mass}"
+    os.makedirs(output_card_dir, exist_ok=True)
+
+    # Creates and writes to 'customizecards.dat' file with specific simulation configuration for the mass.
+    customizecards_path = f"{output_card_dir}/monopole_SpinHalf_PhotonFusion_M{mass}_customizecards.dat"
+    with open(customizecards_path, 'w') as customizecards_file:
+        customizecards_file.write(f"set param_card mass 4110000 {mass}\n")  # Sets the mass of the particle.
+        customizecards_file.write("set param_card mass 25 125\n")  # Sets the mass of the Higgs boson (example).
+        customizecards_file.write("set param_card decay 4110000 0.000000e+0\n")  # Sets the decay of the particle.
+        customizecards_file.write("set param_card gch 1 1.0\n")  # Sets a generic coupling parameter.
+
+    # Creates and writes to 'proc_card.dat' file with commands for generating the simulation process.
+    proc_card_content = f"""import model mono_spinhalf
+generate a a > mm+ mm-
+output monopole_SpinHalf_PhotonFusion_M{mass} -nojpeg
+"""
+    proc_card_path = f"{output_card_dir}/monopole_SpinHalf_PhotonFusion_M{mass}_proc_card.dat"
+    with open(proc_card_path, 'w') as proc_card_file:
+        proc_card_file.write(proc_card_content)
+
+    # Checks for the existence of 'run_card.dat'. If it exists, copies its content to the new directory.
+    run_card_input_path = "monopole_SpinHalf_PhotonFusion_run_card.dat"
+    run_card_output_path = f"{output_card_dir}/monopole_SpinHalf_PhotonFusion_M{mass}_run_card.dat"
+    if os.path.exists(run_card_input_path):
+        with open(run_card_input_path, 'r') as run_card_input_file, open(run_card_output_path, 'w') as run_card_output_file:
+            for line in run_card_input_file:
+                run_card_output_file.write(line)
+            run_card_output_file.write("\n")  # Adds an extra newline for safety.
+    else:
+        # If 'run_card.dat' does not exist, creates an empty file.
+        open(run_card_output_path, 'a').close()
+
+
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_customizecards.dat
@@ -1,0 +1,4 @@
+set param_card mass 4110000 1000
+set param_card mass 25 125
+set param_card decay 4110000 0.000000e+0
+set param_card gch 1 1.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_proc_card.dat
@@ -1,0 +1,3 @@
+import model mono_spinzero
+generate a a > mm+ mm-
+output monopole_SpinZero_PhotonFusion_M1000 -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/cards/SpinZero_PhotonFusion_1000/monopole_SpinZero_PhotonFusion_M1000_run_card.dat
@@ -1,0 +1,129 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  100000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                3=photon from electron, 4=photon from muon          *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6800.0	= ebeam1 ! beam 1 total energy in GeV
+  6800.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+  lhapdf	= pdlabel ! PDF set                                     
+  324900	= lhaid ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False	= gridpack !True = setting up the grid pack
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+# To see MLM/CKKW  merging options: type "update MLM" or "update CKKW"
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+  2	= sde_strategy ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  4	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  False	= use_syst ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/make_cards.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/monopole_SpinZero_PhotonFusion/make_cards.py
@@ -1,0 +1,61 @@
+"""
+Script for Generating Configuration Files for Particle Simulations
+Owner: Matheus Macedo, UERJ-RIO / Brazil
+
+This script is designed to automate the creation of configuration files for particle simulation studies, focusing on different masses of particles with spin zero. It systematically generates a structured directory with necessary configuration files for each specified particle mass. These include:
+1. 'customizecards.dat' for setting specific particle mass, decay parameters, and coupling constants.
+2. 'proc_card.dat' for specifying the simulation process using the imported model.
+3. 'run_card.dat' for defining runtime parameters, copied from a template if it exists.
+
+How to Use:
+- Make sure Python is installed on your computer.
+- Copy this script into a Python file, e.g., 'make_cards.py'.
+- Execute the script from your terminal or command prompt by running 'python generate_spinzero_configs.py'.
+- The script will generate a 'cards' directory in your current working directory with subdirectories for each mass value, each containing the required configuration files.
+
+"""
+
+import os
+
+# Defines a list of particle masses for which to generate configuration files.
+masses = [1000, 1500, 2000, 2500, 3000, 3400, 3500, 3600, 3700, 3800, 3900, 4000, 4100, 4200, 4300, 4400, 4500]
+
+# Creates a main directory called 'cards' if it does not already exist. 
+os.makedirs("cards", exist_ok=True)
+
+# Iterates through each mass in the list to create specific directories and configuration files.
+for mass in masses:
+    # Constructs a directory path for each mass and creates the directory.
+    output_card_dir = f"cards/SpinZero_PhotonFusion_{mass}"
+    os.makedirs(output_card_dir, exist_ok=True)
+
+    # Prepares the path for 'customizecards.dat' and writes configuration settings to it.
+    customizecards_path = f"{output_card_dir}/monopole_SpinZero_PhotonFusion_M{mass}_customizecards.dat"
+    with open(customizecards_path, 'w') as customizecards_file:
+        customizecards_file.write(f"set param_card mass 4110000 {mass}\n")  # Sets the mass of the particle.
+        customizecards_file.write("set param_card mass 25 125\n")  # Sets the Higgs boson mass, for example.
+        customizecards_file.write("set param_card decay 4110000 0.000000e+0\n")  # Defines the particle's decay.
+        customizecards_file.write("set param_card gch 1 1.0\n")  # Sets a coupling constant.
+
+    # Generates 'proc_card.dat' with the model import and process generation commands.
+    proc_card_content = f"""import model mono_spinzero
+generate a a > mm+ mm-
+output monopole_SpinZero_PhotonFusion_M{mass} -nojpeg
+"""
+    proc_card_path = f"{output_card_dir}/monopole_SpinZero_PhotonFusion_M{mass}_proc_card.dat"
+    with open(proc_card_path, 'w') as proc_card_file:
+        proc_card_file.write(proc_card_content)
+
+    # Checks for the existence of a template 'run_card.dat'. If found, copies its content into the new directory.
+    run_card_input_path = "monopole_SpinZero_PhotonFusion_run_card.dat"
+    run_card_output_path = f"{output_card_dir}/monopole_SpinZero_PhotonFusion_M{mass}_run_card.dat"
+    if os.path.exists(run_card_input_path):
+        with open(run_card_input_path, 'r') as run_card_input_file, open(run_card_output_path, 'w') as run_card_output_file:
+            for line in run_card_input_file:
+                run_card_output_file.write(line)
+            run_card_output_file.write("\n")  # Ensures an extra newline at the end for file integrity.
+    else:
+        # Creates an empty 'run_card.dat' if the template is not found.
+        open(run_card_output_path, 'a').close()
+
+


### PR DESCRIPTION
Dear,
This new PR refers to the datacard for Monte Carlo production of magnetic monopoles from the Photin Fusion and Spin zero and Spin half channels. I had already made a [PR](https://github.com/cms-sw/genproductions/pull/3663) previously for Run II, but when I went to do this I realized that there was no need to create everything from scratch and I just copied the folder that gave the path
`genproductions/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV`
for this
`genproductions/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV`
and I made a single change to *run_card.dat changing the beam energy from 6500 (Run2) to 6800 (Run3).
Let me know if it's correct and if I need to make any other changes.

Best,
Matheus Macedo