### PR TITLE
Newer versions, including ggHH for el8 and WZJ

### DIFF
--- a/bin/Powheg/run_pwg_condor.py
+++ b/bin/Powheg/run_pwg_condor.py
@@ -18,8 +18,8 @@ QUEUE = ''
 
 
 #POWHEG_SOURCE = "powhegboxV2_rev3728_date20200429.tar.gz"
-POWHEG_SOURCE = "powhegboxV2_rev3987_date20220622.tar.gz"
-POWHEGRES_SOURCE = "powhegboxRES_rev4004_date20221025.tar.gz"
+POWHEG_SOURCE = "powhegboxV2_rev4060_date20240611.tar.gz"
+POWHEGRES_SOURCE = "powhegboxRES_rev4060_date20240610.tar.gz"
 
 
 rootfolder = os.getcwd()


### PR DESCRIPTION
Move to latest versions of POWHEG V2 (containing ggHH and ggHH_SMEFT for el8) and POWHEG-RES (containing WZJ MiNNLO)

@jshin96 @agrohsje @fabio-mon @mlizzo 