### PR TITLE
Create JHUGen_2l2v.input

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/gg_H_quark-mass-effects_with_JHUGen_NNPDF31_13p6TeV/JHUGen_2l2v.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/gg_H_quark-mass-effects_with_JHUGen_NNPDF31_13p6TeV/JHUGen_2l2v.input
@@ -1,0 +1,1 @@
+DecayMode1=3 DecayMode2=0 WidthSchemeIn=3 ReweightDecay ReadPmHstar PmHstarFile=PMZZdistribution.out LHAPDF=NNPDF31_nnlo_hessian_pdfas/NNPDF31_nnlo_hessian_pdfas WriteFailedEvents=2


### PR DESCRIPTION
Dear GEN experts,

     I hope you are doing well. 
     We are HZZ MC contacts. Currently, HZZ people are asking for HZZ 2l2v samples for Run3 analyzes. For the samples generation, we will use powheg for H production and JHUGen for H decay. The new commit describes H ZZ 2l2nu decay mode. Thanks for your review. 

Best,
Yuji & Lazar [HZZ MC Contacts]