### PR TITLE
Adding HJ_MiNNLO cards

### DIFF
--- a/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/HJ_13p6TeV-nnpdf31-powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/HJ_13p6TeV-nnpdf31-powheg.input
@@ -1,0 +1,113 @@
+max_io_bufsize 2000000
+numevts NEVENTS
+iseed SEED
+
+
+! TO CORRECT FOR UB VIOLATIONS DETECTED DURING STAGE 4
+!btildeviol 1
+!corr_btilde XXX
+!corr_remnant XXX
+
+! SCALE VARIATION
+renscfact  1d0   ! (default 1d0) ren scale factor: muren  = muref * renscfact 
+facscfact  1d0   ! (default 1d0) fac scale factor: mufact = muref * facscfact
+pdfreweight 0       ! PDF reweighting
+bwshape 3   !  complex-pole scheme according to Passarino et al.
+
+lhrwgt_id 'st4'
+lhrwgt_descr 'st4 NNLOPS'
+
+! ALPHAS AND PDF EVOLUTION
+alphas_from_pdf 1 ! (default 0) if 1, uses alphas from PDF evolution tool (e.g. lhapdf or hoppet)
+
+! MINLO SETTINGS
+minlo 1        ! (default 0) if 1, activate minlo
+minnlo 1       ! (default 0) if 1, activate miNNlo
+largeptscales 0  ! (default 0) if 0, at large pt, use muR=muF~Q in fixed order part
+                 !             if 1, at large pt, use muR=muF=pt in the fixed-order part
+#Q0 0.5           ! (default 0.) Q0 value used in profiled scales (see 2006.04133 for more details)
+#                 !              smaller values can be used too.
+#modlog_p 6d0      ! (default 6) optional, only works if minnlo is set to 1)
+#                  ! if >0d0, activate modified logs and set the exponent
+#                  ! if -1d0, activate piecewise modified log version 1 
+#                  ! if -2d0, activate piecewise modified log version 2
+#                  ! piecewise modified log: log(Q/pT) for pT<Q/2
+#                  !                         zero for pT>Q
+#                  !                         smoothly interpolated inbetween
+
+! PROCESS PARAMETERS
+hmass 125          ! higgs mass
+hwidth 0.00407d0
+hdecaywidth 0
+bwcutoff 15 
+
+! POWHEG PARAMETERS
+ih1   1            ! hadron 1 (1 for protons, -1 for antiprotons)
+ih2   1            ! hadron 2 (1 for protons, -1 for antiprotons)
+ebeam1 6800d0      ! energy of beam 1
+ebeam2 6800d0      ! energy of beam 2
+
+! To be set only if using LHA pdfs
+lhans1   306000      ! pdf set for hadron 1 (LHA numbering)
+lhans2   306000      ! pdf set for hadron 2 (LHA numbering)
+
+! Parameters to allow or not the use of stored data
+use-old-grid    1 ! if 1 use old grid if file pwggrids.dat is present (<> 1 regenerate)
+use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound.dat, if present; <> 1 regenerate
+
+
+#bornsuppfact 1 ! (default 1), If 1 the Born suppression factor is included.
+                ! Weighted events are generated. If 0 no suppression
+                ! factor is included, and events are unweighted. A
+                ! generation cut bornktmin>0 must be supplied in this case.
+#ckkwscalup 0 ! (for Hj, default was 1; for HJMiNNLO, default is 0), If 1 compute the scalup scale for subsequent
+              ! shower using the smallest kt in the final state;
+              ! If 0, use the standard POWHEG BOX scalup
+#doublefsr 1  ! (default 1) symmetric treatment of FSR q->qg and g->qqbar splittings
+#runningscales 1  ! (default 0), if 0 use hmass as central
+                  ! factorization and renormalization scale;
+                  ! if 1 use the Ht/2
+
+ncall1   5000     ! number of calls for initializing the integration grid
+itmx1    1        ! number of iterations for initializing the integration grid
+ncall2   5000    ! number of calls for computing the integral and finding upper bound
+itmx2    1        ! number of iterations for computing the integral and finding upper bound
+foldcsi   1       ! number of folds on csi integration
+foldy     1       ! number of folds on  y  integration
+foldphi   1       ! number of folds on phi integration
+nubound 30000     ! number of bbarra calls to setup norm of upper bounding function
+
+! OPTIONAL PARAMETERS
+testplots  1       ! (default 0, do not) do NLO and PWHG distributions
+withnegweights 1  ! (1 default) If 1 output negative weighted events.
+                   ! If 0 discard them
+#bornonly   0      ! (default 0) if 1 do Born only
+bornktmin 0.26     ! Minimum transverse momentum if the Higgs at the underlying Born level
+storeinfo_rwgt 1   ! store info to allow for reweighting
+flg_debug      1   ! store extra event info for debugging
+
+! PARALLEL RUNS
+# the following is for parallel runs (see manual in Z2jet/Docs/)
+manyseeds 1
+parallelstage 1
+xgriditeration 1
+maxseeds 1000
+
+! OPTIONS TO DEAL WITH UNSTABLE POINTS/GRIDS
+storemintupb 0    ! (default 0) if 1 save calls in a file
+
+check_bad_st1 1  ! (default 0) if 1, takes care of removing bad grids during stage 1
+check_bad_st2 1  ! (default 0) if 1, takes care of removing bad grids during stage 2
+
+ubexcess_correct 1
+
+factsc2min 2
+
+
+# fastbtlbound 1
+# storemintupb 1
+# compress_lhe 1
+# compress_upb 1
+# mintupbratlim 1d4
+
+fakevirt 1

