### PR TITLE
Add Run3 pp 5.36TeV Powheg gen fragments

### DIFF
--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToEE_M_10_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToEE_M_10_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_10_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToEE_M_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToEE_M_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToEE_NNPDF31_MllBinned_M_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToMuMu_M_10_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToMuMu_M_10_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_10_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToMuMu_M_50-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToMuMu_M_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToMuMu_NNPDF31_MllBinned_M_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToTauTau_M_10_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToTauTau_M_10_50-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToTauTau_M_10_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_10_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToTauTau_M_50-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_DYToTauTau_M_50-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/Z_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_DYToTauTau_M_50.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/DYToLL/DYToTauTau_NNPDF31_MllBinned_M_50.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_TT_hvq-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/hvq_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_TT.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/TT_hvq/TT_hdamp_NNPDF31_NNLO_inclusive.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WWTo2L2Nu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WWTo2L2Nu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/WW_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WWTo2L2Nu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WWTo2L2Nu/WWTo2L2Nu_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WWToLNu2Q-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WWToLNu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/WW_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WWToLNu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WWToLNu2Q/WWToLNu2Q_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZTo2L2Q-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZTo2L2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/WZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WZTo2L2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WZTo2L2Q/WZTo2L2Q_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZTo3lNu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZTo3lNu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/WZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WZTo3lNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WZTo3lNu/WZTo3lNu_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZToLNu2Q-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WZToLNu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/WZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WZToLNu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WZToLNu2Q/WZToLNu2Q_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToENu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToENu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WmToENu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToENu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToMuNu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToMuNu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WmToMuNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToMuNu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToTauNu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WmToTauNu-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WmToTauNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WmToTauNu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToENu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToENu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WpToENu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToENu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToMuNu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToMuNu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WpToMuNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToMuNu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToTauNu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_WpToTauNu-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/W_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_WpToTauNu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/WToLNu/WpToTauNu_NNPDF31.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+            TauolaPolar,
+            TauolaDefaultInputCards
+        ),
+        parameterSets = cms.vstring('Tauola')
+    ),
+    UseExternalGenerators = cms.untracked.bool(True),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 1', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2L2Nu-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2L2Nu-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ZZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ZZ2L2Nu.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Nu/ZZ_2L2Nu_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2L2Q-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2L2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ZZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ZZ2L2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/ZZTo2L2Q/ZZ_2L2Q_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2Nu2Q-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo2Nu2Q-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ZZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ZZ2Nu2Q.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/ZZTo2Nu2Q/ZZ_2Nu2Q_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo4L-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_ZZTo4L-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ZZ_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ZZ4L.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/ZZTo4L/ZZ_4L_NNPDF31_5p36TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_antitop-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ST_wtch_DR_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ST_atop.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_antitop_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tW_5f_dr_ckm_top-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ST_wtch_DR_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ST_top.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/st_tW_5f_dr_ckm/ST_tW_DR_5f_ckm_top_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_antitop-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_antitop-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ST_tch_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ST_tch_atop.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_antitop_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_top-fragment.py
+++ b/genfragments/ppRef_5p36TeV/Powheg/POWHEG_st_tch_5f_ckm_top-fragment.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/Powheg/el8_amd64_gcc12/ST_tch_el8_amd64_gcc12_CMSSW_14_1_7_Run3_pp_5p36TeV_ST_tch_top.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(True)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/blob/master/bin/Powheg/production/Run3/5p36TeV/st_tch_5f_ckm/ST_tch_5f_ckm_top_5p35TeV.input
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PowhegEmissionVetoSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'POWHEG:nFinal = 2', ## Number of final state particles
+            ## (BEFORE THE DECAYS) in the LHE
+            ## other than emitted extra parton
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8PowhegEmissionVetoSettings',
+            'processParameters',
+            'pythia8PSweightsSettings',
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR adds the genfragments for official pp reference 5.36 TeV (Run3) production of Powheg generator in the directory: genfragments/ppRef_5p36TeV/Powheg .

The genfragments are created using as templates the central production Powheg genfragments for RunIII2024Summer24 defined in https://github.com/cms-PdmV/GridpackFiles/tree/master/Cards/Powheg .

@sarteagae @DickyChant @bbilin
