### PR TITLE
Add ALP and EFT cards for dijets

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_customizecards.dat
@@ -1,0 +1,5 @@
+set param_card alppars 1 1.000000e+03
+set param_card alppars 2 1.000000e+00
+set param_card alppars 3 0.000000e+00
+set param_card alppars 4 0.000000e+00
+set param_card alppars 5 0.000000e+00

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_extramodels.dat
@@ -1,0 +1,1 @@
+ALP_linear_UFO.tar.gz

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_proc_card.dat
@@ -1,0 +1,30 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model ALP_linear_UFO
+define p = g u u~ d d~ c c~ s s~
+define j = g u u~ d d~ c c~ s s~
+generate p p > j j NP<=2 QED=0 @0
+add process p p > j j j NP<=2 QED=0 @1
+%add process p p > j j j j NP<=2 QED=0 @2
+output alp_QCD_HT4000toInf -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_reweight_card.dat
@@ -1,0 +1,83 @@
+change helicity False
+change rwgt_dir rwgt
+
+
+#******************** fa1000 ********************
+launch --rwgt_name=fa1000
+        set param_card alppars 1 1.000000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa1500 ********************
+launch --rwgt_name=fa1500
+        set param_card alppars 1 1.500000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa2000 ********************
+launch --rwgt_name=fa2000
+        set param_card alppars 1 2.000000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa2500 ********************
+launch --rwgt_name=fa2500
+        set param_card alppars 1 2.500000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa3000 ********************
+launch --rwgt_name=fa3000
+        set param_card alppars 1 3.000000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa3500 ********************
+launch --rwgt_name=fa3500
+        set param_card alppars 1 3.500000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa4000 ********************
+launch --rwgt_name=fa4000
+        set param_card alppars 1 4.000000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa4500 ********************
+launch --rwgt_name=fa4500
+        set param_card alppars 1 4.500000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa5000 ********************
+launch --rwgt_name=fa5000
+        set param_card alppars 1 5.000000e+03
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00
+
+#******************** fa50000 ********************
+launch --rwgt_name=fa50000
+        set param_card alppars 1 5.000000e+04
+        set param_card alppars 2 1.000000e+00
+        set param_card alppars 3 0.000000e+00
+        set param_card alppars 4 0.000000e+00
+        set param_card alppars 5 0.000000e+00

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/ALP_dijets/alp_QCD_HT4000toInf_run_card.dat
@@ -1,0 +1,245 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  'alp_QCD_HT'     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+#*********************************************************************
+  10000          = nevents ! Number of unweighted events requested 
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+#*********************************************************************
+        1     = lpp1  ! beam 1 type (0=NO PDF)
+        1     = lpp2  ! beam 2 type (0=NO PDF)
+     6500     = ebeam1  ! beam 1 energy in GeV
+     6500     = ebeam2  ! beam 2 energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                          
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+  F  = cut_decays ! Apply decays to products
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+#   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 10  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0.4 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0.4 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 4000  = htjmin ! minimum jet HT=Sum(jet pt)
+ 13000 = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor ! Apply b cuts !
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_customizecards.dat
@@ -1,0 +1,1 @@
+set param_card dim6 8 0.100000e+00

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_extramodels.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_extramodels.dat
@@ -1,0 +1,1 @@
+TopEffTh.zip

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_proc_card.dat
@@ -1,0 +1,30 @@
+#************************************************************
+#*                        MadGraph 5                        *
+#*                                                          *
+#*                *                       *                 *
+#*                  *        * *        *                   *
+#*                    * * * * 5 * * * *                     *
+#*                  *        * *        *                   *
+#*                *                       *                 *
+#*                                                          *
+#*                                                          *
+#*         VERSION 1.5.11                2013-06-21         *
+#*                                                          *
+#*    The MadGraph Development Team - Please visit us at    *
+#*    https://server06.fynu.ucl.ac.be/projects/madgraph     *
+#*                                                          *
+#************************************************************
+#*                                                          *
+#*               Command File for MadGraph 5                *
+#*                                                          *
+#*     run as ./bin/mg5  filename                           *
+#*                                                          *
+#************************************************************
+
+import model TopEffTh
+define p = g u u~ d d~ c c~ s s~
+define j = g u u~ d d~ c c~ s s~
+generate p p > j j NP==2 @0
+add process p p > j j j NP==2 @1
+add process p p > j j j j NP==2 @2
+output tripleG_QCD_HT4000toInf -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_reweight_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_reweight_card.dat
@@ -1,0 +1,51 @@
+change helicity False
+change rwgt_dir rwgt
+
+
+#******************** CG0p1 ********************
+launch --rwgt_name=CG0p1
+	set param_card dim6 8 0.100000e+00
+
+#******************** CG0p05 ********************
+launch --rwgt_name=CG0p05
+	set param_card dim6 8 0.050000e+00
+
+#******************** CG0p04 ********************
+launch --rwgt_name=CG0p04
+	set param_card dim6 8 0.040000e+00
+
+#******************** CG0p03 ********************
+launch --rwgt_name=CG0p03
+	set param_card dim6 8 0.030000e+00
+
+#******************** CG0p025 ********************
+launch --rwgt_name=CG0p025
+	set param_card dim6 8 0.025000e+00
+
+#******************** CG0p02 ********************
+launch --rwgt_name=CG0p02
+	set param_card dim6 8 0.020000e+00
+
+#******************** CG0p015 ********************
+launch --rwgt_name=CG0p015
+	set param_card dim6 8 0.015000e+00
+
+#******************** CG0p01 ********************
+launch --rwgt_name=CG0p01
+	set param_card dim6 8 0.010000e+00
+
+#******************** CG0p0075 ********************
+launch --rwgt_name=CG0p0075
+	set param_card dim6 8 0.007500e+00
+
+#******************** CG0p005 ********************
+launch --rwgt_name=CG0p005
+	set param_card dim6 8 0.005000e+00
+
+#******************** CG0p0025 ********************
+launch --rwgt_name=CG0p0025
+	set param_card dim6 8 0.002500e+00
+
+#******************** CG0p0 ********************
+launch --rwgt_name=CG0p0
+	set param_card dim6 8 0.000000e+00