--- a/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/HJ_13p6TeV-nnpdf31-powheg.input
+++ b/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/HJ_13p6TeV-nnpdf31-powheg.input
@@ -68,14 +68,14 @@ use-old-ubound  1 ! if 1 use norm of upper bounding function stored in pwgubound
                   ! factorization and renormalization scale;
                   ! if 1 use the Ht/2
 
-ncall1   5000     ! number of calls for initializing the integration grid
+ncall1   100000     ! number of calls for initializing the integration grid
 itmx1    1        ! number of iterations for initializing the integration grid
-ncall2   5000    ! number of calls for computing the integral and finding upper bound
+ncall2   100000    ! number of calls for computing the integral and finding upper bound
 itmx2    1        ! number of iterations for computing the integral and finding upper bound
-foldcsi   1       ! number of folds on csi integration
-foldy     1       ! number of folds on  y  integration
-foldphi   1       ! number of folds on phi integration
-nubound 30000     ! number of bbarra calls to setup norm of upper bounding function
+foldcsi   5       ! number of folds on csi integration
+foldy     2       ! number of folds on  y  integration
+foldphi   2       ! number of folds on phi integration
+nubound 100000     ! number of bbarra calls to setup norm of upper bounding function
 
 ! OPTIONAL PARAMETERS
 testplots  1       ! (default 0, do not) do NLO and PWHG distributions

