### PR TITLE
Update SuperChic to version 5.4

### DIFF
--- a/bin/Superchic/gridpack_generation.sh
+++ b/bin/Superchic/gridpack_generation.sh
@@ -24,7 +24,7 @@ create_setup(){
 }
 
 install_superchic(){
-    SUPERCHIC=SuperChic-5.3
+    SUPERCHIC=SuperChic-5.4
     cd ${WORKDIR}
 
     echo "Downloading "${SUPERCHIC}
@@ -36,7 +36,7 @@ install_superchic(){
     echo "Compiling ${SUPERCHIC}"
     cd ${SUPERCHICDIR}
     CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
-    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${SUPERCHICDIR}/build -DLHAPDF_DIR=$(scram tool tag lhapdf LHAPDF_BASE) -DSUPERCHIC_ENABLE_TESTS=OFF -DSUPERCHIC_ENABLE_FPES=OFF -DSUPERCHIC_ENABLE_DOCS=OFF -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_Fortran_FLAGS="-O2 -g -ffree-line-length-512 -Wno-unused-label -Wno-integer-division -Wno-conversion -Wno-function-elimination"
+    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${SUPERCHICDIR}/build -DLHAPDF_DIR=$(scram tool tag lhapdf LHAPDF_BASE) -DSUPERCHIC_ENABLE_TESTS=OFF -DSUPERCHIC_ENABLE_FPES=OFF -DSUPERCHIC_ENABLE_DOCS=OFF -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_Fortran_FLAGS="-O2 -g -ffree-line-length-512 -Wno-unused-label -Wno-integer-division -Wno-conversion -Wno-function-elimination -Wno-unused-variable -Wno-unused-parameter"
     ${CMAKE} --build BUILD --target install --parallel $(nproc)
     rm -rf BUILD share
 

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_LbyL.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_LbyL.dat
@@ -152,10 +152,18 @@
 ******  W+W- decays
 ****************************************************************************************
 'mu'    ! [wlp] : W+ leptonic channel (mu or el)
-'el'    ! [wlm] : W- leptoinc channel (mu or el)
+'el'    ! [wlm] : W- leptonic channel (mu or el)
 ****************************************************************************************
 ******  V+X simplified model
 ****************************************************************************************
 0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
 100d0    ! [mxs] : mass of MX
 ****************************************************************************************
+******  tau anomalous moments
+****************************************************************************************
+0d0     ! [atau] : magnetic dipole moment
+0d0     ! [dtau] : electric dipole moment [e cm]
+******  flags for calculating individual coeffs - SEE MANUAL for explanation
+.false. ! [calc_tau_coeff] : if true calculate  O(a_tau^n) or O(d_tau^n) coefficients
+'atau'  ! [tau_mom] : 'atau','dtau' - coeffecients for magnetic/electric dipole moments
+1       ! [tau_coeff] : order 'n' in coefficient (0-4)

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_dielectron.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_dielectron.dat
@@ -152,10 +152,18 @@
 ******  W+W- decays
 ****************************************************************************************
 'mu'    ! [wlp] : W+ leptonic channel (mu or el)
-'el'    ! [wlm] : W- leptoinc channel (mu or el)
+'el'    ! [wlm] : W- leptonic channel (mu or el)
 ****************************************************************************************
 ******  V+X simplified model
 ****************************************************************************************
 0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
 100d0    ! [mxs] : mass of MX
 ****************************************************************************************
+******  tau anomalous moments
+****************************************************************************************
+0d0     ! [atau] : magnetic dipole moment
+0d0     ! [dtau] : electric dipole moment [e cm]
+******  flags for calculating individual coeffs - SEE MANUAL for explanation
+.false. ! [calc_tau_coeff] : if true calculate  O(a_tau^n) or O(d_tau^n) coefficients
+'atau'  ! [tau_mom] : 'atau','dtau' - coeffecients for magnetic/electric dipole moments
+1       ! [tau_coeff] : order 'n' in coefficient (0-4)

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_dimuon.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_dimuon.dat
@@ -152,10 +152,18 @@
 ******  W+W- decays
 ****************************************************************************************
 'mu'    ! [wlp] : W+ leptonic channel (mu or el)
-'el'    ! [wlm] : W- leptoinc channel (mu or el)
+'el'    ! [wlm] : W- leptonic channel (mu or el)
 ****************************************************************************************
 ******  V+X simplified model
 ****************************************************************************************
 0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
 100d0    ! [mxs] : mass of MX
 ****************************************************************************************
+******  tau anomalous moments
+****************************************************************************************
+0d0     ! [atau] : magnetic dipole moment
+0d0     ! [dtau] : electric dipole moment [e cm]
+******  flags for calculating individual coeffs - SEE MANUAL for explanation
+.false. ! [calc_tau_coeff] : if true calculate  O(a_tau^n) or O(d_tau^n) coefficients
+'atau'  ! [tau_mom] : 'atau','dtau' - coeffecients for magnetic/electric dipole moments
+1       ! [tau_coeff] : order 'n' in coefficient (0-4)

--- a/bin/Superchic/production/PbPb_5p36TeV/superchic_ditau.dat
+++ b/bin/Superchic/production/PbPb_5p36TeV/superchic_ditau.dat
@@ -152,10 +152,18 @@
 ******  W+W- decays
 ****************************************************************************************
 'mu'    ! [wlp] : W+ leptonic channel (mu or el)
-'el'    ! [wlm] : W- leptoinc channel (mu or el)
+'el'    ! [wlm] : W- leptonic channel (mu or el)
 ****************************************************************************************
 ******  V+X simplified model
 ****************************************************************************************
 0.04d0   ! [tau] : mass distribution decay constant (GeV^-1)
 100d0    ! [mxs] : mass of MX
 ****************************************************************************************
+******  tau anomalous moments
+****************************************************************************************
+0d0     ! [atau] : magnetic dipole moment
+0d0     ! [dtau] : electric dipole moment [e cm]
+******  flags for calculating individual coeffs - SEE MANUAL for explanation
+.false. ! [calc_tau_coeff] : if true calculate  O(a_tau^n) or O(d_tau^n) coefficients
+'atau'  ! [tau_mom] : 'atau','dtau' - coeffecients for magnetic/electric dipole moments
+1       ! [tau_coeff] : order 'n' in coefficient (0-4)


### PR DESCRIPTION
This PR updates the SuperChic generator to version 5.4 as released recently in: https://github.com/LucianHL/SuperChic/releases/tag/v5.4

The new SuperChic v5.4 source package should be copied from:  https://anstahll.web.cern.ch/anstahll/superchic/SuperChic-5.4.tar.gz   to the generator directory:  https://cms-project-generators.web.cern.ch/cms-project-generators/superchic/

@bbilin 