### PR TITLE
Fixing MadGraph5_aMCatNLO condor gridpack generation 

### DIFF
--- a/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
+++ b/bin/MadGraph5_aMCatNLO/PLUGIN/CMS_CLUSTER/__init__.py
@@ -52,6 +52,12 @@ pjoin = os.path.join
 multiple_try = misc.multiple_try
 pjoin = os.path.join
 
+import socket
+hostname = socket.gethostname()
+
+def singularityWraper():
+    if "lxplus" in hostname:
+        return f'\nMY.WantOS = \"{hostname.split(".")[0].replace("lxplus","el")}\"\n' # Following https://batchdocs.web.cern.ch/local/submit.html#os-selection-via-containers and simply using hostname 
 
 def cleansubproc(subproc):
     subproc.terminate()
@@ -230,7 +236,7 @@ class CMSCondorCluster(CondorCluster):
                   
                   queue 1
                """
-        
+        text += singularityWraper() 
         if self.cluster_queue not in ['None', None]:
             requirement = 'Requirements = %s=?=True' % self.cluster_queue
         else:

--- a/bin/MadGraph5_aMCatNLO/Utilities/source_condor.sh
+++ b/bin/MadGraph5_aMCatNLO/Utilities/source_condor.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # HTCondor python bindings are lost after cmsenv/scram
-PYTHON_BINDINGS="$(python3 -c 'import htcondor; import os; print(os.path.dirname(htcondor.__path__[0]))' 2>/dev/null)"
-if [ -z "$PYTHON_BINDINGS" ]; then
-  pip3 install htcondor --user #FIXME need better way to interface HTCondor Python API for Python3.9
+#PYTHON_BINDINGS="$(python3 -c 'import htcondor; import os; print(os.path.dirname(htcondor.__path__[0]))' 2>/dev/null)"
+#if [ -z "$PYTHON_BINDINGS" ]; then
+if [ -d $CMSSW_BASE/venv ];
+then 
+  echo "venv exists"
+else
+  scram-venv
+  cmsenv
+  pip3 install htcondor --upgrade #FIXME need better way to interface HTCondor Python API for Python3.9
 fi


### PR DESCRIPTION
First draft,

1. Enabling generation at lxplus with `singularity` wrapping up for condor jobs
2. Switch to `scram-venv` for htcondor python api installation

@DickyChant 