### PR TITLE
Madgraph cards to produce Run 3 gridpacks for Dark Photon analysis in the Hidden Abelian Higgs Model

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 1.000000e+00 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 1.000000e+00 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m1

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m1/DPhoton_m1_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 2.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 4  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 1.000000e+01 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 1.000000e+01 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m10

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m10/DPhoton_m10_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 10.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 20  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 2.000000e+00 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 2.000000e+00 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m2

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m2/DPhoton_m2_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 4.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 8  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 4.000000e+00 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 4.000000e+00 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m4

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m4/DPhoton_m4_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 5.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 10  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 6.000000e+00 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 6.000000e+00 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m6

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m6/DPhoton_m6_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 6.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 12  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_param_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_param_card.dat
@@ -1,0 +1,73 @@
+BLOCK CKMBLOCK # 
+      1 4.880000e-01 # cabi
+BLOCK GAUGEMASS # 
+      1 9.118800e+01 # mzinput
+BLOCK HIDDEN # 
+      1 8.000000e+00 # mzdinput
+      2 1.000000e+05 # mhsinput
+      3 2.000000e-02 # epsilon
+      4 1.000000e-10 # kap
+      5 1.279000e+02 # axm1
+BLOCK HIGGS # 
+      1 1.250000e+02 # mhinput
+BLOCK MASS # 
+      4 1.420000e+00 # mc
+      5 4.700000e+00 # mb
+      6 1.743000e+02 # mt
+      11 5.110000e-04 # me
+      13 1.057000e-01 # mm
+      15 1.777000e+00 # mta
+      1 0.000000e+00 # d : 0.0
+      2 0.000000e+00 # u : 0.0
+      3 0.000000e+00 # s : 0.0
+      12 0.000000e+00 # ve : 0.0
+      14 0.000000e+00 # vm : 0.0
+      16 0.000000e+00 # vt : 0.0
+      21 0.000000e+00 # g : 0.0
+      22 0.000000e+00 # a : 0.0
+      23 9.118800e+01 # z : mzinput
+      24 8.027180e+01 # w+ : cw*mz0
+      25 1.250000e+02 # h : mhinput
+      35 1.000000e+05 # h2 : mhsinput
+      1023 8.000000e+00 # zp : mzdinput
+BLOCK SMINPUTS # 
+      1 2.250000e-01 # swsq
+      2 1.279000e+02 # aewm1
+      3 1.300000e-01 # gf (note that parameter not used if you use a pdf set)
+      4 1.180000e-01 # as
+BLOCK YUKAWA # 
+      4 1.420000e+00 # ymc
+      5 4.700000e+00 # ymb
+      6 1.743000e+02 # ymt
+      11 5.110000e-04 # ymel
+      13 1.057000e-01 # ymmu
+      15 1.777000e+00 # ymtau
+BLOCK QNUMBERS 1023 #         zp
+      1 0 # 3 times electric charge
+      2 3 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+BLOCK QNUMBERS 35 #         h2
+      1 0 # 3 times electric charge
+      2 1 # number of spin states (2s+1)
+      3 1 # colour rep (1: singlet, 3: triplet, 8: octet)
+      4 0 # particle/antiparticle distinction (0=own anti)
+DECAY  1   0.000000e+00
+DECAY  2   0.000000e+00
+DECAY  3   0.000000e+00
+DECAY  4   0.000000e+00
+DECAY  5   0.000000e+00
+DECAY  6   1.508336e+00
+DECAY  11   0.000000e+00
+DECAY  12   0.000000e+00
+DECAY  13   0.000000e+00
+DECAY  14   0.000000e+00
+DECAY  15   0.000000e+00
+DECAY  16   0.000000e+00
+DECAY  21   0.000000e+00
+DECAY  22   0.000000e+00
+DECAY  23   2.441404e+00
+DECAY  24   2.047600e+00
+DECAY  25   2.822990e-03
+DECAY  35   auto
+DECAY  1023   auto

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_proc_card.dat
@@ -1,0 +1,10 @@
+import model --modelname HAHM_variableMW_v3_UFO
+
+define p = g u c d s b u~ c~ d~ s~ b~
+define j = g u c d s b u~ c~ d~ s~ b~
+define f = u c d s u~ c~ d~ s~ b b~ e+ e- m+ m- tt+ tt- ve vm vt ve~ vm~ vt~
+
+generate p p > zp > m+ m- @0
+add process p p > zp > m+ m- j @1
+
+output DPhoton_m8

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/HAHM_DPhoton/DPhoton_m8/DPhoton_m8_run_card.dat
@@ -1,0 +1,187 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update to_full                                                *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  150000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=elastic photon of proton,*
+#             +/-3=PDF of electron/positron beam                     *
+#             +/-4=PDF of muon/antimuon beam                         *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800.0     = ebeam1  ! beam 1 total energy in GeV
+     6800.0     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes alpha_s and its evol.         *
+# pdlabel: lhapdf=LHAPDF (installation needed) [1412.7420]           *
+#          iww=Improved Weizsaecker-Williams Approx.[hep-ph/9310350] *
+#          eva=Effective W/Z/A Approx.       [21yy.zzzzz]            *
+#          none=No PDF, same as lhapdf with lppx=0                   *
+#*********************************************************************
+     nn23lo1    = pdlabel    
+     230000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False = fixed_fac_scale1  ! if .true. use fixed fac scale for beam 1
+ False = fixed_fac_scale2  ! if .true. use fixed fac scale for beam 2
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+
+ 
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  False     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 4 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 8.0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ 16  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   2  = sde_strategy  ! default integration strategy (hep-ph/2021.00773)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ -1.0  = ptj       ! minimum pt for the jets 
+  4.0  = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1 = etaj    ! max rap for the jets 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 4 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+#
+systematics = systematics_program ! none, systematics [python], SysCalc [depreceted, C++]
+['--mur=0.5,1,2', '--muf=0.5,1,2', '--pdf=errorset', '--alps=0.5,1,2'] = systematics_arguments ! see: https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Systematics#Systematicspythonmodule


### PR DESCRIPTION
This set of cards is documenting the Run 3 MC request for the low mass dimuon analysis in the Hidden Abelian Higgs Model. 
Technical details are summarized below:
* Generator: Madgraph5_amc@NLO (+ Pythia8)
* Model: HAHM_variableMW_v3_UFO
* Set of masses: 1, 2, 4, 6, 8, and 10 GeV
* 1j- sample production with proper matching: 
     * xqcut tuned according to the mass;
     * qcut is set to be double of the xqcut ("X=ktdurham" line in the run card);
     * DJR is basically always continues under different xqcut and qcut options.

References to previous analyses:
* [EXO-19-018](https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=EXO-19-018): Technical details in [CMS AN-2019/103](https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/103) ([DAS link](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=dataset%3D%2FDarkPhotonToMuMu*M*madgraph*TuneCP5%2FRunIIAutumn18MiniAOD-102X*v15-v1%2FMINIAODSIM))
* [EXO-21-005](https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=EXO-21-005) (scouting): no central production

We ask for review from GEN so that we can proceed with the central MC request in EXO MC&I (@tvami).

[cc: @z4027163]
