### PR TITLE
Update Starlight to version 330

### DIFF
--- a/bin/Starlight/gridpack_generation.sh
+++ b/bin/Starlight/gridpack_generation.sh
@@ -22,33 +22,29 @@ create_setup(){
 }
 
 install_starlight(){
-    DPMJET=dpmjet3.0-5
-    STARLIGHT=STARlight-REV_326
+    DPMJET=DPMJET-19.3.7
+    STARLIGHT=STARlight-Rev_330
     cd ${WORKDIR}
 
     echo "Downloading "${DPMJET}
     export DPMJETDIR=${WORKDIR}/dpmjet_v${DPMJET//[!0-9]/}
-    wget --no-verbose --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/starlight/${DPMJET}.tar
-    tar -xf ${DPMJET}.tar && mv ${DPMJET} ${DPMJETDIR}
-    rm -f ${DPMJET}.tar
+    wget --no-verbose --no-check-certificate https://anstahll.web.cern.ch/anstahll/starlight/${DPMJET}.tar.gz
+    tar -xzf ${DPMJET}.tar.gz && mv ${DPMJET} ${DPMJETDIR}
+    rm -f ${DPMJET}.tar.gz
 
     echo "Downloading "${STARLIGHT}
     STARLIGHT_VER=${STARLIGHT//[!0-9]/}
     STARLIGHTDIR=${WORKDIR}/starlight_v${STARLIGHT_VER}
-    wget --no-verbose --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/starlight/${STARLIGHT}.tar.gz
+    wget --no-verbose --no-check-certificate https://anstahll.web.cern.ch/anstahll/starlight/${STARLIGHT}.tar.gz
     tar -xzf ${STARLIGHT}.tar.gz && mv ${STARLIGHT} ${STARLIGHTDIR}
     rm -f ${STARLIGHT}.tar.gz
 
-    echo "Patching "${DPMJET}" and "${STARLIGHT}
-    patch -ufZs -p1 -i ${PRODDIR}/patches/dpmjet.patch -d ${DPMJETDIR}
-    patch -ufZs -p1 -i ${PRODDIR}/patches/starlight_pythia.patch -d ${STARLIGHTDIR}
-    patch -ufZs -p1 -i ${PRODDIR}/patches/starlight_varnotused.patch -d ${STARLIGHTDIR}
+    echo "Patching "${STARLIGHT}
     patch -ufZs -p1 -i ${PRODDIR}/patches/starlight_xsec.patch -d ${STARLIGHTDIR}
-    patch -ufZs -p1 -i ${PRODDIR}/patches/starlight_nuclearpar.patch -d ${STARLIGHTDIR}
 
     echo "Compiling ${DPMJET}"
     cd ${DPMJETDIR}
-    rm -f fpe.o
+    export FC=gfortran
     make -j $(nproc)
 
     echo "Compiling ${STARLIGHT}"

--- a/bin/Starlight/macros/convert_SL2LHE.cpp
+++ b/bin/Starlight/macros/convert_SL2LHE.cpp
@@ -11,7 +11,9 @@ int getMomPdgID(const int& chnId)
     return 113; // rho0
   else if (chnId == 223 || chnId == 223211111)
     return 223; // omega
-  else if (chnId == 443011 || chnId == 443013)
+  else if (chnId == 333 || chnId == 333011 || chnId == 933)
+    return 333; // phi
+  else if (chnId == 443011 || chnId == 443013 || chnId == 4432212)
     return 443; // J/psi
   else if (chnId == 444011 || chnId == 444013)
     return 100443; // psi(2S)
@@ -23,8 +25,8 @@ int getMomPdgID(const int& chnId)
     return 200553; // Y(3S)
   else if (chnId == 9010221 || chnId == 225 || chnId == 335 || chnId == 115)
     return chnId; // f0(975) , f2(1270) , f2(1525) , a2(1320)
-  else if (chnId == 221 || chnId == 331 || chnId == 441 || chnId == 333)
-    return chnId; // eta , eta' , etac , phi
+  else if (chnId == 221 || chnId == 331 || chnId == 441)
+    return chnId; // eta , eta' , etac
   return 0;
 };
 
@@ -77,7 +79,7 @@ void convert_SL2LHE(const std::string& inFileName, const double& beamE1, const d
     // EVENT: n ntracks nvertices
 	if (not (std::istringstream(line) >> label >> iEvt >> nTrk >> nVtx) ||
         label != "EVENT:")
-      throw std::logic_error("[convert_SL2LHE] Failed to parse event line: "+line);
+      continue;
 
     // Particle tuple: pdg id, status, mother index, 4-momentum
     std::vector<std::tuple<int, int, int, ROOT::Math::PxPyPzMVector>> parV;
@@ -137,7 +139,7 @@ void convert_SL2LHE(const std::string& inFileName, const double& beamE1, const d
     outFile << std::fixed << std::setprecision(8) << std::scientific;
     //# particles, subprocess id, event weight, event scale, alpha_em, alpha_s
     outFile << parV.size() << " 81 " << 1.0 << " " << scale << " " << -1.0 << " " << -1.0 << std::endl;
-    outFile << std::fixed << std::setprecision(10) << std::scientific;
+    outFile << std::fixed << std::setprecision(15);
     for (const auto& pV : parV) {
       const auto& [pdgId, status, momI, p] = pV;
       //particle: pdg id, status, mother index (1, 2), color flow tag (1, 2), (px, py, pz, energy, mass [GeV]), proper lifetime [mm], spin

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_omega_dipion.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_omega_dipion.in
@@ -1,23 +1,23 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 2                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 223               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 4.0                # max y
+RAP_N_BINS = 80              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
-INTERFERENCE = 0             # Interference (0 = off, 1 = on)
+INTERFERENCE = 1             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)
 INT_PT_MAX = 0.24            # Maximum pt considered, when interference is turned on
 INT_PT_N_BINS = 120          # Number of pt bins when interference is turned on

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_phi_dikaon.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_phi_dikaon.in
@@ -1,23 +1,23 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 2                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 333               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 2.5                # max y
+RAP_N_BINS = 50              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
-INTERFERENCE = 0             # Interference (0 = off, 1 = on)
+INTERFERENCE = 1             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)
 INT_PT_MAX = 0.24            # Maximum pt considered, when interference is turned on
 INT_PT_N_BINS = 120          # Number of pt bins when interference is turned on

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_phi_direct_dikaon.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_phi_direct_dikaon.in
@@ -1,23 +1,23 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 2                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 933               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 2.5                # max y
+RAP_N_BINS = 50              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
-INTERFERENCE = 0             # Interference (0 = off, 1 = on)
+INTERFERENCE = 1             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)
 INT_PT_MAX = 0.24            # Maximum pt considered, when interference is turned on
 INT_PT_N_BINS = 120          # Number of pt bins when interference is turned on

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_rho_dipion.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_rho_dipion.in
@@ -1,23 +1,23 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 3                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 113               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 4.0                # max y
+RAP_N_BINS = 80              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
-INTERFERENCE = 0             # Interference (0 = off, 1 = on)
+INTERFERENCE = 1             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)
 INT_PT_MAX = 0.24            # Maximum pt considered, when interference is turned on
 INT_PT_N_BINS = 120          # Number of pt bins when interference is turned on

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_rho_direct_dipion.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_coherent_rho_direct_dipion.in
@@ -1,23 +1,23 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 3                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 913               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 4.0                # max y
+RAP_N_BINS = 80              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
-INTERFERENCE = 0             # Interference (0 = off, 1 = on)
+INTERFERENCE = 1             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)
 INT_PT_MAX = 0.24            # Maximum pt considered, when interference is turned on
 INT_PT_N_BINS = 120          # Number of pt bins when interference is turned on

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_dimuon.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_dimuon.in
@@ -8,12 +8,12 @@ COLL_E = 5362                # Collision energy in GeV
 W_MAX = 202.0                # Max value of w
 W_MIN = 2                    # Min value of w
 W_N_BINS = 500               # Bins i w
