### PR TITLE
Fix check_dataset_names script for bcvegpy2-pythia8-evtgen generators

### DIFF
--- a/bin/utils/check_dataset_names.py
+++ b/bin/utils/check_dataset_names.py
@@ -35,7 +35,7 @@ def validate_dataset_name(dataset_name):
     r"amcatnloFXFX-madspin|amcatnlo|amcatnlo-madspin|alpgen|mcatnlo|powheg|"
     r"powheg-madspin|powheg-JHUGenV\d*|powheg-minlo|powheg-minnlo|powheg-minlo-JHUGenV\d*|"
     r"powheg-minnlo-JHUGen\d*|JHUGen|hardcol|bcvegpy2)"
-    r"-(pythia6|pythia8|herwig6|herwigpp|herwig7))"
+    r"-(pythia6|pythia8|pythia8-evtgen|herwig6|herwigpp|herwig7))"
     )
     blocks = dataset_name.split('_')
 


### PR DESCRIPTION
Dear colleagues, 

I've found that the current version of check_dataset_names.py script does not allows names which uses the following generators: "bcvegpy2-pythia8-evtgen". 
For e.g. for "BcToJpsiPi_TuneCP5_13p6TeV_bcvegpy2-pythia8-evtgen" I got "--Invalid ME-PS format" error. 

I suggest a minor fix to the script to allow it supports the names with these generators. The local check with the example above solves the problem. 

Best,
Kirill