### PR TITLE
Adding THQ and THW datacard with required kt=-1 for run3 sample production

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_customizecards.dat
@@ -1,4 +1,4 @@
 #put card customizations here (change top and higgs mass for example)
 set param_card mass 6 172.5
 set param_card mass 25 125
-set param_card yukawa 6 172.5
+set param_card yukawa 6 -172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_proc_card.dat
@@ -2,12 +2,9 @@ set group_subprocesses Auto
 set ignore_six_quark_processes False
 set loop_optimized_output True
 set complex_mass_scheme False
-define l+ = e+ mu+ ta+
-define l- = e- mu- ta-
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
-define wdec = u c d s u~ c~ d~ s~ l+ l- vl vl~
+import model sm
 import model HC_NLO_X0_UFO
+define wdec = u c d s u~ c~ d~ s~ l+ l- vl vl~
 generate p p > x0 t~ b j $$ w+ w-, (t~ > b~ w-, w- > wdec wdec)
 add process p p > x0 t b~ j $$ w+ w-, (t > b w+, w+ > wdec wdec)
 output thq_4f_ckm_LO_ctcvcp -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
@@ -1,17 +1,3 @@
-#*********************************************************************
-#                       MadGraph5_aMC@NLO                            *
-#                                                                    *
-#                     run_card.dat MadEvent                          *
-#                                                                    *
-#  This file is used to set the parameters of the run.               *
-#                                                                    *
-#  Some notation/conventions:                                        *
-#                                                                    *
-#   Lines starting with a '# ' are info or comments                  *
-#                                                                    *
-#   mind the format:   value    = variable     ! comment             *
-#*********************************************************************
-#
 #*******************                                                 
 # Running parameters
 #*******************                                                 
@@ -38,8 +24,8 @@
 #*********************************************************************
   1	=  lpp1     ! beam 1 type 
   1	=  lpp2     ! beam 2 type
-  6800.0	=  ebeam1   ! beam 1 total energy in GeV
-  6800.0	=  ebeam2   ! beam 2 total energy in GeV
+  6500.0	=  ebeam1   ! beam 1 total energy in GeV
+  6500.0	=  ebeam2   ! beam 2 total energy in GeV
 #*********************************************************************
 # Beam polarization from -100 (left-handed) to 100 (right-handed)    *
 #*********************************************************************
@@ -60,7 +46,7 @@
   91.188	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
   91.188	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
   -1	=  dynamical_scale_choice  ! Select one of the preselect dynamical choice
-  1 =  scalefact         ! scale factor for event-by-event scales
+  0.33 =  scalefact         ! scale factor for event-by-event scales
 #*********************************************************************
 # Matching - Warning! ickkw > 1 is still beta
 #*********************************************************************
@@ -91,7 +77,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-  True	=  cut_decays     ! Cut decay products 
+  False	=  cut_decays     ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for
@@ -266,3 +252,5 @@
 #          reweighting into account!                                 *
 #*********************************************************************
   True	=  use_syst       ! Enable systematics studies
+
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp/thq_4f_ckm_LO_ctcvcp_run_card.dat
@@ -24,8 +24,8 @@
 #*********************************************************************
   1	=  lpp1     ! beam 1 type 
   1	=  lpp2     ! beam 2 type
-  6500.0	=  ebeam1   ! beam 1 total energy in GeV
-  6500.0	=  ebeam2   ! beam 2 total energy in GeV
+  6800.0	=  ebeam1   ! beam 1 total energy in GeV
+  6800.0	=  ebeam2   ! beam 2 total energy in GeV
 #*********************************************************************
 # Beam polarization from -100 (left-handed) to 100 (right-handed)    *
 #*********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_customizecards.dat
@@ -1,4 +1,4 @@
 #put card customizations here (change top and higgs mass for example)
 set param_card mass 6 172.5
 set param_card mass 25 125
-set param_card yukawa 6 172.5
+set param_card yukawa 6 -172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_proc_card.dat
@@ -2,11 +2,10 @@ set group_subprocesses Auto
 set ignore_six_quark_processes False
 set loop_optimized_output True
 set complex_mass_scheme False
-define l+ = e+ mu+ ta+
-define l- = e- mu- ta-
-define vl = ve vm vt
-define vl~ = ve~ vm~ vt~
+import model sm
 import model HC_NLO_X0_UFO-no_b_mass