--- a/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13TeV/TopEFT_tripleG_dijets/tripleG_QCD_HT4000toInf_run_card.dat
@@ -1,0 +1,245 @@
+#*********************************************************************
+#                       MadGraph/MadEvent                            *
+#                  http://madgraph.hep.uiuc.edu                      *
+#                                                                    *
+#                        run_card.dat                                *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************                                                 
+# Running parameters
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  'tripleG_QCD_HT'     = run_tag ! name of the run 
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+  .true.     = gridpack  !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+#*********************************************************************
+  10000          = nevents ! Number of unweighted events requested 
+      0 = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+#*********************************************************************
+        1     = lpp1  ! beam 1 type (0=NO PDF)
+        1     = lpp2  ! beam 2 type (0=NO PDF)
+     6500     = ebeam1  ! beam 1 energy in GeV
+     6500     = ebeam2  ! beam 2 energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+        0     = polbeam1 ! beam polarization for beam 1
+        0     = polbeam2 ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+ 'lhapdf'    = pdlabel     ! PDF set                                  
+  263000    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number 
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ F        = fixed_ren_scale  ! if .true. use fixed ren scale
+ F        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.1880  = scale            ! fixed ren scale
+ 91.1880  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.1880  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ 1        = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+ 1        = ickkw            ! 0 no matching, 1 MLM, 2 CKKW matching
+ 1        = highestmult      ! for ickkw=2, highest mult group
+ 1        = ktscheme         ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+ 1        = alpsfact         ! scale factor for QCD emission vx
+ F        = chcluster        ! cluster only according to channel diag
+ F        = pdfwgt           ! for ickkw=1, perform pdf reweighting
+ 5        = asrwgtflavor     ! highest quark flavor for a_s reweight
+ 3.0      = lhe_version       ! Change the way clustering information pass to shower.        
+#*********************************************************************
+#*********************************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+   T  = auto_ptj_mjj  ! Automatic setting of ptj and mjj
+#**********************************************************
+#                                                                          
+#                                                                    
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+  15  = bwcutoff
+#**********************************************************
+# Apply pt/E/eta/dr/mij cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#**********************************************************
+  F  = cut_decays ! Apply decays to products
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+#   0  = nhel          ! Number of helicities used per event
+#*******************                                                 
+# Standard Cuts
+#*******************                                                 
+#                                                                    
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = ptj       ! minimum pt for the jets 
+  0  = ptb       ! minimum pt for the b 
+ 10  = pta       ! minimum pt for the photons 
+ 10  = ptl       ! minimum pt for the charged leptons 
+  0  = misset    ! minimum missing Et (sum of neutrino's momenta)
+  0  = ptheavy   ! minimum pt for one heavy final state
+ 1.0 = ptonium   ! minimum pt for the quarkonium states
+ -1  = ptjmax    ! maximum pt for the jets
+ -1  = ptbmax    ! maximum pt for the b
+ -1  = ptamax    ! maximum pt for the photons
+ -1  = ptlmax    ! maximum pt for the charged leptons
+ -1  = missetmax ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the lab frame)                         *
+#*********************************************************************
+  0  = ej     ! minimum E for the jets 
+  0  = eb     ! minimum E for the b 
+  0  = ea     ! minimum E for the photons 
+  0  = el     ! minimum E for the charged leptons 
+ -1   = ejmax ! maximum E for the jets
+ -1   = ebmax ! maximum E for the b
+ -1   = eamax ! maximum E for the photons
+ -1   = elmax ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+   5  = etaj    ! max rap for the jets 
+  -1  = etab    ! max rap for the b
+ 2.5  = etaa    ! max rap for the photons 
+ 2.5  = etal    ! max rap for the charged leptons 
+ 0.6  = etaonium ! max rap for the quarkonium states
+   0  = etajmin ! min rap for the jets
+   0  = etabmin ! min rap for the b
+   0  = etaamin ! min rap for the photons
+   0  = etalmin ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0   = drjj    ! min distance between jets 
+ 0   = drbb    ! min distance between b's 
+ 0.4 = drll    ! min distance between leptons 
+ 0.4 = draa    ! min distance between gammas 
+ 0   = drbj    ! min distance between b and jet 
+ 0.4 = draj    ! min distance between gamma and jet 
+ 0.4 = drjl    ! min distance between jet and lepton 
+ 0   = drab    ! min distance between gamma and b 
+ 0   = drbl    ! min distance between b and lepton 
+ 0.4 = dral    ! min distance between gamma and lepton 
+ -1  = drjjmax ! max distance between jets
+ -1  = drbbmax ! max distance between b's
+ -1  = drllmax ! max distance between leptons
+ -1  = draamax ! max distance between gammas
+ -1  = drbjmax ! max distance between b and jet
+ -1  = drajmax ! max distance between gamma and jet
+ -1  = drjlmax ! max distance between jet and lepton
+ -1  = drabmax ! max distance between gamma and b
+ -1  = drblmax ! max distance between b and lepton
+ -1  = dralmax ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0   = mmjj    ! min invariant mass of a jet pair 
+ 0   = mmbb    ! min invariant mass of a b pair 
+ 0   = mmaa    ! min invariant mass of gamma gamma pair
+ 0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1  = mmjjmax ! max invariant mass of a jet pair
+ -1  = mmbbmax ! max invariant mass of a b pair
+ -1  = mmaamax ! max invariant mass of gamma gamma pair
+ -1  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+ 0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+ 0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0  = xptj ! minimum pt for at least one jet  
+ 0  = xptb ! minimum pt for at least one b 
+ 0  = xpta ! minimum pt for at least one photon 
+ 0  = xptl ! minimum pt for at least one charged lepton 
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+ 0   = ptj1min ! minimum pt for the leading jet in pt
+ 0   = ptj2min ! minimum pt for the second jet in pt
+ 0   = ptj3min ! minimum pt for the third jet in pt
+ 0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1  = ptj1max ! maximum pt for the leading jet in pt 
+ -1  = ptj2max ! maximum pt for the second jet in pt
+ -1  = ptj3max ! maximum pt for the third jet in pt
+ -1  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+ 0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0   = ptl2min ! minimum pt for the second lepton in pt
+ 0   = ptl3min ! minimum pt for the third lepton in pt
+ 0   = ptl4min ! minimum pt for the fourth lepton in pt
+ -1  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1  = ptl2max ! maximum pt for the second lepton in pt
+ -1  = ptl3max ! maximum pt for the third lepton in pt
+ -1  = ptl4max ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+ 4000  = htjmin ! minimum jet HT=Sum(jet pt)
+ 13000 = htjmax ! maximum jet HT=Sum(jet pt)
+ 0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1  = ihtmax  !inclusive Ht for all partons (including b)
+ 0   = ht2min ! minimum Ht for the two leading jets
+ 0   = ht3min ! minimum Ht for the three leading jets
+ 0   = ht4min ! minimum Ht for the four leading jets
+ -1  = ht2max ! maximum Ht for the two leading jets
+ -1  = ht3max ! maximum Ht for the three leading jets
+ -1  = ht4max ! maximum Ht for the four leading jets
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+ 0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor ! Apply b cuts !
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+ 10   = xqcut   ! minimum kt jet measure between partons
+#*********************************************************************
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+   T  = use_syst      ! Enable systematics studies

