### PR TITLE
Check_dag_success.py should run in python3 in master

### DIFF
--- a/bin/Powheg/check_dag_success.py
+++ b/bin/Powheg/check_dag_success.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import re
 


### PR DESCRIPTION
The master branch is, according to https://cms-gen.gitbook.io/cms-generator-central-place/how-to-produce-gridpacks/powheg-box, to be used with CMSSW_13, in which python 2 is not available anymore, so updating check_dag_success to use python3