### PR TITLE
Create mg356 branch

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -136,8 +136,8 @@ make_gridpack () {
     MGBASEDIR=mgbasedir
     
     MG_EXT=".tar.gz"
-    MG=MG5_aMC_v3.5.5$MG_EXT
-    MGSOURCE=https://launchpad.net/mg5amcnlo/3.0/3.5.x/+download/$MG
+    MG=MG5_aMC_v3.5.6$MG_EXT
+    MGSOURCE=https://launchpad.net/mg5amcnlo/3.0/3.6.x/+download/$MG
 
     MGBASEDIRORIG=$(echo ${MG%$MG_EXT} | tr "." "_")
     isscratchspace=0

--- a/bin/MadGraph5_aMCatNLO/patches/0016-fix-nb_core1-in-systematics.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0016-fix-nb_core1-in-systematics.patch
@@ -1,6 +1,6 @@
 --- a/madgraph/interface/common_run_interface.py
 +++ b/madgraph/interface/common_run_interface.py
-@@ -1813,7 +1813,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
+@@ -1815,7 +1815,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                      break
              else:
                  raise self.InvalidCmd('Invalid run name. Please retry')


### PR DESCRIPTION
Update patches and gridpack_generation.sh script according to mg356. Please note there is no mg356 version in cms-project-generators [1] yet, so this commit temporarily uses mg356 in mg5 launchpad [2], which should be updated later.

[1] https://cms-project-generators.web.cern.ch/cms-project-generators/
[2] https://launchpad.net/mg5amcnlo/3.0/3.6.x/+download/MG5_aMC_v3.5.6.tar.gz