### PR TITLE
Add early abortion for systematics module

### DIFF
--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_LO.sh
@@ -204,7 +204,10 @@ mv process/$event_file process/madevent/Events/${runlabel}/events.lhe
 pushd process/madevent
 pdfsets="PDF_SETS_REPLACE"
 scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur,dyn --dyn=-1,1,2,3,4 --alps=0.5,1,2"
-echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent
+if { echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/madevent 2>&1 >&3 3>&- | grep '^' >&2; } 3>&1; then
+    echo "Encounter Error in Running Systematics Module"
+    exit 10086
+fi
 popd
 
 # check lhe output  

--- a/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
+++ b/bin/MadGraph5_aMCatNLO/runcmsgrid_NLO.sh
@@ -146,7 +146,10 @@ if [ ! -e $LHEWORKDIR/header_for_madspin.txt ]; then
     pdfsets="PDF_SETS_REPLACE"
     scalevars="--mur=1,2,0.5 --muf=1,2,0.5 --together=muf,mur --dyn=-1"
 
-    echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/aMCatNLO
+    if { echo "systematics $runlabel --start_id=1001 --pdf=$pdfsets $scalevars" | ./bin/aMCatNLO 2>&1 >&3 3>&- | grep '^' >&2; } 3>&1; then
+        echo "Encounter Error in Running Systematics Module"
+        exit 10086
+fi
 
     cp $LHEWORKDIR/process/Events/${runlabel}/events.lhe $LHEWORKDIR/${runname}_final.lhe
 


### PR DESCRIPTION
This PR implements an early abortion mechanism for `systematics` module of MG5aMC as agreed among xPOG PnR and GEN. 

It should work as intended, as shown in https://gitlab.cern.ch/sqian/systematics/-/pipelines/7794147 

`wplus_LO/NLO_good` jobs are without error case, while `wplus_LO/NLO_buggy` ones are with an error at `systematics` module part.

This PR is to address https://github.com/cms-sw/cmssw/issues/43784 

@DickyChant 