### PR TITLE
Add Run3 pp 5.36TeV Powheg input cards

### DIFF
--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_10_50.input
@@ -1,0 +1,52 @@
+! Z production parameter
+vdecaymode 1      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 10      ! M Z > mass_low in GeV
+mass_high 50     ! M Z < mass_high in GeV	 
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_50.input
@@ -1,0 +1,51 @@
+! Z production parameter
+vdecaymode 1      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 50      ! M Z > mass_low in GeV
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_10_50.input
@@ -1,0 +1,52 @@
+! Z production parameter
+vdecaymode 2      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 10      ! M Z > mass_low in GeV
+mass_high 50     ! M Z < mass_high in GeV	 
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_50.input
@@ -1,0 +1,51 @@
+! Z production parameter
+vdecaymode 2      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 50      ! M Z > mass_low in GeV
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_10_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_10_50.input
@@ -1,0 +1,52 @@
+! Z production parameter
+vdecaymode 3      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 10      ! M Z > mass_low in GeV
+mass_high 50     ! M Z < mass_high in GeV	 
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_50.input
+++ b/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_50.input
@@ -1,0 +1,51 @@
+! Z production parameter
+vdecaymode 3      !(1:leptonic decay, 2:muonic decay, 3: tauonic decay,...)
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1          ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1 325300     ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300     ! pdf set for hadron 2 (LHA numbering)	
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000   ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   500000   ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  1        ! number of folds on csi integration
+foldy    1        ! number of folds on  y  integration
+foldphi  1        ! number of folds on phi integration
+nubound  50000    ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+iseed    SEED    ! initialize random number sequence 
+mass_low 50      ! M Z > mass_low in GeV
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876   ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955    ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 0, 