--- a/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/minnloHelper_HJ.sh
+++ b/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/minnloHelper_HJ.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+trap "exit" INT
+
+WHAT=$1;
+PARAM=$2;
+if [ "$#" -lt 1 ]; then
+    echo "minnloHelper_HJ.sh <OPTION>";
+    exit 1;
+fi
+
+NJOBS=200
+SVN=3900
+ARCH=el9_amd64_gcc11
+CMSSW=CMSSW_13_2_5
+SUFFIX=powheg-MiNNLO31-svn${SVN}-j${NJOBS}
+
+PROCS=(HJ_13p6TeV-nnpdf31)
+
+case $WHAT in
+
+    SLC6 )
+        cmssw-cc6 --command-to-run ./$0 $PARAM
+    ;;
+    
+    INIT )
+        ln -s ../../../../*.py .
+        ln -s ../../../../*.sh .
+        ln -s ../../../../patches .
+        ln -s ../../../../Templates .
+        ln -s ../../../../Utilities .
+        ln -s ../../../../production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV .
+    ;;
+    
+    PRINT )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC}
+        done
+    ;;
+    
+    COMPILE )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            python3 ./run_pwg_condor.py -p 0 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -d 1 --svn ${SVN}
+        done
+    ;;
+    
+    RECOMPILE )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            cd ${DIR}/POWHEG-BOX/HJ/HJMiNNLO
+            make
+            cd -
+            cp -v ${DIR}/POWHEG-BOX/HJ/HJMiNNLO/pwhg_main ${DIR}/
+        done
+    ;;
+    
+    ONESHOT )
+        for PROC in ${PROCS[@]}
+        do
+            python3 ./run_pwg_condor.py -p f -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -d 1 --svn ${SVN}
+        done
+    ;;
+
+    GRIDS )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 123 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q 1:longlunch,2:workday,3:longlunch --step3pilot -x 3 -j ${NJOBS} 
+        done
+    ;;
+    
+    DAG )
+        for PROC in ${PROCS[@]}
+        do
+            if [ ! -f "${PROC}-${SUFFIX}/pwg-st3-0001-stat.dat" ]; then
+                condor_submit_dag run_${PROC}-${SUFFIX}.dag
+            fi
+        done
+    ;;
+    
+    LONGGRIDS )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 123 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q 1:workday,2:tomorrow,3:workday --step3pilot -x 3 -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS1 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 1 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q workday -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS2 )
+        for PROC in ${PROCS[@]}
+        do
+            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 2 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q workday -j ${NJOBS}
+        done
+    ;;
+    
+    GRIDS3 )
+        for PROC in ${PROCS[@]}
+        do
+#            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 3 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q longlunch -j ${NJOBS} --step3pilot &
+            k5reauth -R -- python3 ./run_pwg_parallel_condor.py -p 3 -i HJ_MiNNLO_NNPDF31_13p6TeV/${PROC}-powheg.input -m HJ -f ${PROC}-${SUFFIX} -q longlunch -j ${NJOBS} &
+        done
+    ;;
+    
+    XS )
+        for PROC in ${PROCS[@]}
+        do
+            echo ${PROC}
+            cat ${PROC}-${SUFFIX}/pwg-st3-0001-stat.dat | grep total
+            cat ${PROC}-${SUFFIX}/pwg-st3-0001-stat.dat | grep suppression
+        done
+    ;;
+    
+    PACK )
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            python3 ./run_pwg_condor.py -p 9 -m HJ -f ${PROC}-${SUFFIX} 
+        done
+        ./minnloHelper_HJ.sh PACK_REDUCED
+        ./minnloHelper_HJ.sh PACK_NORWL
+    ;;
+    
+    TEST )
+        mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            /usr/bin/time -v ./runcmsgrid.sh 20 1 1 &
+            cd ..
+        done
+    ;;
+    
+    LONGTEST )
+        mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            /usr/bin/time -v ./runcmsgrid.sh 800 1 1 &
+            cd ..
+        done
+    ;;
+    
+    PACK_REDUCED )
+        mkdir PACK_REDUCED; cd PACK_REDUCED
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            cp ../../pwg-rwl-reduced.dat pwg-rwl.dat
+            tar zcf ../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz *
+            cd ..
+        done
+    ;;
+    
+    TEST_REDUCED )
+        cd PACK_REDUCED; mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz
+            ./runcmsgrid.sh 1000 1 1 &
+            cd ..
+        done
+    ;;
+    
+    PACK_NORWL )
+        mkdir PACK_REDUCED; cd PACK_REDUCED
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}-norwl
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            sed -i '/rwl_file/d' powheg.input
+            sed -i '/MINNLO="true"/d' runcmsgrid.sh
+            tar zcf ../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz *
+            cd ..
+        done
+    ;;
+    
+    TEST_NORWL )
+        cd PACK_REDUCED; mkdir TEST; cd TEST
+        eval `scramv1 runtime -sh`
+        for PROC in ${PROCS[@]}
+        do
+            DIR=${PROC}-${SUFFIX}-norwl
+            rm -r ${DIR}; mkdir ${DIR}; cd ${DIR}
+            tar -xzf ../../HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz
+            ./runcmsgrid.sh 5 1 1 &
+            cd ..
+        done
+    ;;
+    
+    COPY )
+        for PROC in ${PROCS[@]}
+        do
+            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
+            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz
+            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz
+            cp -p -v HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            cp -p -v PACK_REDUCED/HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+            cp -p -v PACK_REDUCED/HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
+        done
+    ;;
+    
+    COPY_GRIDS )
+        OLDPATH=/afs/cern.ch/work/m/mseidel/generator/CMSSW_10_2_23/src/
+        OLDSUFFIX=powheg-MiNNLO31-svn3900-ew-rwl6-j${NJOBS}-st2fix-ana-hoppetweights-ymax20
+        for PROC in ${PROCS[@]}
+        do
+            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.dat ${PROC}-${SUFFIX}/
+            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.top ${PROC}-${SUFFIX}/
+        done
+    ;;
+
+esac

--- a/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/minnloHelper_HJ.sh
+++ b/bin/Powheg/production/Run3/13p6TeV/HJ_MiNNLO_NNPDF31_13p6TeV/minnloHelper_HJ.sh
@@ -208,26 +208,4 @@ case $WHAT in
         done
     ;;
     
-    COPY )
-        for PROC in ${PROCS[@]}
-        do
-            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz
-            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz
-            echo HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz
-            cp -p -v HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
-            cp -p -v PACK_REDUCED/HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-reducedrwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
-            cp -p -v PACK_REDUCED/HJ_${ARCH}_${CMSSW}_${PROC}-${SUFFIX}-norwl.tgz /afs/cern.ch/work/m/mseidel/public/MiNNLO-gridpacks/
-        done
-    ;;
-    
-    COPY_GRIDS )
-        OLDPATH=/afs/cern.ch/work/m/mseidel/generator/CMSSW_10_2_23/src/
-        OLDSUFFIX=powheg-MiNNLO31-svn3900-ew-rwl6-j${NJOBS}-st2fix-ana-hoppetweights-ymax20
-        for PROC in ${PROCS[@]}
-        do
-            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.dat ${PROC}-${SUFFIX}/
-            cp ${OLDPATH}/${PROC}-${OLDSUFFIX}/*.top ${PROC}-${SUFFIX}/
-        done
-    ;;
-
 esac


### PR DESCRIPTION
This adds cards for HJ_MiNNLO, with the settings described in the [GEN meeting on 24/02](https://indico.cern.ch/event/1516779/contributions/6382701/attachments/3019221/5326259/ggH_MiNNLO_AdeWit_2402.pdf)

Note: I'm not sure the pdf sets used are correct, so comments on that welcome.

In the gridpacks, I'd propose to include the scale weights and the pdf weights for the main set of pdfs - I have been removing weights manually (editing the pwg-rwl file and recreating the tarball), but if there is another method that is recommended for this I'd be happy to hear it.