### PR TITLE
add 13p6TeV DiPhotonJetsBox1BJet (2BJet) card for Sherpa

### DIFF
--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_gg_jbb_Mgg80-13600
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_gg_jbb_Mgg80-13600
@@ -1,0 +1,68 @@
+(run){
+  EVENTS 1000;
+  EVENT_MODE HepMC;
+
+  ME_SIGNAL_GENERATOR Comix Internal;
+  EVENT_GENERATION_MODE Unweighted;
+
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+
+  CSS_EW_MODE 1;
+  ME_QED Off;
+}(run)
+
+(processes){
+
+  Process 93 93 -> 22 22 5 -5 93{1};
+  Order (*,2);
+  Enhance_Factor 5 {4};
+  Enhance_Factor 10 {5};
+  CKKW sqr(20./E_CMS);
+  Integration_Error 0.03 {4};
+  Integration_Error 0.05 {5};
+  End process;
+
+  Process 93 93 -> 22 22 5 5 93{1};
+  Order (*,2);
+  Enhance_Factor 5 {4};
+  Enhance_Factor 10 {5};
+  CKKW sqr(20./E_CMS);
+  Integration_Error 0.03 {4};
+  Integration_Error 0.05 {5};
+  End process;
+
+  Process 93 93 -> 22 22 -5 -5 93{1};
+  Order (*,2);
+  Enhance_Factor 5 {4};
+  Enhance_Factor 10 {5};
+  CKKW sqr(20./E_CMS);
+  Integration_Error 0.03 {4};
+  Integration_Error 0.05 {5};
+  End process;
+
+
+}(processes)
+
+(selector){
+  Mass  22 22 80. E_CMS.;
+  PT 22 10. E_CMS;
+  PT 5 10. E_CMS;
+  PT -5 10. E_CMS;
+  PT 93 10. E_CMS;
+  DeltaR 22 22 0.3 10
+  DeltaR 93 93 0.3 10
+  DeltaR 22 5 0.3 10
+  DeltaR 22 -5 0.3 10
+  DeltaR 5 -5 0.1 10
+  DeltaR 5 93 0.1 10
+  DeltaR -5 93 0.1 10
+  PseudoRapidity 93 -6 6
+
+}(selector)
+

--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_ggbjj_Mgg80-13600
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_13p6TeV_ggbjj_Mgg80-13600
@@ -1,0 +1,63 @@
+(run){
+  EVENTS 1000;
+  EVENT_MODE HepMC;
+
+  ME_SIGNAL_GENERATOR Comix Internal;
+  EVENT_GENERATION_MODE Unweighted;
+
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+
+  CSS_EW_MODE 1;
+  ME_QED Off;
+}(run)
+
+(processes){
+
+  Process 93 93 -> 22 22  5 93{2};
+  Order (*,2);
+  Enhance_Factor 2 {3};
+  Enhance_Factor 5 {4};
+  Enhance_Factor 10 {5};
+  CKKW sqr(20./E_CMS);
+  Integration_Error 0.005 {3};
+  Integration_Error 0.03 {4};
+  Integration_Error 0.05 {5};
+  End process;
+
+  Process 93 93 -> 22 22 -5 93{2};
+  Order (*,2);
+  Enhance_Factor 2 {3};
+  Enhance_Factor 5 {4};
+  Enhance_Factor 10 {5};
+  CKKW sqr(20./E_CMS);
+  Integration_Error 0.005 {3};
+  Integration_Error 0.03 {4};
+  Integration_Error 0.05 {5};
+  End process;
+
+
+}(processes)
+
+(selector){
+  Mass  22 22 80. E_CMS.;
+  PT 22 10. E_CMS;
+  PT 5 10. E_CMS;
+  PT -5 10. E_CMS;
+  PT 93 10. E_CMS;
+  DeltaR 22 22 0.3 10
+  DeltaR 93 93 0.3 10
+  DeltaR 22 5 0.3 10
+  DeltaR 22 -5 0.3 10
+  DeltaR 5 -5 0.1 10
+  DeltaR 5 93 0.1 10
+  DeltaR -5 93 0.1 10
+  PseudoRapidity 93 -6 6
+
+}(selector)
+


### PR DESCRIPTION
In this request, we add the card for 13p6TeV Sherpa process DiPhotonJetsBox1BJet_MGG-80toInf and DiPhotonJetsBox2BJets_MGG-80toInf in which we simply change the beam energy based on the Run2 13TeV card.