--- a/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdampDOWN_NNPDF31_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdampDOWN_NNPDF31_NNLO_inclusive.input
@@ -1,0 +1,83 @@
+! TTbar production parameters
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+ebeam1 2680d0  ! energy of beam 1
+ebeam2 2680d0  ! energy of beam 2
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 150.7305 ! 0.8738 x mtop, https://gitlab.cern.ch/cms-gen/Tuning/-/merge_requests/11
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into e l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass 0.1056583755 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/dmass   0.100 ! 
+tdec/umass   0.100 !
+tdec/smass   0.200 ! 
+tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+withnegweights 1    ! default 0
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdampUP_NNPDF31_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdampUP_NNPDF31_NNLO_inclusive.input
@@ -1,0 +1,83 @@
+! TTbar production parameters
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+ebeam1 2680d0  ! energy of beam 1
+ebeam2 2680d0  ! energy of beam 2
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 397.6125 ! 2.305 x mtop,  https://gitlab.cern.ch/cms-gen/Tuning/-/merge_requests/11 
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into e l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass 0.1056583755 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/dmass   0.100 ! 
+tdec/umass   0.100 !
+tdec/smass   0.200 ! 
+tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+withnegweights 1    ! default 0
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_NNPDF31_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_NNPDF31_NNLO_inclusive.input
@@ -1,0 +1,83 @@
+! TTbar production parameters
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+ebeam1 2680d0  ! energy of beam 1
+ebeam2 2680d0  ! energy of beam 2
+qmass  172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (top quark pole mass)
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 237.8775
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into e l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/twidth  1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass 0.1056583755 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/dmass   0.100 ! 
+tdec/umass   0.100 !
+tdec/smass   0.200 ! 
+tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+withnegweights 1    ! default 0
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_mtop166p5_NNPDF31_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_mtop166p5_NNPDF31_NNLO_inclusive.input
@@ -1,0 +1,83 @@
+! TTbar production parameters
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+ebeam1 2680d0  ! energy of beam 1
+ebeam2 2680d0  ! energy of beam 2
+qmass  166.5   ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 237.8775
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into e l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/twidth  1.173 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass 0.1056583755 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/dmass   0.100 ! 
+tdec/umass   0.100 !
+tdec/smass   0.200 ! 
+tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+withnegweights 1    ! default 0
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_mtop178p5_NNPDF31_NNLO_inclusive.input
+++ b/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_mtop178p5_NNPDF31_NNLO_inclusive.input
@@ -1,0 +1,83 @@
+! TTbar production parameters
+
+numevts NEVENTS
+iseed SEED
+ih1   1        ! hadron 1
+ih2   1        ! hadron 2
+
+
+! To be set only if using LHA pdfs
+lhans1 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2 325300  ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+ebeam1 2680d0  ! energy of beam 1
+ebeam2 2680d0  ! energy of beam 2
+qmass  178.5   ! mass of heavy quark in GeV
+facscfact 1    ! factorization scale factor: mufact=muref*facscfact 
+renscfact 1    ! renormalization scale factor: muren=muref*renscfact 
+
+hdamp 237.8775
+
+topdecaymode 22222   ! an integer of 5 digits that are either 0, or 2, representing in 
+                     ! the order the maximum number of the following particles(antiparticles)
+                     ! in the final state: e  mu tau up charm
+                     ! For example
+                     ! 22222    All decays (up to 2 units of everything)
+                     ! 20000    both top go into e l nu (with the appropriate signs)
+                     ! 10011    one top goes into electron (or positron), the other into (any) hadrons,
+                     !          or one top goes into charm, the other into up
+                     ! 00022    Fully hadronic
+                     ! 00002    Fully hadronic with two charms
+                     ! 00011    Fully hadronic with a single charm
+                     ! 00012    Fully hadronic with at least one charm
+
+
+! Parameters for the generation of spin correlations in t tbar decays
+tdec/wmass 80.377 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/wwidth 2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/bmass 4.78 ! ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2w 0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/twidth  1.498 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+tdec/emass 0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass 0.1056583755 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/dmass   0.100 ! 
+tdec/umass   0.100 !
+tdec/smass   0.200 ! 
+tdec/cmass   1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+tdec/sin2cabibbo 0.0506 ! 0.22500*0.22500, CKM_Vus in Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+! Parameters to allow-disallow use of stored data
+use-old-grid 1    ! if 1 use old grid if file pwggrids.dat is present (# 1: regenerate)
+use-old-ubound 1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; # 1: regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1 5        ! number of iterations for initializing the integration grid
+ncall2 500000  ! number of calls for computing the integral and finding upper bound
+itmx2 5        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1      ! number of folds on x integration
+foldy   1      ! number of folds on y integration
+foldphi 1      ! number of folds on phi integration
+nubound 500000  ! number of bbarra calls to setup norm of upper bounding function
+iymax 1        ! <= 10, normalization of upper bounding function in iunorm X iunorm square in y, log(m2qq)
+
+xupbound 2      ! increase upper bound for radiation generation
+
+pdfreweight 0
+storeinfo_rwgt 0    ! store weight information
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+withnegweights 1    ! default 0
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToENu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToENu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos   -24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   1     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToMuNu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToMuNu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos   -24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   2     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToTauNu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToTauNu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos   -24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   3     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToENu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToENu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos    24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   1     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToMuNu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToMuNu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos    24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   2     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToTauNu_NNPDF31.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToTauNu_NNPDF31.input
@@ -1,0 +1,61 @@
+! W boson production parameters
+idvecbos    24     ! PDG code for vector boson to be produced ( W+:24 W-:-24 )
+vdecaymode   3     ! code for selected W decay (1: electronic; 2: muonic; 3: tauonic)
+withdamp     1     ! (default 1, use) use Born-zero damping factor
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0      ! energy of beam 1
+ebeam2 2680d0      ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1  ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1  ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   500000    ! number of calls for initializing the integration grid
+itmx1    5         ! number of iterations for initializing the integration grid
+ncall2   500000    ! number of calls for computing the integral and finding upper bound
+itmx2    5         ! number of iterations for computing the integral and finding upper bound
+foldcsi  1         ! number of folds on csi integration
+foldy    1         ! number of folds on  y  integration
+foldphi  1         ! number of folds on phi integration
+nubound  50000     ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1         ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1         ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0       ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+
+renscfact  1d0     ! (default 1d0) ren scale factor: muren  = muref * renscfact
+facscfact  1d0     ! (default 1d0) fac scale factor: mufact = muref * facscfact
+iseed    SEED      ! initialize random number sequence
+
+alphaem 0.0072973525693 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2   0.23121    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zmass   91.1876    ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Zwidth  2.4955     ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+Wmass   80.377     ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+Wwidth  2.085      ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+cmass_lhe    1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthr     1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bmass_lhe    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+pdfreweight 0      ! PDF reweighting
+storeinfo_rwgt 0   ! store weight information
+withnegweights 1   ! default 0,

--- a/bin/Powheg/production/Run3/5p36TeV/WWTo2L2Nu/WWTo2L2Nu_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WWTo2L2Nu/WWTo2L2Nu_NNPDF31_5p36TeV.input
@@ -1,0 +1,43 @@
+! WW boson production parameters
+
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+leptonic 1
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1
+

--- a/bin/Powheg/production/Run3/5p36TeV/WWToLNu2Q/WWToLNu2Q_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WWToLNu2Q/WWToLNu2Q_NNPDF31_5p36TeV.input
@@ -1,0 +1,43 @@
+! WW boson production parameters
+
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+semileptonic 1
+renscfact  1   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1
+

--- a/bin/Powheg/production/Run3/5p36TeV/WZTo2L2Q/WZTo2L2Q_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WZTo2L2Q/WZTo2L2Q_NNPDF31_5p36TeV.input
@@ -1,0 +1,43 @@
+! WZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+hll 1
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed SEED
+
+pdfreweight 0
+storeinfo_rwgt 0
+withnegweights 1 

--- a/bin/Powheg/production/Run3/5p36TeV/WZTo3lNu/WZTo3lNu_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WZTo3lNu/WZTo3lNu_NNPDF31_5p36TeV.input
@@ -1,0 +1,43 @@
+! WZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+lll 1
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed SEED
+
+pdfreweight 0
+storeinfo_rwgt 0
+withnegweights 1 

--- a/bin/Powheg/production/Run3/5p36TeV/WZToLNu2Q/WZToLNu2Q_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/WZToLNu2Q/WZToLNu2Q_NNPDF31_5p36TeV.input
@@ -1,0 +1,43 @@
+! WZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bound
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+lhh 1
+
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed SEED
+
+pdfreweight 0
+storeinfo_rwgt 0
+withnegweights 1 

--- a/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_NNPDF31_5p36TeV.input
@@ -1,0 +1,42 @@
+! ZZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS   ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+leptons-nu 1
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1

--- a/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Q/ZZ_2L2Q_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Q/ZZ_2L2Q_NNPDF31_5p36TeV.input
@@ -1,0 +1,42 @@
+! ZZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS   ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+semileptonic 1
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1

--- a/bin/Powheg/production/Run3/5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_NNPDF31_5p36TeV.input
@@ -1,0 +1,42 @@
+! ZZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS   ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+hadrons-nu 1
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1

--- a/bin/Powheg/production/Run3/5p36TeV/ZZTo4L/ZZ_4L_NNPDF31_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/ZZTo4L/ZZ_4L_NNPDF31_5p36TeV.input
@@ -1,0 +1,42 @@
+! ZZ boson production parameters
+mllmin 4d0         ! default 0.1 GeV this is minimum invar mass for Z leptons
+
+numevts NEVENTS   ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300   ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+ncall1   1000000  ! number of calls for initializing the integration grid
+itmx1    5        ! number of iterations for initializing the integration grid
+ncall2   1000000  ! number of calls for computing the integral and finding upper bounds
+itmx2    5        ! number of iterations for computing the integral and finding upper bound
+foldcsi  2        ! number of folds on csi integration
+foldy    5        ! number of folds on  y  integration
+foldphi  2        ! number of folds on phi integration
+nubound  1000000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1        ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1        ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0      ! increase upper bound for radiation generation
+
+! OPTIONAL PARAMETERS
+leptonic 1
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact 
+
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+iseed    SEED    ! initialize random number sequence 
+
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0
+withnegweights 1

--- a/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p36TeV.input
@@ -1,0 +1,89 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 50000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       -1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
+                     ! primary-w-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 

--- a/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p36TeV.input
@@ -1,0 +1,89 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 50000   ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 50000   ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+wdecaymode 11111     ! decay mode: the 5 digits correspond to the following
+                     ! primary-w-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 

--- a/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p36TeV.input
@@ -1,0 +1,86 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000  ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 100000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       -1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 

--- a/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p36TeV.input
+++ b/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p36TeV.input
@@ -1,0 +1,86 @@
+! ST-wtchannel production parameters
+
+! GENERAL POWHEG PARAMETERS
+
+numevts NEVENTS    ! number of events to be generated
+ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 2680d0     ! energy of beam 1
+ebeam2 2680d0     ! energy of beam 2
+
+iseed    SEED    ! initialize random number sequence 
+
+! To be set only if using LHA pdfs
+lhans1   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+lhans2   325300    ! NNPDF31_nnlo_as_0118_mc_hessian_pdfas
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+ncall1 100000  ! number of calls for initializing the integration grid
+itmx1    5     ! number of iterations for initializing the integration grid
+ncall2 100000  ! number of calls for computing the integral and finding upper bound
+itmx2    5     ! number of iterations for computing the integral and finding upper bound
+foldcsi   5    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   1    ! number of folds on phi integration
+nubound 100000 ! number of bbarra calls to setup norm of upper bounding function
+icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
+iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
+xupbound 2d0   ! increase upper bound for radiation generation
+
+
+withdamp       1
+hdamp 237.8775
+
+
+! mandatory production parameters
+ttype       1          ! 1 for t, -1 for tbar
+
+
+! mandatory parameters used in decay generation
+topdecaymode 11111   ! decay mode: the 5 digits correspond to the following
+                     ! top-decay channels (l,mu,tau,u,c) 
+                     ! 0 means close, 1 open
+tdec/elbranching 0.1086 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+
+! optional production parameters 
+! (defaults defined in init_couplings.f)
+topmass      172.5   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+wmass        80.377  ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+sthw2        0.23121 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+alphaem_inv  137.035999084 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+topwidth     1.330 ! Eq. (72.1) http://pdg.lbl.gov/2017/reviews/rpp2017-rev-top-quark.pdf
+wwidth       2.085 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-gauge-higgs-bosons.pdf
+lhfm/cmass   1.67  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/bmass   4.78  ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+lhfm/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+lhfm/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+lhfm/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/emass   0.000510998950 ! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-phys-constants.pdf
+tdec/mumass  0.1056583755   ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+tdec/taumass 1.77686        ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-leptons.pdf
+charmthr     1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+charmthrpdf  1.67 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthr    4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+bottomthrpdf 4.78 ! https://pdg.lbl.gov/2023/tables/rpp2023-sum-quarks.pdf (pole mass)
+
+
+
+CKM_Vud   0.97435  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vus   0.22500  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vub   0.00369  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcd   0.22486  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcs   0.97349  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vcb   0.04182  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtd   0.00857  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vts   0.04110  ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+CKM_Vtb   0.999118 ! Table (12.27) https://pdg.lbl.gov/2023/reviews/rpp2023-rev-ckm-matrix.pdf
+
+
+
+pdfreweight 0       ! PDF reweighting
+dampreweight 0      ! h_damp reweighting (mt/2, mt, mt*2)
+storeinfo_rwgt 0    ! store weight information
+withnegweights 1 ! default 


### PR DESCRIPTION
This PR adds the Run3 pp reference at 5.36 TeV Powheg input cards for HIN PAG.
It includes DY, W and top production cards. They are similar to the input cards used for PbPb 5.36 TeV except that the PDF is changed to NNPDF31 (325300) as used in standard pp production.

@DickyChant @bbilin 