### PR TITLE
Update pythia fragment for Run3 VBF anomalous coupling samples

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/Hadronizer_TuneCP5_13p6TeV_pTmaxMatch_1_pTmaxFudge_half_LHE_pythia8_cff.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hadronizer_TuneCP5_13p6TeV_pTmaxMatch_1_pTmaxFudge_half_LHE_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13600.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'SpaceShower:pTmaxMatch = 1',
+            'TimeShower:pTmaxMatch = 1',
+            'SpaceShower:pTmaxFudge = .5',
+            'TimeShower:pTmaxFudge = .5',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters',
+                                    )
+    )
+)


### PR DESCRIPTION
Hi Gen Group,

We want to commit this pythia fragment for JHUGen LO VBF with anomalous couplings. I am unfamiliar with the exact defaults recommended for Run3, but we want the following:

- Gen recommended default pythia tunes for Run3 13.6 TeV 
- SpaceShower/TimeShower fudge factors as written in this fragement. (To match Run2 VBF pythia configs)

Can you check to make sure that this pythia fragment reflects the above bullet points?

Best,
Jeff