+define p = p b b~
+define j = j b b~
 define wdec = u c d s u~ c~ d~ s~ l+ l- vl vl~
 generate p p > x0 t w-, (t > w+ b, w+ > wdec wdec), w- > wdec wdec @1
 add process p p > x0 t~ w+, (t~ > w- b~, w- > wdec wdec), w+ > wdec wdec @2

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
@@ -1,17 +1,3 @@
-#*********************************************************************
-#                       MadGraph5_aMC@NLO                            *
-#                                                                    *
-#                     run_card.dat MadEvent                          *
-#                                                                    *
-#  This file is used to set the parameters of the run.               *
-#                                                                    *
-#  Some notation/conventions:                                        *
-#                                                                    *
-#   Lines starting with a '# ' are info or comments                  *
-#                                                                    *
-#   mind the format:   value    = variable     ! comment             *
-#*********************************************************************
-#
 #*******************                                                 
 # Running parameters
 #*******************                                                 
@@ -38,8 +24,8 @@
 #*********************************************************************
   1	=  lpp1     ! beam 1 type 
   1	=  lpp2     ! beam 2 type
-  6800.0	=  ebeam1   ! beam 1 total energy in GeV
-  6800.0	=  ebeam2   ! beam 2 total energy in GeV
+  6500.0	=  ebeam1   ! beam 1 total energy in GeV
+  6500.0	=  ebeam2   ! beam 2 total energy in GeV
 #*********************************************************************
 # Beam polarization from -100 (left-handed) to 100 (right-handed)    *
 #*********************************************************************
@@ -54,8 +40,8 @@
 #*********************************************************************
 # Renormalization and factorization scales                           *
 #*********************************************************************
-  False	=  fixed_ren_scale   ! if .true. use fixed ren scale
-  False	=  fixed_fac_scale   ! if .true. use fixed fac scale
+  True	=  fixed_ren_scale   ! if .true. use fixed ren scale
+  True	=  fixed_fac_scale   ! if .true. use fixed fac scale
   40	=  scale             ! fixed ren scale
   40	=  dsqrt_q2fact1     ! fixed fact scale for pdf1
   40	=  dsqrt_q2fact2     ! fixed fact scale for pdf2
@@ -91,7 +77,7 @@
 # Apply pt/E/eta/dr/mij cuts on decay products or not
 # (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
 #**********************************************************
-  True	=  cut_decays     ! Cut decay products 
+  False	=  cut_decays     ! Cut decay products 
 #*************************************************************
 # Number of helicities to sum per event (0 = all helicities)
 # 0 gives more stable result, but longer run time (needed for

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp/thw_5f_ckm_LO_ctcvcp_run_card.dat
@@ -24,8 +24,8 @@
 #*********************************************************************
   1	=  lpp1     ! beam 1 type 
   1	=  lpp2     ! beam 2 type
-  6500.0	=  ebeam1   ! beam 1 total energy in GeV
-  6500.0	=  ebeam2   ! beam 2 total energy in GeV
+  6800.0	=  ebeam1   ! beam 1 total energy in GeV
+  6800.0	=  ebeam2   ! beam 2 total energy in GeV
 #*********************************************************************
 # Beam polarization from -100 (left-handed) to 100 (right-handed)    *
 #*********************************************************************


### PR DESCRIPTION
Dear GEN expert,

We are reproducing THW and THQ samples because they were mistakenly generated with kt=1 instead of the required kt=-1 setting used in [run2 analysis](https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=HIG-19-008&tp=an&id=2256&ancode=HIG-19-008) . Recently, we ask [here](https://its.cern.ch/jira/browse/PDMVMCPROD-138) the sample to be invalidated to reproduce it with correct settings with the same sample names to maintain consistency.We are requesting to review the correct madgraph cards exactly same as we used in run2 but beam energy changed in the following cards:
[thq_4f_ckm_LO_ctcvcp](https://github.com/mobassirameen/genproductions/tree/addMyFile/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thq_4f_ckm_LO_ctcvcp)
[thw_5f_ckm_LO_ctcvcp](https://github.com/mobassirameen/genproductions/tree/addMyFile/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/thw_5f_ckm_LO_ctcvcp)

Please review them, if there are any other issues, please let us know.

Adding @mlizzo @vischia @sscruz @attikis