--- a/genfragments/ThirteenTeV/ADD/ADDdiJet_LambdaT-10000_MHat-6000to13000_PtHat-600toInf_TuneCP5_13TeV-pythia8_cfi.py
+++ b/genfragments/ThirteenTeV/ADD/ADDdiJet_LambdaT-10000_MHat-6000to13000_PtHat-600toInf_TuneCP5_13TeV-pythia8_cfi.py
@@ -1,7 +1,7 @@
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
-process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+process.generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
 	comEnergy = cms.double(13000),
 	crossSection = cms.untracked.double(1),
 	filterEfficiency = cms.untracked.double(1),

--- a/genfragments/ThirteenTeV/ADD/ADDdiJet_LambdaT-10000_MHat-6000to13000_PtHat-600toInf_TuneCP5_13TeV-pythia8_cfi.py
+++ b/genfragments/ThirteenTeV/ADD/ADDdiJet_LambdaT-10000_MHat-6000to13000_PtHat-600toInf_TuneCP5_13TeV-pythia8_cfi.py
@@ -1,0 +1,32 @@
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+	comEnergy = cms.double(13000),
+	crossSection = cms.untracked.double(1),
+	filterEfficiency = cms.untracked.double(1),
+	maxEventsToPrint = cms.untracked.int32(0),
+	pythiaHepMCVerbosity = cms.untracked.bool(False),
+	pythiaPylistVerbosity = cms.untracked.int32(0),
+	
+	PythiaParameters = cms.PSet(
+                pythia8CommonSettingsBlock,
+                pythia8CP5SettingsBlock,
+		processParameters = cms.vstring(
+			'PhaseSpace:mHatMin = 6000 ',
+			'PhaseSpace:mHatMax = 13000 ',
+			'PhaseSpace:pTHatMin = 600.0 ',
+			'HardQCD:all = off ',
+	                'ExtraDimensionsLED:dijets = on',
+			'ExtraDimensionsLED:CutOffmode = 0',
+			'ExtraDimensionsLED:LambdaT = 10000',
+			'ExtraDimensionsLED:negInt = 0', # Change sign of interferecen term if ==1
+			'ExtraDimensionsLED:nQuarkNew = 5', # outgoing mass-less quark flavours
+			'ExtraDimensionsLED:opMode = 1', # 0=Franceshini paper 1=Giudice paper
+
+		),
+		parameterSets = cms.vstring('pythia8CommonSettings',
+                                            'pythia8CP5Settings',
+                                            'processParameters')
+	)
+)


### PR DESCRIPTION
These are the Madgraph cards for virtual ALP exchange and EFT triple-gluon coupling in dijet angular distributions used in EXO-24-011.

(it is build on top of #3864, maybe consider this after the other)