### PR TITLE
New MC fragments for H -> meson gamma

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,85 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/VBF_H_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyDst       D*0',
+'Alias      MyantiDst   anti-D*0',
+'Alias      MyDz        D0',
+'Alias      MyantiDz    anti-D0',
+'#',
+'Decay MyHiggs0',
+'0.500      MyDst       gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'0.500      MyantiDst   gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyDst',
+'0.619   MyDz     pi0     VSS;',
+'0.381   MyDz     gamma    VSP_PWAVE;',
+'Enddecay',
+'Decay MyantiDst',
+'0.619   MyantiDz     pi0     VSS;',
+'0.381   MyantiDz     gamma    VSP_PWAVE;',
+'Enddecay',
+'Decay MyDz',
+'1.000    K-      pi+      PHSP;',
+'Enddecay',
+'Decay MyantiDz',
+'1.000    K+      pi-      PHSP;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 3",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -63,6 +64,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 3",
@@ -71,6 +73,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/VBF_H_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyKst       K*0',
+'Alias      MyantiKst   anti-K*0',
+'#',
+'Decay MyHiggs0',
+'0.500      MyKst       gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'0.500      MyantiKst   gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyKst',
+'1.000      K+     pi-  VSS;',
+'Enddecay',
+'Decay MyantiKst',
+'1.000      K-     pi+  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 3",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -53,6 +54,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 3",
@@ -61,6 +63,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hphigamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hphigamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -48,6 +49,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 3",
@@ -56,6 +58,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hphigamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hphigamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/VBF_H_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyPhi       phi',
+'#',
+'Decay MyHiggs0',
+'1.000      MyPhi     gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyPhi',
+'1.000      K+     K-  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 3",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -48,6 +49,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,   
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 3",
@@ -56,6 +58,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/VBFH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/VBF_H_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyRho       rho0',
+'#',
+'Decay MyHiggs0',
+'1.000      MyRho     gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyRho',
+'1.000      pi+     pi-  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 3",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/Zphigamma_01j_MadGraph_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/Zphigamma_01j_MadGraph_13p6TeV.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/el9_amd64_gcc11/MadGraph5_aMCatNLO/Hmesongamma/ZtoPhiGamma_01j_el9_amd64_gcc11_CMSSW_13_2_9_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         PythiaParameters = cms.PSet(
+                             pythia8CommonSettingsBlock,
+                             pythia8CP5SettingsBlock,
+                             pythia8PSweightsSettingsBlock,
+                             processParameters = cms.vstring( 
+                                 'JetMatching:setMad = off',
+                                 'JetMatching:scheme = 1',
+                                 'JetMatching:merge = on',
+                                 'JetMatching:jetAlgorithm = 2',
+                                 'JetMatching:etaJetMax = 5.',
+                                 'JetMatching:coneRadius = 1.',
+                                 'JetMatching:slowJetPower = 1',
+                                 'JetMatching:qCut = 19.', #this is the actual merging scale
+                                 'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+                                 'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+                                 'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+                                 'TimeShower:mMaxGamma = 4.0',
+                                 'BeamRemnants:primordialKThard = 2.48'
+                             ),
+                             parameterSets = cms.vstring(
+                                 'pythia8CommonSettings',
+                                 'pythia8CP5Settings',
+                                 'pythia8PSweightsSettings',
+                                 'processParameters',
+                             )
+                         )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/Zrhogamma_01j_MadGraph_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/Zrhogamma_01j_MadGraph_13p6TeV.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/el9_amd64_gcc11/MadGraph5_aMCatNLO/Hmesongamma/ZtoRhoGamma_01j_el9_amd64_gcc11_CMSSW_13_2_9_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         PythiaParameters = cms.PSet(
+                             pythia8CommonSettingsBlock,
+                             pythia8CP5SettingsBlock,
+                             pythia8PSweightsSettingsBlock,
+                             processParameters = cms.vstring( 
+                                 'JetMatching:setMad = off',
+                                 'JetMatching:scheme = 1',
+                                 'JetMatching:merge = on',
+                                 'JetMatching:jetAlgorithm = 2',
+                                 'JetMatching:etaJetMax = 5.',
+                                 'JetMatching:coneRadius = 1.',
+                                 'JetMatching:slowJetPower = 1',
+                                 'JetMatching:qCut = 19.', #this is the actual merging scale
+                                 'JetMatching:nQmatch = 4', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+                                 'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+                                 'JetMatching:doShowerKt = off', #off for MLM matching, turn on for shower-kT matching
+                                 'TimeShower:mMaxGamma = 4.0',
+                                 'BeamRemnants:primordialKThard = 2.48'
+                             ),
+                             parameterSets = cms.vstring(
+                                 'pythia8CommonSettings',
+                                 'pythia8CP5Settings',
+                                 'pythia8PSweightsSettings',
+                                 'processParameters',
+                             )
+                         )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -63,6 +64,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,   
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 1",
@@ -70,6 +72,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         parameterSets = cms.vstring(
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
+                            'pythia8PSweightsSettings',
                             'pythia8CP5Settings',
                             'processParameters',
  

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_HDstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,85 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/gg_H_quark-mass-effects_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyDst       D*0',
+'Alias      MyantiDst   anti-D*0',
+'Alias      MyDz        D0',
+'Alias      MyantiDz    anti-D0',
+'#',
+'Decay MyHiggs0',
+'0.500      MyDst       gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'0.500      MyantiDst   gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyDst',
+'0.619   MyDz     pi0     VSS;',
+'0.381   MyDz     gamma    VSP_PWAVE;',
+'Enddecay',
+'Decay MyantiDst',
+'0.619   MyantiDz     pi0     VSS;',
+'0.381   MyantiDz     gamma    VSP_PWAVE;',
+'Enddecay',
+'Decay MyDz',
+'1.000    K-      pi+      PHSP;',
+'Enddecay',
+'Decay MyantiDz',
+'1.000    K+      pi-      PHSP;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 1",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/gg_H_quark-mass-effects_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyKst       K*0',
+'Alias      MyantiKst   anti-K*0',
+'#',
+'Decay MyHiggs0',
+'0.500      MyKst       gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'0.500      MyantiKst   gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyKst',
+'1.000      K+     pi-  VSS;',
+'Enddecay',
+'Decay MyantiKst',
+'1.000      K-     pi+  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 1",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hkstar0gamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -53,6 +54,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,   
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 1",
@@ -61,6 +63,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hphigamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hphigamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -48,6 +49,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 1",
@@ -56,6 +58,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hphigamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hphigamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/gg_H_quark-mass-effects_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyPhi       phi',
+'#',
+'Decay MyHiggs0',
+'1.000      MyPhi     gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyPhi',
+'1.000      K+     K-  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 1",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
@@ -11,7 +11,8 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 )
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
 from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
 
