### PR TITLE
STARLIGHT: Fix path to dmpjet.dat

### DIFF
--- a/bin/Starlight/gridpack_generation.sh
+++ b/bin/Starlight/gridpack_generation.sh
@@ -50,7 +50,7 @@ install_starlight(){
     echo "Compiling ${STARLIGHT}"
     cd ${STARLIGHTDIR}
     mkdir -p build && cd build
-    cp $DPMJETDIR/dpmjet.dat ./
+    cp $DPMJETDIR/dpmdata/dpmjet.dat ./
     cp ${STARLIGHTDIR}/config/my.input ./
     export PYTHIADIR=$(scram tool tag pythia8 PYTHIA8_BASE)
     cmake ${STARLIGHTDIR} -DENABLE_DPMJET=ON -DENABLE_PYTHIA=ON

--- a/bin/Superchic/macros/convert_SCLHE2LHE.cpp
+++ b/bin/Superchic/macros/convert_SCLHE2LHE.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <tuple>
 #include "Math/Vector4D.h"
 
 


### PR DESCRIPTION
This PR fixes the path to the dpmjet.dat file used during the installation of Starlight, which was changed after the latest update of the DPMJET package.

In addition it also fixes a minor issue when compiling Superchic gridpacks in GCC12.