### PR TITLE
Added JPsiToEE run3 fragments

### DIFF
--- a/genfragments/ThirteenPointSixTeV/JPsi/JPsiToEE_pth0To10_TuneCP5_13p6TeV-pythia.py
+++ b/genfragments/ThirteenPointSixTeV/JPsi/JPsiToEE_pth0To10_TuneCP5_13p6TeV-pythia.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+                                 comEnergy = cms.double(13600.0),
+                                 filterEfficiency = cms.untracked.double(1.0),
+                                 maxEventsToPrint = cms.untracked.int32(0),
+                                 pythiaPylistVerbosity = cms.untracked.int32(0),
+                                 pythiaHepMCVerbosity = cms.untracked.bool(False),
+                                 PythiaParameters = cms.PSet(
+
+    pythia8CommonSettingsBlock,
+    pythia8CP5SettingsBlock,
+    pythia8PSweightsSettingsBlock,
+    processParameters = cms.vstring(
+      'Main:timesAllowErrors    = 10000',
+      'Charmonium:gg2ccbar(3S1)[3S1(1)]g    = on,on',
+      'Charmonium:gg2ccbar(3S1)[3S1(1)]gm   = on,on',
+      'Charmonium:gg2ccbar(3S1)[3S1(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[3S1(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[3S1(8)]g = on,on',
+      'Charmonium:gg2ccbar(3S1)[1S0(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[1S0(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[1S0(8)]g = on,on',
+      'Charmonium:gg2ccbar(3S1)[3PJ(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[3PJ(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[3PJ(8)]g = on,on',
+      'PhaseSpace:pTHatMax = 10.',
+      '443:onMode = off',
+      '443:onIfMatch = 11 -11',
+      '100443:onMode = off',
+      '100443:onIfMatch = 11 -11',
+      ),
+
+    parameterSets = cms.vstring(
+      'pythia8CommonSettings',
+      'pythia8CP5Settings',
+      'pythia8PSweightsSettings',
+      'processParameters')
+    )
+)
+
+
+ProductionFilterSequence = cms.Sequence(generator)
+

--- a/genfragments/ThirteenPointSixTeV/JPsi/JPsiToEE_pth10ToInf_TuneCP5_13p6TeV-pythia.py
+++ b/genfragments/ThirteenPointSixTeV/JPsi/JPsiToEE_pth10ToInf_TuneCP5_13p6TeV-pythia.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+                                 comEnergy = cms.double(13600.0),
+                                 filterEfficiency = cms.untracked.double(1.0),
+                                 maxEventsToPrint = cms.untracked.int32(0),
+                                 pythiaPylistVerbosity = cms.untracked.int32(0),
+                                 pythiaHepMCVerbosity = cms.untracked.bool(False),
+                                 PythiaParameters = cms.PSet(
+
+    pythia8CommonSettingsBlock,
+    pythia8CP5SettingsBlock,
+    pythia8PSweightsSettingsBlock,
+    processParameters = cms.vstring(
+      'Main:timesAllowErrors    = 10000',
+      'Charmonium:gg2ccbar(3S1)[3S1(1)]g    = on,on',
+      'Charmonium:gg2ccbar(3S1)[3S1(1)]gm   = on,on',
+      'Charmonium:gg2ccbar(3S1)[3S1(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[3S1(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[3S1(8)]g = on,on',
+      'Charmonium:gg2ccbar(3S1)[1S0(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[1S0(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[1S0(8)]g = on,on',
+      'Charmonium:gg2ccbar(3S1)[3PJ(8)]g    = on,on',
+      'Charmonium:qg2ccbar(3S1)[3PJ(8)]q    = on,on',
+      'Charmonium:qqbar2ccbar(3S1)[3PJ(8)]g = on,on',
+      'PhaseSpace:pTHatMin = 10.',
+      '443:onMode = off',
+      '443:onIfMatch = 11 -11',
+      '100443:onMode = off',
+      '100443:onIfMatch = 11 -11',
+      ),
+
+    parameterSets = cms.vstring(
+      'pythia8CommonSettings',
+      'pythia8CP5Settings',
+      'pythia8PSweightsSettings',
+      'processParameters')
+    )
+)
+
+
+ProductionFilterSequence = cms.Sequence(generator)
+


### PR DESCRIPTION
This PR contains fragments for the production of JPsi To EE run 3 samples in 2 different ptHat bins ([0,10], [10,inf]) needed for the run3 DarkPhotonToEE analysis [1] and for EGamma object studies [2].

The production of these samples was already requested by the EXO MCI group [3] but due to a missing comma at the end of line 31, the produced samples contain inclusive jpsi decays instead of electron decays only and without any constraint on the pThat.

This PR contains the fixed fragments, as requested by the conveners.
I already checked that these new fragments produce electron decay only.

[1] https://indico.cern.ch/event/1446626/contributions/6108666/attachments/2929094/5143392/EXO%20Meeting%20-%20Dielectron%20resonance%20search.pdf
[2] https://indico.cern.ch/event/1479781/contributions/6242375/attachments/2977195/5241576/X2ee_EGM_20241129-1.pdf
[3] https://gitlab.cern.ch/cms-exo-mci/EXO-MCsampleRequests/-/merge_requests/305