@@ -48,6 +49,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
         PythiaParameters = cms.PSet(
          pythia8CommonSettingsBlock,
          pythia8CP5SettingsBlock,
+         pythia8PSweightsSettingsBlock,
          pythia8PowhegEmissionVetoSettingsBlock,     
          processParameters = cms.vstring(
             "POWHEG:nFinal = 1",
@@ -56,6 +58,7 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
                             'pythia8PowhegEmissionVetoSettings',
                             'pythia8CommonSettings',
                             'pythia8CP5Settings',
+                            'pythia8PSweightsSettings',
                             'processParameters',
  
         )

--- a/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/Hmesongamma/ggH_Hrhogamma_POWHEGEvtGen_13p6TeV.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/13p6TeV/slc7_amd64_gcc10/Powheg/V2/gg_H_quark-mass-effects_NNPDF31_13p6TeV_M125_slc7_amd64_gcc10_CMSSW_12_4_11_patch3.tgz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(1),
+                         filterEfficiency = cms.untracked.double(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(5),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2020_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2020.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'Alias      MyHiggs0    Higgs0',
+'Alias      MyRho       rho0',
+'#',
+'Decay MyHiggs0',
+'1.000      MyRho     gamma     HELAMP 1.0 0.0 1.0 0.0;',
+'Enddecay',
+'Decay MyRho',
+'1.000      pi+     pi-  VSS;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyHiggs0'),
+            operates_on_particles = cms.vint32(25),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+         pythia8CommonSettingsBlock,
+         pythia8CP5SettingsBlock,
+         pythia8PowhegEmissionVetoSettingsBlock,     
+         processParameters = cms.vstring(
+            "POWHEG:nFinal = 1",
+                        ),
+        parameterSets = cms.vstring(
+                            'pythia8PowhegEmissionVetoSettings',
+                            'pythia8CommonSettings',
+                            'pythia8CP5Settings',
+                            'processParameters',
+ 
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+ProductionFilterSequence = cms.Sequence(generator)
+
+
+


### PR DESCRIPTION
New configurations for Run3 H -> meson + gamma analyses, preserving correct spin alignment in decay products. 
- POWHEG + EvtGen are used for spin-0 Higgs
- MadGraph + a user-defined UFO model for spin-1 Z (NOT IN THIS PR YET)

@mlizzo @yihui-lai @maravin @gumoret 