-RAP_MAX = 8.                 # max y
-RAP_N_BINS = 80              # Bins i y
-CUT_PT = 1                   # Cut in pT? 0 = (no, 1 = yes)
+RAP_MAX = 3.                 # max y
+RAP_N_BINS = 60              # Bins i y
+CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
 PT_MIN = 0.2                 # Minimum pT in GeV
 PT_MAX = 9999.0              # Maximum pT in GeV
-CUT_ETA = 1                  # Cut in pseudorapidity? (0 = no, 1 = yes)
+CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
 ETA_MIN = -2.8               # Minimum pseudorapidity
 ETA_MAX = 2.8                # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_ditau.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_ditau.in
@@ -8,12 +8,12 @@ COLL_E = 5362                # Collision energy in GeV
 W_MAX = 50.0                 # Max value of w
 W_MIN = 3.56                 # Min value of w
 W_N_BINS = 500               # Bins i w
-RAP_MAX = 8.                 # max y
+RAP_MAX = 4.                 # max y
 RAP_N_BINS = 80              # Bins i y
-CUT_PT = 1                   # Cut in pT? 0 = (no, 1 = yes)
+CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
 PT_MIN = 0.2                 # Minimum pT in GeV
 PT_MAX = 9999.0              # Maximum pT in GeV
-CUT_ETA = 1                  # Cut in pseudorapidity? (0 = no, 1 = yes)
+CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
 ETA_MIN = -2.8               # Minimum pseudorapidity
 ETA_MAX = 2.8                # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_phi_dikaon.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_phi_dikaon.in
