### PR TITLE
Add Run3 PbPb single top t-channel POWHEG cards

### DIFF
--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p35TeV.input
@@ -1,0 +1,86 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2681d0     ! energy of beam 1
+ebeam2 2681d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+lhans2   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000  ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 100000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       -1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 

--- a/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p35TeV.input
+++ b/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p35TeV.input
@@ -1,0 +1,86 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2681d0     ! energy of beam 1
+ebeam2 2681d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+lhans2   904400    ! nPDF: EPPS21nlo_CT18Anlo_Pb208
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000  ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 100000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_antitop-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_antitop-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ST_tch_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ST_tch_atop.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_top-fragment.py
+++ b/genfragments/PbPb_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_top-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc11/ST_tch_el8_amd64_gcc11_CMSSW_13_0_18_HeavyIon_Run3_PbPb_5p36TeV_ST_tch_top.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/PbPb_5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5362.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR adds two new POWHEG cards and PYTHIA8 genfragments associated to the single top and the antitop t-channel production using POWHEG (ST_tch mode)l for Run3 PbPb MC production.

@DickyChant @bbilin