### PR TITLE
changed PYTHIA fragment to reflect changes

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_2e2mu.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_2e2mu.py
@@ -30,12 +30,9 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
-            'BeamRemnants:primordialKT = off',
             'SpaceShower:pTdampMatch = 1',
             'SpaceShower:pTdampFudge = 0.85',
             'SpaceShower:MEcorrections = off',
-            'SpaceShower:alphaSvalue = 0.118',
-            'SpaceShower:alphaSorder = 2'
         ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',

--- a/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_4e.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_4e.py
@@ -30,12 +30,9 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
-            'BeamRemnants:primordialKT = off',
             'SpaceShower:pTdampMatch = 1',
             'SpaceShower:pTdampFudge = 0.85',
             'SpaceShower:MEcorrections = off',
-            'SpaceShower:alphaSvalue = 0.118',
-            'SpaceShower:alphaSorder = 2'
         ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',

--- a/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_4mu.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_4mu.py
@@ -30,12 +30,9 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
-            'BeamRemnants:primordialKT = off',
             'SpaceShower:pTdampMatch = 1',
             'SpaceShower:pTdampFudge = 0.85',
             'SpaceShower:MEcorrections = off',
-            'SpaceShower:alphaSvalue = 0.118',
-            'SpaceShower:alphaSorder = 2'
         ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',

--- a/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_nofilter.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_nofilter.py
@@ -30,12 +30,9 @@ generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
         pythia8CP5SettingsBlock,
         pythia8PSweightsSettingsBlock,
         processParameters = cms.vstring(
-            'BeamRemnants:primordialKT = off',
             'SpaceShower:pTdampMatch = 1',
             'SpaceShower:pTdampFudge = 0.85',
             'SpaceShower:MEcorrections = off',
-            'SpaceShower:alphaSvalue = 0.118',
-            'SpaceShower:alphaSorder = 2'
         ),
         parameterSets = cms.vstring('pythia8CommonSettings',
                                     'pythia8CP5Settings',


### PR DESCRIPTION
https://github.com/cms-sw/genproductions/pull/3781#event-15638132976 was merged prematurely, here is the correction. After working with Steve Mrenna, we turned the matrix-element corrections off.

Since MCFM+JHUGen gridpacks are separated by final state, this formulation of the PYTHIA filters separated by the 4-lepton final-state works for each given gridpack. You can see a presentation on this at an HZZ meeting here: 
https://indico.cern.ch/event/1433234/#38-mc-simulation-gluon-fusion.

There is no filter planned for tau decays - so electrons and muons will be the only ones with a filter applied. For tau decays, simply use the fragment without a filter (GluGluToZZTo4L_TuneCP5_13p6TeV-MCFM-jhugen7.5.2_nofilter.py).

The strings do not point to the path to the gridpack in cvmfs, since this setup will be used for many different configurations of anomalous couplings in off-shell gluon fusion production.