@@ -1,21 +1,21 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 4                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 333               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 2.5                # max y
+RAP_N_BINS = 50              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
 INTERFERENCE = 0             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)

--- a/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_rho_dipion.in
+++ b/bin/Starlight/production/PbPb_5p36TeV/starlight_incoherent_rho_dipion.in
@@ -1,21 +1,21 @@
-PROD_MODE = 1                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
-PROD_PID = 11                # Channel of interest
+PROD_MODE = 4                # gg or gP switch (1 = 2-photon, 2 = coherent vector meson (narrow), 3 = coherent vector meson (wide), 4 = incoherent vector meson)
+PROD_PID = 113               # Channel of interest
 BEAM_1_Z = 82                # Z of projectile
 BEAM_1_A = 208               # A of projectile
 BEAM_2_Z = 82                # Z of target
 BEAM_2_A = 208               # A of target
 COLL_E = 5362                # Collision energy in GeV
-W_MAX = 202.0                # Max value of w
-W_MIN = 2                    # Min value of w
-W_N_BINS = 500               # Bins i w
-RAP_MAX = 3.                 # max y
-RAP_N_BINS = 60              # Bins i y
+W_MAX = -1                   # Max value of w
+W_MIN = -1                   # Min value of w
+W_N_BINS = 50                # Bins i w
+RAP_MAX = 4.0                # max y
+RAP_N_BINS = 80              # Bins i y
 CUT_PT = 0                   # Cut in pT? 0 = (no, 1 = yes)
-PT_MIN = 0.2                 # Minimum pT in GeV
-PT_MAX = 9999.0              # Maximum pT in GeV
+PT_MIN = 1.0                 # Minimum pT in GeV
+PT_MAX = 3.0                 # Maximum pT in GeV
 CUT_ETA = 0                  # Cut in pseudorapidity? (0 = no, 1 = yes)
-ETA_MIN = -2.8               # Minimum pseudorapidity
-ETA_MAX = 2.8                # Maximum pseudorapidity
+ETA_MIN = -10                # Minimum pseudorapidity
+ETA_MAX = 10                 # Maximum pseudorapidity
 BREAKUP_MODE = 5             # Controls the nuclear breakup; a 5 here makes no requirement on the breakup of the ions
 INTERFERENCE = 0             # Interference (0 = off, 1 = on)
 IF_STRENGTH = 1.             # % of intefernce (0.0 - 0.1)

--- a/bin/Starlight/run_generic_tarball_cvmfs.sh
+++ b/bin/Starlight/run_generic_tarball_cvmfs.sh
@@ -72,8 +72,20 @@ tar -xaf ${path}
 # and fallback to /tmp
 export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
 
+# define singularity
+if [ "$use_gridpack_env" != false ]; then
+    if [ -n "$scram_arch_version" ]; then
+        sing=$(echo ${scram_arch_version} | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    elif egrep -q "scram_arch_version=[^$]" runcmsgrid.sh; then
+        sing=$(grep "scram_arch_version=[^$]" runcmsgrid.sh | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    fi
+    if [ -n "${sing}" ]; then
+        sing="cmssw-el"${sing}" --"
+    fi
+fi
+
 #generate events
-./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+${sing} ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
 
 mv cmsgrid_final.lhe $LHEWORKDIR/
 

--- a/bin/Starlight/runcmsgrid_starlight.sh
+++ b/bin/Starlight/runcmsgrid_starlight.sh
@@ -64,7 +64,7 @@ set_dpmjet_config(){
 run_starlight(){
     echo "*** STARTING STARLIGHT PRODUCTION ***"
     cd ${LHEWORKDIR}/${STARLIGHTDIR}/build
-    if [ "$ProdM" -ge 4 ]; then
+    if [ "$ProdM" -ge 5 ]; then
         ./starlight < my.input 2>&1 | tee slight.log; test ${PIPESTATUS[0]} -eq 0 || fail_exit "starlight error: exit code not 0"
         ${LHEWORKDIR}/macros/convert_SL2LHE slight.out ${Beam1E} ${Beam2E} 0 2>&1 | tee slight.log; test ${PIPESTATUS[0]} -eq 0 || fail_exit "convert_SL2LHE error: exit code not 0"
         sed -i '/STARLIGHT/a '${DPMJETDIR} slight.lhe


### PR DESCRIPTION
This PR updates Starlight to version 330 and DPMJET to version 19.3.7.
In addition, it adds new input cards for coherent and incoherent production.

For now the source files are retrieved from my personal CERN website. Once the files:
https://anstahll.web.cern.ch/anstahll/starlight/DPMJET-19.3.7.tar.gz
https://anstahll.web.cern.ch/anstahll/starlight/STARlight-Rev_330.tar.gz

are copied to the central CMS generator website, I will update this PR with the central website link.