### PR TITLE
Add cards for Z/H->psi(nS)+gamma signals with Run-3 CoM energy

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,11 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+generate g g > h, (h > jpsi a, jpsi > mu+ mu-)
+output GluGluToH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToJPsiG_JPsiToMuMu/GluGluToH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,11 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+generate g g > h, (h > jpsi a, jpsi > mu+ mu-)
+output GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu/GluGluToH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,14 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = u c d s u~ c~ d~ s~
+generate p p > h p p $$ z / a p g h w+ w-, (h > jpsi a, jpsi > mu+ mu-)
+add process p p > h p p $$ w+ w- / a p g h z, (h > jpsi a, jpsi > mu+ mu\
+-)
+output VBFToH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToJPsiG_JPsiToMuMu/VBFToH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,14 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = u c d s u~ c~ d~ s~
+generate p p > h p p $$ z / a p g h w+ w-, (h > jpsi a, jpsi > mu+ mu-)
+add process p p > h p p $$ w+ w- / a p g h z, (h > jpsi a, jpsi > mu+ mu\
+-)
+output VBFToH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu/VBFToH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,15 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+add model sm
+define p   = g u c d s u~ c~ d~ s~
+define all = g u c d s t b u~ c~ d~ s~ t~ b~ ve vm vt e- mu- ta- ve~ vm~ vt~ e+ mu+ ta+
+generate    p p > w+ > w+ h, (h > jpsi a, jpsi > mu+ mu-), (w+ > all all)
+add process p p > w- > w- h, (h > jpsi a, jpsi > mu+ mu-), (w- > all all)
+output WH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToJPsiG_JPsiToMuMu/WH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,15 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+add model sm
+define p   = g u c d s u~ c~ d~ s~
+define all = g u c d s t b u~ c~ d~ s~ t~ b~ ve vm vt e- mu- ta- ve~ vm~ vt~ e+ mu+ ta+
+generate    p p > w+ > w+ h, (h > jpsi a, jpsi > mu+ mu-), (w+ > all all)
+add process p p > w- > w- h, (h > jpsi a, jpsi > mu+ mu-), (w- > all all)
+output WH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/WH_HToPsiPrimeG_PsiPrimeToMuMu/WH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,14 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+add model sm
+define p   = g u c d s u~ c~ d~ s~
+define all = g u c d s t b u~ c~ d~ s~ t~ b~ ve vm vt e- mu- ta- ve~ vm~ vt~ e+ mu+ ta+
+generate p p > z > z h, (h > jpsi a, jpsi > mu+ mu-), (z > all all)
+output ZH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToJPsiG_JPsiToMuMu/ZH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,14 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+add model sm
+define p   = g u c d s u~ c~ d~ s~
+define all = g u c d s t b u~ c~ d~ s~ t~ b~ ve vm vt e- mu- ta- ve~ vm~ vt~ e+ mu+ ta+
+generate p p > z > z h, (h > jpsi a, jpsi > mu+ mu-), (z > all all)
+output ZH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZH_HToPsiPrimeG_PsiPrimeToMuMu/ZH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > z, (z > jpsi a, jpsi > mu+ mu-)
+output ZToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToJPsiG_JPsiToMuMu/ZToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > z, (z > jpsi a, jpsi > mu+ mu-)
+output ZToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ZToPsiPrimeG_PsiPrimeToMuMu/ZToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,278 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > b b~ h HIG<=0 QED<=1, (h > jpsi a, jpsi > mu+ mu-)
+output bbH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToJPsiG_JPsiToMuMu/bbH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > b b~ h HIG<=0 QED<=1, (h > jpsi a, jpsi > mu+ mu-)
+output bbH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/bbH_HToPsiPrimeG_PsiPrimeToMuMu/bbH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > t t~ h HIG<=0 QED<=1, (h > jpsi a, jpsi > mu+ mu-)
+output ttH_HToJPsiG_JPsiToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToJPsiG_JPsiToMuMu/ttH_HToJPsiG_JPsiToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_customizecards.dat
@@ -1,0 +1,2 @@
+set param_card mass 443 3.686
+set param_card decay 443 0.000286

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_extramodels.dat
@@ -1,0 +1,1 @@
+jpsi_sm.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_proc_card.dat
@@ -1,0 +1,12 @@
+set default_unset_couplings 99
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_optimized_output True
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model jpsi_sm
+define p = g u c d s u~ c~ d~ s~
+generate p p > t t~ h HIG<=0 QED<=1, (h > jpsi a, jpsi > mu+ mu-)
+output ttH_HToPsiPrimeG_PsiPrimeToMuMu -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/XToPsiNSG/ttH_HToPsiPrimeG_PsiPrimeToMuMu/ttH_HToPsiPrimeG_PsiPrimeToMuMu_run_card.dat
@@ -1,0 +1,277 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+  10000 = nevents ! Number of unweighted events requested
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+        1   = lpp1    ! beam 1 type
+        1   = lpp2    ! beam 2 type
+     6800.0 = ebeam1  ! beam 1 total energy in GeV
+     6800.0 = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+              lhapdf = pdlabel      ! PDF set
+   $DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale        ! if .true. use fixed ren scale
+ False   = fixed_fac_scale        ! if .true. use fixed fac scale
+ 91.188  = scale                  ! fixed ren scale
+ 91.188  = dsqrt_q2fact1          ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2          ! fixed fact scale for pdf2
+ -1      = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+  1.0    = scalefact              ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False   = gridpack       !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  3.0     = lhe_version    ! Change the way clustering information pass to shower.
+  True    = clusinfo       ! include clustering tag in output
+  average =  event_norm    ! average/sum. Normalization of the weight in the LHEF
+
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0     = ickkw        ! 0 no matching, 1 MLM
+ 1.0   = alpsfact     ! scale factor for QCD emission vx
+ False = chcluster    ! cluster only according to channel diag
+ 4     = asrwgtflavor ! highest quark flavor for a_s reweight
+ False = auto_ptj_mjj ! Automatic setting of ptj and mjj if xqcut >0
+                      ! (turn off for VBF and single top processes)
+ 0.0   = xqcut        ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# handling of the helicities:
+#  0: sum over all helicities
+#  1: importance sampling over helicities
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module     ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+   {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************
+# Parton level cuts definition *
+#*******************************
+#
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*********************************************************************
+   False  = cut_decays    ! Cut decay products
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj        ! minimum pt for the jets
+  0.0  = ptb        ! minimum pt for the b
+  0.0  = pta        ! minimum pt for the photons
+  0.0  = ptl        ! minimum pt for the charged leptons
+  0.0  = misset     ! minimum missing Et (sum of neutrino's momenta)
+ -1.0  = ptjmax     ! maximum pt for the jets
+ -1.0  = ptbmax     ! maximum pt for the b
+ -1.0  = ptamax     ! maximum pt for the photons
+ -1.0  = ptlmax     ! maximum pt for the charged leptons
+ -1.0  = missetmax  ! maximum missing Et (sum of neutrino's momenta)
+    {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+  0.0  = ej        ! minimum E for the jets
+  0.0  = eb        ! minimum E for the b
+  0.0  = ea        ! minimum E for the photons
+  0.0  = el        ! minimum E for the charged leptons
+ -1.0  = ejmax     ! maximum E for the jets
+ -1.0  = ebmax     ! maximum E for the b
+ -1.0  = eamax     ! maximum E for the photons
+ -1.0  = elmax     ! maximum E for the charged leptons
+    {} = e_min_pdg ! E cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = e_max_pdg ! E cut for other particles (syntax e.g. {6: 100, 25: 50})
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0  = etaj        ! max rap for the jets
+ -1.0  = etab        ! max rap for the b
+ -1.0  = etaa        ! max rap for the photons
+ -1.0  = etal        ! max rap for the charged leptons
+  0.0  = etajmin     ! min rap for the jets
+  0.0  = etabmin     ! min rap for the b
+  0.0  = etaamin     ! min rap for the photons
+  0.0  = etalmin     ! main rap for the charged leptons
+    {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+    {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+  0.0  = drjj    ! min distance between jets
+  0.0  = drbb    ! min distance between b's
+  0.0  = drll    ! min distance between leptons
+  0.0  = draa    ! min distance between gammas
+  0.0  = drbj    ! min distance between b and jet
+  0.0  = draj    ! min distance between gamma and jet
+  0.0  = drjl    ! min distance between jet and lepton
+  0.0  = drab    ! min distance between gamma and b
+  0.0  = drbl    ! min distance between b and lepton
+  0.0  = dral    ! min distance between gamma and lepton
+ -1.0  = drjjmax ! max distance between jets
+ -1.0  = drbbmax ! max distance between b's
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = draamax ! max distance between gammas
+ -1.0  = drbjmax ! max distance between b and jet
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = drjlmax ! max distance between jet and lepton
+ -1.0  = drabmax ! max distance between gamma and b
+ -1.0  = drblmax ! max distance between b and lepton
+ -1.0  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+  0.0  = mmbb    ! min invariant mass of a b pair
+  0.0  = mmaa    ! min invariant mass of gamma gamma pair
+  0.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmbbmax ! max invariant mass of a b pair
+ -1.0  = mmaamax ! max invariant mass of gamma gamma pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+# {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+# {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only
+#                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+  0.0  = mmnl    ! min invariant mass for all letpons (l+- and vl)
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+  0.0  = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = ptheavy ! minimum pt for at least one heavy final state
+ 0.0  = xptj    ! minimum pt for at least one jet
+ 0.0  = xptb    ! minimum pt for at least one b
+ 0.0  = xpta    ! minimum pt for at least one photon
+ 0.0  = xptl    ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+  0.0  = ptj1min ! minimum pt for the leading jet in pt
+  0.0  = ptj2min ! minimum pt for the second jet in pt
+  0.0  = ptj3min ! minimum pt for the third jet in pt
+  0.0  = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+  0    = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+  0.0  = ptl1min ! minimum pt for the leading lepton in pt
+  0.0  = ptl2min ! minimum pt for the second lepton in pt
+  0.0  = ptl3min ! minimum pt for the third lepton in pt
+  0.0  = ptl4min ! minimum pt for the fourth lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ -1.0  = ptl3max ! maximum pt for the third lepton in pt
+ -1.0  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+  0.0  = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+  0.0  = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0  = ht2min ! minimum Ht for the two leading jets
+  0.0  = ht3min ! minimum Ht for the three leading jets
+  0.0  = ht4min ! minimum Ht for the four leading jets
+ -1.0  = ht2max ! maximum Ht for the two leading jets
+ -1.0  = ht3max ! maximum Ht for the three leading jets
+ -1.0  = ht4max ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+  0.0 = ptgmin   ! Min photon transverse momentum
+  0.4 = R0gamma  ! Radius of isolation code
+  1.0 = xn       ! n parameter of eq.(3.4) in hep-ph/9801442
+  1.0 = epsgamma ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+ True = isoEM    ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0.0   = xetamin  ! minimum rapidity for two jets in the WBF case
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies


### PR DESCRIPTION
This PR adds the needed cards to generate Z/H->psi(nS)+gamma signals with Run-3 center-of-mass energy.
They are very similar to the ones already available in genproductions [1], the only change is in the beams energy. Given that the cards in different folders are very similar, I can make a script to create all the needed cards from some templates, as you prefer.

The effort for the Run-3 analysis of these signatures has just started [2], so this is the first step before requesting the central production of the Run-3 signal samples.

[1] : https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/13TeV/XToJPsiG_JPsiToMuMu
[2] : https://indico.cern.ch/event/1495519/#21-z-h-j-studies-for-run-3