### PR TITLE
Run2 LQ_S1 Signal MG5 Cards

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card lqparam ms1 500
+set param_card mass 9000005 500

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_extramodels.dat
@@ -1,0 +1,1 @@
+LO_LQ_S1_runningPtclWidth.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_proc_card.dat
@@ -1,0 +1,36 @@
+import model LO_LQ_S1_runningPtclWidth-yLL3x1_0pt01
+
+define top1 = t t~
+define top2 = t t~
+define bottom = b b~
+
+define ele = e+ e-
+define mu = mu+ mu-
+define tau = ta+ ta-
+define eletau = e+ e- ta+ ta-
+define mutau = mu+ mu- ta+ ta-
+define lep = ele
+
+define p = p b b~
+
+define nuele = ve ve~
+define numu = vm vm~
+define nutau = vt vt~
+define nueletau = ve ve~ vt vt~
+define numutau = vm vm~ vt vt~
+define nu = nuele
+
+define Wboson1 = w+ w-
+define Wboson2 = w+ w-
+
+define q5 = u u~ d d~ s s~ c c~ b b~
+
+define l3 = ele mu tau
+define nu3 = nuele numu nutau
+
+generate    p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > l3 nu3)), (top2 > bottom Wboson2, (Wboson2 > l3 nu3)) QCD=2 QED=2 NP>0 @0 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > q5 q5)),  (top2 > bottom Wboson2, (Wboson2 > l3 nu3)) QCD=2 QED=2 NP>0 @1 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > l3 nu3)), (top2 > bottom Wboson2, (Wboson2 > q5 q5))  QCD=2 QED=2 NP>0 @2 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > q5 q5)),  (top2 > bottom Wboson2, (Wboson2 > q5 q5))  QCD=2 QED=2 NP>0 @3 
+
+output S1LQ_TLTL_ele_M-500_yukL-0pt01

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_run_card.dat
@@ -1,0 +1,273 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  25000	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'             = pdlabel      ! PDF set                                  
+ $DEFAULT_PDF_SETS    = lhaid        ! if pdlabel=lhapdf, this is the lhapdf number 
+ $DEFAULT_PDF_MEMBERS = reweight_PDF ! reweight to get PDF uncertainty
+#*********************************************************************
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False	= gridpack !True = setting up the grid pack
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  0	= ickkw ! 0 no matching, 1 MLM
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  10.0	= ptj ! minimum pt for the jets 
+  10.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  10.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0	= ej ! minimum E for the jets 
+  0.0	= eb ! minimum E for the b 
+  0.0	= ea ! minimum E for the photons 
+  0.0	= el ! minimum E for the charged leptons 
+  -1.0	= ejmax ! maximum E for the jets
+  -1.0	= ebmax ! maximum E for the b
+  -1.0	= eamax ! maximum E for the photons
+  -1.0	= elmax ! maximum E for the charged leptons
+  {}	= e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0	= etaj ! max rap for the jets 
+  5.0	= etab ! max rap for the b
+  5.0	= etaa ! max rap for the photons 
+  5.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.0	= drll ! min distance between leptons 
+  0.0	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.0	= draj ! min distance between gamma and jet 
+  0.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.0	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  0.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  0.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  10.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21, 9000005	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLQ5L_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLQ5L_proc_card.dat
@@ -1,0 +1,32 @@
+import model LO_LQ_S1_runningPtclWidth-LQYUK_YUKVALUE
+
+define top = t t~
+define bottom = b b~
+
+define ele = e+ e-
+define mu = mu+ mu-
+define tau = ta+ ta-
+define eletau = e+ e- ta+ ta-
+define mutau = mu+ mu- ta+ ta-
+define lep = LEPF
+
+define p = p b b~
+
+define nuele = ve ve~
+define numu = vm vm~
+define nutau = vt vt~
+define nueletau = ve ve~ vt vt~
+define numutau = vm vm~ vt vt~
+define nu = NUF
+
+define Wboson = w+ w-
+
+define q5 = u u~ d d~ s s~ c c~ b b~
+
+define l3 = ele mu tau
+define nu3 = nuele numu nutau
+
+generate    p p > top lep q5 lep, (top > bottom Wboson, (Wboson > l3 nu3)) QCD=2 QED=2 NP>0 @0
+add process p p > top lep q5 lep, (top > bottom Wboson, (Wboson > q5 q5))  QCD=2 QED=2 NP>0 @1
+
+output LQOUTPUT

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLQ5N_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLQ5N_proc_card.dat
@@ -1,0 +1,32 @@
+import model LO_LQ_S1_runningPtclWidth-LQYUK_YUKVALUE
+
+define top = t t~
+define bottom = b b~
+
+define ele = e+ e-
+define mu = mu+ mu-
+define tau = ta+ ta-
+define eletau = e+ e- ta+ ta-
+define mutau = mu+ mu- ta+ ta-
+define lep = LEPF
+
+define p = p b b~
+
+define nuele = ve ve~
+define numu = vm vm~
+define nutau = vt vt~
+define nueletau = ve ve~ vt vt~
+define numutau = vm vm~ vt vt~
+define nu = NUF
+
+define Wboson = w+ w-
+
+define q5 = u u~ d d~ s s~ c c~ b b~
+
+define l3 = ele mu tau
+define nu3 = nuele numu nutau
+
+generate    p p > top lep q5 nu, (top > bottom Wboson, (Wboson > l3 nu3)) QCD=2 QED=2 NP>0 @0
+add process p p > top lep q5 nu, (top > bottom Wboson, (Wboson > q5 q5))  QCD=2 QED=2 NP>0 @1
+
+output LQOUTPUT

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLTL_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_TLTL_proc_card.dat
@@ -1,0 +1,36 @@
+import model LO_LQ_S1_runningPtclWidth-LQYUK_YUKVALUE
+
+define top1 = t t~
+define top2 = t t~
+define bottom = b b~
+
+define ele = e+ e-
+define mu = mu+ mu-
+define tau = ta+ ta-
+define eletau = e+ e- ta+ ta-
+define mutau = mu+ mu- ta+ ta-
+define lep = LEPF
+
+define p = p b b~
+
+define nuele = ve ve~
+define numu = vm vm~
+define nutau = vt vt~
+define nueletau = ve ve~ vt vt~
+define numutau = vm vm~ vt vt~
+define nu = NUF
+
+define Wboson1 = w+ w-
+define Wboson2 = w+ w-
+
+define q5 = u u~ d d~ s s~ c c~ b b~
+
+define l3 = ele mu tau
+define nu3 = nuele numu nutau
+
+generate    p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > l3 nu3)), (top2 > bottom Wboson2, (Wboson2 > l3 nu3)) QCD=2 QED=2 NP>0 @0 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > q5 q5)),  (top2 > bottom Wboson2, (Wboson2 > l3 nu3)) QCD=2 QED=2 NP>0 @1 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > l3 nu3)), (top2 > bottom Wboson2, (Wboson2 > q5 q5))  QCD=2 QED=2 NP>0 @2 
+add process p p > top1 lep top2 lep, (top1 > bottom Wboson1, (Wboson1 > q5 q5)),  (top2 > bottom Wboson2, (Wboson2 > q5 q5))  QCD=2 QED=2 NP>0 @3 
+
+output LQOUTPUT

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card lqparam ms1 LQMASS
+set param_card mass 9000005 LQMASS

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_extramodels.dat
@@ -1,0 +1,1 @@
+LO_LQ_S1_runningPtclWidth.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/S1LQ_run_card.dat
@@ -1,0 +1,273 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1	= run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  N_EVENTS	= nevents ! Number of unweighted events requested 
+  0	= iseed ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+  1	= lpp1 ! beam 1 type 
+  1	= lpp2 ! beam 2 type
+  6500.0	= ebeam1 ! beam 1 total energy in GeV
+  6500.0	= ebeam2 ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'             = pdlabel      ! PDF set                                  
+ $DEFAULT_PDF_SETS    = lhaid        ! if pdlabel=lhapdf, this is the lhapdf number 
+ $DEFAULT_PDF_MEMBERS = reweight_PDF ! reweight to get PDF uncertainty
+#*********************************************************************
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+  False	= fixed_ren_scale ! if .true. use fixed ren scale
+  False	= fixed_fac_scale ! if .true. use fixed fac scale
+  91.188	= scale ! fixed ren scale
+  91.188	= dsqrt_q2fact1 ! fixed fact scale for pdf1
+  91.188	= dsqrt_q2fact2 ! fixed fact scale for pdf2
+  -1	= dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0	= scalefact ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False	= gridpack !True = setting up the grid pack
+  -1.0	= time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0	= lhe_version ! Change the way clustering information pass to shower.        
+  True	= clusinfo ! include clustering tag in output
+  average	= event_norm ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+  0	= ickkw ! 0 no matching, 1 MLM
+  1.0	= alpsfact ! scale factor for QCD emission vx
+  False	= chcluster ! cluster only according to channel diag
+  5	= asrwgtflavor ! highest quark flavor for a_s reweight
+  False	= auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes) 
+  0.0	= xqcut ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+  0	= nhel ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+  None	= bias_module ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+  {}	= bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0	= bwcutoff ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+  False	= cut_decays ! Cut decay products 
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  10.0	= ptj ! minimum pt for the jets 
+  10.0	= ptb ! minimum pt for the b 
+  10.0	= pta ! minimum pt for the photons 
+  10.0	= ptl ! minimum pt for the charged leptons 
+  0.0	= misset ! minimum missing Et (sum of neutrino's momenta)
+  -1.0	= ptjmax ! maximum pt for the jets
+  -1.0	= ptbmax ! maximum pt for the b
+  -1.0	= ptamax ! maximum pt for the photons
+  -1.0	= ptlmax ! maximum pt for the charged leptons
+  -1.0	= missetmax ! maximum missing Et (sum of neutrino's momenta)
+  {}	= pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0	= ej ! minimum E for the jets 
+  0.0	= eb ! minimum E for the b 
+  0.0	= ea ! minimum E for the photons 
+  0.0	= el ! minimum E for the charged leptons 
+  -1.0	= ejmax ! maximum E for the jets
+  -1.0	= ebmax ! maximum E for the b
+  -1.0	= eamax ! maximum E for the photons
+  -1.0	= elmax ! maximum E for the charged leptons
+  {}	= e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+  5.0	= etaj ! max rap for the jets 
+  5.0	= etab ! max rap for the b
+  5.0	= etaa ! max rap for the photons 
+  5.0	= etal ! max rap for the charged leptons 
+  0.0	= etajmin ! min rap for the jets
+  0.0	= etabmin ! min rap for the b
+  0.0	= etaamin ! min rap for the photons
+  0.0	= etalmin ! main rap for the charged leptons
+  {}	= eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+  {}	= eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0	= drjj ! min distance between jets 
+  0.0	= drbb ! min distance between b's 
+  0.0	= drll ! min distance between leptons 
+  0.0	= draa ! min distance between gammas 
+  0.0	= drbj ! min distance between b and jet 
+  0.0	= draj ! min distance between gamma and jet 
+  0.0	= drjl ! min distance between jet and lepton 
+  0.0	= drab ! min distance between gamma and b 
+  0.0	= drbl ! min distance between b and lepton 
+  0.0	= dral ! min distance between gamma and lepton 
+  -1.0	= drjjmax ! max distance between jets
+  -1.0	= drbbmax ! max distance between b's
+  -1.0	= drllmax ! max distance between leptons
+  -1.0	= draamax ! max distance between gammas
+  -1.0	= drbjmax ! max distance between b and jet
+  -1.0	= drajmax ! max distance between gamma and jet
+  -1.0	= drjlmax ! max distance between jet and lepton
+  -1.0	= drabmax ! max distance between gamma and b
+  -1.0	= drblmax ! max distance between b and lepton
+  -1.0	= dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *           
+#*********************************************************************
+  0.0	= mmjj ! min invariant mass of a jet pair 
+  0.0	= mmbb ! min invariant mass of a b pair 
+  0.0	= mmaa ! min invariant mass of gamma gamma pair
+  0.0	= mmll ! min invariant mass of l+l- (same flavour) lepton pair
+  -1.0	= mmjjmax ! max invariant mass of a jet pair
+  -1.0	= mmbbmax ! max invariant mass of a b pair
+  -1.0	= mmaamax ! max invariant mass of gamma gamma pair
+  -1.0	= mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+  {}	= mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+  {'default': False}	= mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  10.0	= mmnl ! min invariant mass for all letpons (l+- and vl) 
+  -1.0	= mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0	= ptllmin ! Minimum pt for 4-momenta sum of leptons(l and vl)
+  -1.0	= ptllmax ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+  0.0	= ptheavy ! minimum pt for at least one heavy final state
+  0.0	= xptj ! minimum pt for at least one jet  
+  0.0	= xptb ! minimum pt for at least one b 
+  0.0	= xpta ! minimum pt for at least one photon 
+  0.0	= xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0	= ptj1min ! minimum pt for the leading jet in pt
+  0.0	= ptj2min ! minimum pt for the second jet in pt
+  0.0	= ptj3min ! minimum pt for the third jet in pt
+  0.0	= ptj4min ! minimum pt for the fourth jet in pt
+  -1.0	= ptj1max ! maximum pt for the leading jet in pt 
+  -1.0	= ptj2max ! maximum pt for the second jet in pt
+  -1.0	= ptj3max ! maximum pt for the third jet in pt
+  -1.0	= ptj4max ! maximum pt for the fourth jet in pt
+  0	= cutuse ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0	= ptl1min ! minimum pt for the leading lepton in pt
+  0.0	= ptl2min ! minimum pt for the second lepton in pt
+  0.0	= ptl3min ! minimum pt for the third lepton in pt
+  0.0	= ptl4min ! minimum pt for the fourth lepton in pt
+  -1.0	= ptl1max ! maximum pt for the leading lepton in pt 
+  -1.0	= ptl2max ! maximum pt for the second lepton in pt
+  -1.0	= ptl3max ! maximum pt for the third lepton in pt
+  -1.0	= ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0	= htjmin ! minimum jet HT=Sum(jet pt)
+  -1.0	= htjmax ! maximum jet HT=Sum(jet pt)
+  0.0	= ihtmin !inclusive Ht for all partons (including b)
+  -1.0	= ihtmax !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+  -1.0	= ht2max ! maximum Ht for the two leading jets
+  -1.0	= ht3max ! maximum Ht for the three leading jets
+  -1.0	= ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0	= ptgmin ! Min photon transverse momentum
+  0.4	= r0gamma ! Radius of isolation code
+  1.0	= xn ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0	= epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+  True	= isoem ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+  0.0	= xetamin ! minimum rapidity for two jets in the WBF case  
+  0.0	= deltaeta ! minimum rapidity for two jets in the WBF case 
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+  -1.0	= ktdurham 
+  0.4	= dparameter 
+  -1.0	= ptlund 
+  1, 2, 3, 4, 5, 6, 21, 9000005	= pdgs_for_merging_cut ! PDGs for two cuts above   
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+  5	= maxjetflavor ! Maximum jet pdg code
+#*********************************************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/makeCards_LQ.py
+++ b/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/LQ_S1/makeCards_LQ.py
@@ -1,0 +1,89 @@
+# EXAMPLES: python3 makeCards_LQ.py tau
+
+import os
+import sys
+
+
+lflav  = sys.argv[1]
+# Options: ["ele", "mu", "tau", "eletau", "mutau"]
+
+
+if lflav != "ele" and lflav != "mu" and lflav != "tau" and lflav != "eletau" and lflav != "mutau":
+    print("Invalid lepton coupling to LQ. Exiting.")
+    exit(0)
+
+
+custoTemplate = open("./S1LQ_customizecards.dat")
+custoCard = custoTemplate.read()
+custoTemplate.close()
+modelTemplate = open("./S1LQ_extramodels.dat")
+modelCard = modelTemplate.read()
+modelTemplate.close()
+runTemplate = open("./S1LQ_run_card.dat")
+runCard = runTemplate.read()
+runTemplate.close()
+
+mass_list = ['500','750','1000','1250','1500','1750','2000','2250','2500','2750','3000']
+yuk_list = ['0pt01']
+chrl_list = ['L','R']
+fs_list = ['TLTL','TLQ5L','TLQ5N']
+
+
+for fs in fs_list:
+
+    procTemplate = open("./S1LQ_"+fs+"_proc_card.dat")
+    procCard = procTemplate.read()
+    procTemplate.close()
+
+    for chrl in chrl_list:
+
+        if fs != 'TLTL' and chrl == 'R':
+            continue
+
+        if lflav == "ele":
+            restrictInfo = "y"+chrl+chrl+"3x1"
+            nevents = "25000"
+        elif lflav == "mu":
+            restrictInfo = "y"+chrl+chrl+"3x2"
+            nevents = "25000"
+        elif lflav == "tau":
+            restrictInfo = "y"+chrl+chrl+"3x3"
+            nevents = "50000"
+        elif lflav == "eletau":
+            restrictInfo = "y"+chrl+chrl+"3x3"+"y"+chrl+chrl+"3x1"
+            nevents = "100000"
+        elif lflav == "mutau":
+            restrictInfo = "y"+chrl+chrl+"3x3"+"y"+chrl+chrl+"3x2"
+            nevents = "100000"
+
+        for mass in mass_list:
+
+            for yuk in yuk_list:
+
+                yukdec = yuk.replace("pt",".")
+
+                print (f"Generating cards for Final State = {fs}, Chirality = {chrl}, Mass = {mass}, Yuk = {yukdec}")
+                prefix = "S1LQ_"+fs+"_"+lflav+"_M-"+mass+"_yuk"+chrl+"-"+yuk                                               #Example: "S1LQ_TLTL_ele_M-500_yukL-0pt01"
+                os.makedirs("./LQ_Cards/"+fs+"/"+lflav+"/"+chrl+"/"+prefix, exist_ok=True)                                 #Example: "./LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/"
+
+                newprocCard = open("./LQ_Cards/"+fs+"/"+lflav+"/"+chrl+"/"+prefix+"/"+prefix+"_proc_card.dat",'w+')        #Example: "./LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_proc_card.dat"
+                newprocCard_1 = procCard.replace("LQYUK",restrictInfo).replace("YUKVALUE",yuk).replace("LEPF",lflav).replace("NUF","nu"+lflav).replace("LQOUTPUT",prefix)
+                newprocCard.write(newprocCard_1)
+                newprocCard.close()
+            
+                newcustoCard = open("./LQ_Cards/"+fs+"/"+lflav+"/"+chrl+"/"+prefix+"/"+prefix+"_customizecards.dat",'w+')  #Example: "./LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_customizecards.dat"
+                newcustoCard_1 = custoCard.replace("LQMASS",mass)
+                newcustoCard.write(newcustoCard_1)
+                newcustoCard.close()
+            
+                newmodelCard = open("./LQ_Cards/"+fs+"/"+lflav+"/"+chrl+"/"+prefix+"/"+prefix+"_extramodels.dat",'w+')     #Example: "./LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_extramodels.dat"
+                newmodelCard_1 = modelCard
+                newmodelCard.write(newmodelCard_1)
+                newmodelCard.close()
+            
+                newrunCard = open("./LQ_Cards/"+fs+"/"+lflav+"/"+chrl+"/"+prefix+"/"+prefix+"_run_card.dat",'w+')          #Example: "./LQ_Cards/TLTL/ele/L/S1LQ_TLTL_ele_M-500_yukL-0pt01/S1LQ_TLTL_ele_M-500_yukL-0pt01_run_card.dat"
+                newrunCard_1 = runCard.replace("N_EVENTS",nevents)
+                newrunCard.write(newrunCard_1)
+                newrunCard.close()
+        
+exit(0)


### PR DESCRIPTION
Dear Experts,

This is a merge request for Run2 Madgraph cards for our leptoquark analysis, nearly identical to the Run3 merge request which was granted a few months ago [here](https://github.com/cms-sw/genproductions/pull/3773). The only changes to these cards are those of the beam energies (ebeam1 and ebeam2), which have been changed from 6800 to 6500. Everything else should be identical.

Thank you for your time!
Philip Meltzer