### PR TITLE
fixed the cards

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/JHUGen.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/JHUGen.input
@@ -1,1 +1,1 @@
-DecayMode1=8 DecayMode2=1
+DecayMode1=8 DecayMode2=1 WriteFailedEvents=2

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
@@ -1,8 +1,6 @@
 numevts NEVENTS
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
-#ndns1 131         ! pdf set for hadron 1 (mlm numbering)
-#ndns2 131         ! pdf set for hadron 2 (mlm numbering)
 ebeam1 6800     ! energy of beam 1
 ebeam2 6800    ! energy of beam 2
 
@@ -13,13 +11,13 @@ lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
 use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
 use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
 
-ncall1 50000   ! number of calls for initializing the integration grid
-itmx1  5    ! number of iterations for initializing the integration grid
-ncall2 50000    ! number of calls for computing the integral and finding upper bound
+ncall1 550000   ! number of calls for initializing the integration grid
+itmx1  7    ! number of iterations for initializing the integration grid
+ncall2 75000    ! number of calls for computing the integral and finding upper bound
 itmx2  5     ! number of iterations for computing the integral and finding upper bound
-foldcsi   1    ! number of folds on csi integration
-foldy     1    ! number of folds on  y  integration
-foldphi   1    ! number of folds on phi integration
+foldcsi   2    ! number of folds on csi integration
+foldy     5    ! number of folds on  y  integration
+foldphi   2    ! number of folds on phi integration
 nubound 50000  ! number of bbarra calls to setup norm of upper bounding function
 icsimax  1     ! <= 100, number of csi subdivision when computing the upper bounds
 iymax    1     ! <= 100, number of y subdivision when computing the upper bounds
@@ -40,11 +38,11 @@ iseed SEED
 ! **** Mandatory parameters for ALL models ****
 massren 0           ! Mass renormalization scheme. 0 = OS, 1 = MSBAR , 2 = DRBAR
 zerowidth 0         ! Control if the Higgs boson is to be produced on-shell or not: 1 = On-Shell; 0 = Off-shell with Breit-Wigner
-ew 0                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
+ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW corrections
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 1d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 
 ! **** Mandatory parameters for SM or MW ****
 hmass 125d0            ! Higgs boson mass
@@ -54,7 +52,7 @@ bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quar
 
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-#withnegweights 1 1
+#withnegweights 1
 #pdfreweight 0
 #storeinfo_rwgt 0
 bwshape 3 ! complex-pole scheme according to Passarino et al.

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
@@ -1,4 +1,4 @@
-numevts NEVENTS
+numevts NEVENTS    ! number of events to be generated
 ih1   1           ! hadron 1 (1 for protons, -1 for antiprotons)
 ih2   1           ! hadron 2 (1 for protons, -1 for antiprotons)
 ebeam1 6800     ! energy of beam 1
@@ -32,7 +32,7 @@ hfact    60.0d0    ! (default no dumping factor) dump factor for high-pt radiati
 runningscale 1    ! 0 = scales equal to the Higgs pole mass; 1  = scales equal to the Higgs virtuality;
                   ! 2 = scales equal to the Higgs pole mass for Born-like configuration and to the transverse mass for real emission contribution
 
-iseed SEED
+iseed    SEED    ! initialize random number sequence
 
 ! GGF_H production:
 ! **** Mandatory parameters for ALL models ****
@@ -52,9 +52,9 @@ bottommass 4.75d0    ! bottom quark mass - if defined it enables the bottom quar
 
 ! Optional
 hdecaywidth 0        ! If equals to 1 read total decay width from HDECAY sm.br2 file
-#withnegweights 1
-#pdfreweight 0
-#storeinfo_rwgt 0
+withnegweights 1
+pdfreweight 0       ! PDF reweighting
+storeinfo_rwgt 0    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.
 
 

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
@@ -56,14 +56,3 @@ withnegweights 1
 pdfreweight 0       ! PDF reweighting
 storeinfo_rwgt 0    ! store weight information
 bwshape 3 ! complex-pole scheme according to Passarino et al.
-
-
-#manyseeds 1
-
-#parallelstage 4
-
-#xgriditeration 1 1
-rwl_group_events 2000
-lhapdf6maxsets 50
-rwl_file 'pwg-rwl.dat'
-rwl_format_rwgt 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/ggHtoZZto2L2Q/gg_H_quark-mass-effects_ZZto2L2Q_NNPDF31_13p6TeV_M125.input
@@ -42,7 +42,7 @@ ew 1                ! ew = 0 disable EW corrections - ew = 1 enable EW correctio
 model 0
 gfermi 0.116637D-04        ! GF
 hdecaymode -1      ! PDG code for first decay product of the higgs
-masswindow 1d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
+masswindow 9999d0  !(default 10d0) number of widths around hmass in the BW for an off-shell Higgs boson
 
 ! **** Mandatory parameters for SM or MW ****
 hmass 125d0            ! Higgs boson mass


### PR DESCRIPTION
Dear GEN expert,

Already merged [PR](https://github.com/cms-sw/genproductions/pull/3794) of powheg cards are fixed according to the observed error and warning in the [gen_log](https://cms-pdmv-prod.web.cern.ch/mcm/restapi/requests/gen_log/HIG-Run3Summer22wmLHEGS-01407) while validating the sample.
Please have a look at your convenience and let me know and in case of any issues.

Thanks and regards,
Mohammad