### PR TITLE
add ggHH HEFT cards

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_0p00_kt_1p00_c2_0p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_0p00_kt_1p00_c2_0p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      0.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_0p00_kt_1p00_c2_1p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_0p00_kt_1p00_c2_1p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      0.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       1.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      1.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p10.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p10.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      1.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.1       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p35.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_0p35.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      1.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.35      ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_3p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_3p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      1.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       3.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_m2p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_1p00_kt_1p00_c2_m2p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      1.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       -2.0      ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_2p45_kt_1p00_c2_0p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_2p45_kt_1p00_c2_0p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      2.45      ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_5p00_kt_1p00_c2_0p00.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_5p00_kt_1p00_c2_0p00.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      5.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       0.0       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1

--- a/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_m20p00_kt_1p00_c2_2p24.input
+++ b/bin/Powheg/production/Run3/13p6TeV/Higgs/HH_EFT/HEFT/kl_kt_c2_original_basis/powheg_ggHH_kl_m20p00_kt_1p00_c2_2p24.input
@@ -1,0 +1,117 @@
+! ggHH production parameters:
+mtdep 3
+!                      1: Born improved HEFT
+!                      2: approximated full theory (FTapprox)
+!                      3: full theory
+
+hmass 125            ! Higgs boson mass
+topmass 173          ! top quark mass (THIS VALUE IS HARD CODED IN THE VIRTUAL
+                     ! MATRIX ELEMENT AND FOR CONSISTENCY HAS NOT TO BE CHANGED WHEN
+                     ! RUNNING FULL THEORY PREDICTIONS - i.e. mtdep 1
+hdecaymode -1        ! PDG code for Higgs boson decay products (it affects only the SMC)
+!                      allowed values are:
+!                      0 all decay channels open
+!                      1-6 d dbar, u ubar,..., t tbar (as in HERWIG)
+!                      7-9 e+ e-, mu+ mu-, tau+ tau-
+!                      10  W+W-
+!                      11  ZZ
+!                      12  gamma gamma
+!                      -1  all decay channels closed
+
+! Values of the Higgs couplings w.r.t SM
+chhh      -20.0       ! Trilinear Higgs self-coupling
+ct        1.0       ! Top-Higgs Yukawa coupling
+ctt       2.24       ! Two-top-two-Higgs (tthh) coupling
+cggh      0.0       ! Effective gluon-gluon-Higgs coupling
+cgghh     0.0       ! Effective two-gluon-two-Higgses coupling
+
+
+! general parameters:
+numevts NEVENTS        ! number of events to be generated
+ih1         1        ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2         1        ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800     ! energy of beam 1
+ebeam2 6800    ! energy of beam 2
+! To be set only if using LHA pdfs
+lhans1 325300       ! pdf set for hadron 1 (LHA numbering)
+lhans2 325300       ! pdf set for hadron 2 (LHA numbering)
+! To be set only if using internal mlm pdf
+# ndns1 131          ! pdf set for hadron 1 (mlm numbering)
+# ndns2 131          ! pdf set for hadron 2 (mlm numbering)
+! To be set only if using different pdf sets for the two incoming hadrons
+! QCDLambda5 0.25    ! for not equal pdf sets
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1    ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1    ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+!
+ncall1  10000        ! number of calls for initializing the integration grid
+itmx1       3        ! number of iterations for initializing the integration grid
+ncall2  10000        ! number of calls for computing the integral and finding upper bound
+itmx2       3        ! number of iterations for computing the integral and finding upper bound
+foldcsi     1        ! number of folds on csi integration
+foldy       1        ! number of folds on  y  integration
+foldphi     1        ! number of folds on phi integration
+nubound 15000        ! number of bbarra calls to setup norm of upper bounding function
+# icsimax   1        ! <= 100, number of csi subdivision when computing the upper bounds
+# iymax     1        ! <= 100, number of y subdivision when computing the upper bounds
+# xupbound 2d0       ! increase upper bound for radiation generation
+
+
+! OPTIONAL PARAMETERS
+
+! scale settings:
+#fixedscale   1      ! (dafault 0) fixed scale uses muren = mufac = 2*m_H
+facscfact   1d0      ! (default 1d0) fac scale factor: mufact = muref * facscfact, muref=mHH/2
+renscfact   1d0      ! (default 1d0) ren scale factor: muren  = muref * renscfact, muref=mHH/2
+
+! Born, plots and powheg strategy:
+bornonly          0  ! (default 0) if 1 do Born only
+LOevents          0  !
+#testplots 1
+fastbtlbound      1  ! fast evaluation of Btilde upper bounds
+storemintupb      1  ! store function calls in binary file for more precise generation
+ubexcess_correct  1  ! corrects for error in upper bound estimate
+storeinfo_rwgt    1  ! store info to allow for reweighting
+compute_rwgt      0  ! store info to allow for reweighting
+softtest          0  ! no check of the soft limit in the real
+colltest          0  ! no check of the collinear limit in the real
+
+! PARAMETERS needed for ggHH
+hdamp           250
+
+! PARAMETERS for parallel runnning
+! - non parallel (for testing purposes only)
+iseed SEED           !  Start the random number generator with seed iseed
+#rand1     0         !  skipping  rand2*100000000+rand1 numbers.
+#rand2     0         !  (see RM48 short writeup in CERNLIB)
+
+! - parallel
+manyseeds 1          ! Used to perform multiple runs with different random
+                     ! seeds in the same directory.
+                     ! If set to 1, the program asks for an integer j;
+                     ! The file pwgseeds.dat at line j is read, and the
+                     ! integer at line j is used to initialize the random
+                     ! sequence for the generation of the event.
+                     ! The event file is called pwgevents-'j'.lhe
+parallelstage 4
+xgriditeration 0
+maxseeds    9999
+
+! PARAMETERS for reweighting
+# rwl_file 'reweight_setup.xml'  https://github.com/alisw/POWHEG
+# rwl_file         'pwg-rwl.dat'
+# rwl_format_rwgt  1
+# rwl_add          1
+# rwl_group_events 2000
+# lhapdf6maxsets 30
+
+
+! PARAMETERS for Pythia8
+#py8tune  xxx
+#py8hepmc 1
+#py8nohad 1
+#py8nompi 1
+
+check_bad_st1 1
+check_bad_st2 1


### PR DESCRIPTION
Cards for ggHH HEFT production targetting early run3 results. The cards are copies of run2 ones, changing the basis to allow smooth HEFT/c2 scans and CM energy

The powheg model used was: ggHH