### PR TITLE
Corrected the collider energy for ZH cards with anomalous couplings.

### DIFF
--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz1_prime2=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz1_prime2=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1Zg.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1Zg.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghzgs1_prime2=1,0 MPhotonCutoff=0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghzgs1_prime2=1,0 MPhotonCutoff=0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1Zgmix.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1Zgmix.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghzgs1_prime2=-642.9534,0 MPhotonCutoff=0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghzgs1_prime2=-642.9534,0 MPhotonCutoff=0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1mix.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/L1mix.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz1_prime2=-517.788,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz1_prime2=-517.788,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/SM.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/SM.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a2.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a2.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz2=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz2=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a2mix.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a2mix.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz2=0.112481,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz2=0.112481,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a3.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a3.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz4=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=0,0 ghz4=1,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a3mix.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/a3mix.input
@@ -1,1 +1,1 @@
-VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz4=0.144057,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax
+ColliderEnergy=13.6 VegasNc0=99999999 Process=50 DecayMode1=9 MReso=125 GaReso=0.00407 ghz1=1,0 ghz4=0.144057,0 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info ReadCSmax

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2AA_ZH_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2AA_ZH_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs2=0.655141,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs2=0.655141,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2AA_dec_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2AA_dec_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs2=0.0530640,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs2=0.0530640,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2ZA_ZH_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2ZA_ZH_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs2=0.140705,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs2=0.140705,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2ZA_dec_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa2ZA_dec_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs2=0.0477547,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs2=0.0477547,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3AA_ZH_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3AA_ZH_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs4=0.747376,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs4=0.747376,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3AA_dec_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3AA_dec_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs4=0.0536022,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghgsgs4=0.0536022,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3ZA_ZH_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3ZA_ZH_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs4=0.175403,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs4=0.175403,0

--- a/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3ZA_dec_05.input
+++ b/bin/JHUGen/cards/13p6TeV/anomalouscouplings/ZH_NNPDF31_lo_13p6TeV/fa3ZA_dec_05.input
@@ -1,1 +1,1 @@
-Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs4=0.0529487,0
+ColliderEnergy=13.6 Process=50 DecayMode1=9 MPhotonCutoff=0.01 VegasNc0=999999999 LHAPDF=NNPDF31_lo_as_0130/NNPDF31_lo_as_0130.info MReso=125 GaReso=0.00407 ReadCSmax ghz1=1,0 ghzgs4=0.0529487,0


### PR DESCRIPTION
Hello, 

The current Run3 JHUGen cards for ZH do not have the ColliderEnergy parameter correctly specified. The cards in this PR correctly specify the collider energy to be 13.6 TeV. 