### PR TITLE
PDF value is set with recommended PDF set value

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
@@ -6,8 +6,8 @@ ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 6800     ! energy of beam 1
 ebeam2 6800    ! energy of beam 2
 
-lhans1 306000       ! pdf set for hadron 1 (LHA numbering)
-lhans2 306000       ! pdf set for hadron 2 (LHA numbering)
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
 
 ! Parameters to allow or not the use of stored data
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)


### PR DESCRIPTION
Dear GEN expert,
In my already merged [PR](https://github.com/cms-sw/genproductions/pull/3786) request, PDF value was not set with the recommended value for the ggH->ZZ->2L2Q., I got notice after this PR merged, my bad.
But now it is set with the recommended PDF set value. sorry for the inconvenience.


Thanks and regards,
Mohammad (for tth-multilepton run-3 analysis)