### PR TITLE
Add Run3 pp 5.36TeV MadGraph gen fragments

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_customizecards.dat
@@ -1,0 +1,22 @@
+# These inputs are based on fixing the PDG vlaues of mZ, mW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s) dependent.
+# We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+
+set param_card SMINPUTS 1 132.30648214177197
+set param_card SMINPUTS 2 1.1663787e-05
+
+# Z boson
+set param_card mass 23 91.153509740726733
+set param_card DECAY 23 2.4932018986110700
+
+# W boson
+set param_card mass 24 80.351812293789408
+set param_card DECAY 24 2.0904310808144846
+
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCTopWGSummaryPlots#Top_Quark_Mass
+# CMS combined result (Sep 2015)
+
+# top quark
+set param_card mass 6 172.5
+set param_card DECAY 6 1.311
+set param_card yukawa 6 172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_proc_card.dat
@@ -1,0 +1,20 @@
+import model sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+generate p p > ell+ vl $ t t~ h @0
+add process p p > ell- vl~ $ t t~ h @1
+add process p p > ell+ vl j $ t t~ h @2
+add process p p > ell- vl~ j $ t t~ h @3
+add process p p > ell+ vl j j $ t t~ h @4
+add process p p > ell- vl~ j j $ t t~ h @5
+add process p p > ell+ vl j j j $ t t~ h @6
+add process p p > ell- vl~ j j j $ t t~ h @7
+add process p p > ell+ vl j j j j $ t t~ h @8
+add process p p > ell- vl~ j j j j $ t t~ h @9
+
+output wellnu4j_5f_LO_MLM -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_run_card.dat
@@ -1,0 +1,227 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  3000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                3=photon from electron, 4=photon from muon          *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     2680     = ebeam1  ! beam 1 total energy in GeV
+     2680     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     'lhapdf'    = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 10   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   1  = sde_strategy  ! default integration strategy (hep-ph/2021.xxxxx)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.0  = pta        ! minimum pt for the photons
+ 0.0  = ptj        ! minimum pt for the jets 
+ 0.0   = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0 = etaa    ! max rap for the photons
+ -1.0 = etaj    ! max rap for the jets 
+ -1.0 = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = draj    ! min distance between gamma and jet 
+ 0.0 = dral    ! min distance between gamma and lepton 
+ 0.0 = drjj    ! min distance between jets
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = dralmax ! maxdistance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptj ! minimum pt for at least one jet
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of the jets sorted by pt                          *
+ #*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt 
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ #*********************************************************************
+ # Control the Ht(k)=Sum of k leading jets                            *
+ #*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+ -1.0	= ht2max ! maximum Ht for the two leading jets
+ -1.0	= ht3max ! maximum Ht for the three leading jets
+ -1.0	= ht4max ! maximum Ht for the four leading jets
+ #*********************************************************************
+ # WBF cuts                                                           *
+ #*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+
+#**************************************
+# Manually added by Sihyun Jeon
+#**************************************
+  False	= cut_decays ! Cut decay products 
+  False	= pdfwgt ! for ickkw=1, perform pdf reweighting

--- a/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_customizecards.dat
@@ -1,0 +1,22 @@
+# These inputs are based on fixing the PDG vlaues of mZ, mW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s) dependent.
+# We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+
+set param_card SMINPUTS 1 132.30648214177197
+set param_card SMINPUTS 2 1.1663787e-05
+
+# Z boson
+set param_card mass 23 91.153509740726733
+set param_card DECAY 23 2.4932018986110700
+
+# W boson
+set param_card mass 24 80.351812293789408
+set param_card DECAY 24 2.0904310808144846
+
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCTopWGSummaryPlots#Top_Quark_Mass
+# CMS combined result (Sep 2015)
+
+# top quark
+set param_card mass 6 172.5
+set param_card DECAY 6 1.311
+set param_card yukawa 6 172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_proc_card.dat
@@ -1,0 +1,20 @@
+import model sm-ckm_no_b_mass
+
+define ell+ = e+ mu+ ta+
+define ell- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+generate p p > ell+ vl $ t t~ h @0
+add process p p > ell- vl~ $ t t~ h @1
+add process p p > ell+ vl j $ t t~ h @2
+add process p p > ell- vl~ j $ t t~ h @3
+add process p p > ell+ vl j j $ t t~ h @4
+add process p p > ell- vl~ j j $ t t~ h @5
+add process p p > ell+ vl j j j $ t t~ h @6
+add process p p > ell- vl~ j j j $ t t~ h @7
+add process p p > ell+ vl j j j j $ t t~ h @8
+add process p p > ell- vl~ j j j j $ t t~ h @9
+
+output wellnu4j_5f_LO_MLM -nojpeg
+

--- a/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/PbPb_5p36TeV/wellnu4j_5f_LO_MLM/wellnu4j_5f_LO_MLM_run_card.dat
@@ -1,0 +1,227 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  3000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                3=photon from electron, 4=photon from muon          *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     2681     = ebeam1  ! beam 1 total energy in GeV
+     2681     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     'lhapdf'    = pdlabel     ! PDF set                                     
+     $DEFAULT_nPDF_SETS    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_nPDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False = fixed_ren_scale  ! if .true. use fixed ren scale
+ False        = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  True     = gridpack  !True = setting up the grid pack
+  -1.0 = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 1 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 10   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+ 0.4   =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   1  = sde_strategy  ! default integration strategy (hep-ph/2021.xxxxx)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+ 0.0  = pta        ! minimum pt for the photons
+ 0.0  = ptj        ! minimum pt for the jets 
+ 0.0   = ptl       ! minimum pt for the charged leptons 
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0 = etaa    ! max rap for the photons
+ -1.0 = etaj    ! max rap for the jets 
+ -1.0 = etal    ! max rap for the charged leptons 
+ 0.0  = etalmin ! main rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = draj    ! min distance between gamma and jet 
+ 0.0 = dral    ! min distance between gamma and lepton 
+ 0.0 = drjj    ! min distance between jets
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = dralmax ! maxdistance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+ 0.0   = mmjj    ! min invariant mass of a jet pair
+ 0.0   = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+ -1.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptj ! minimum pt for at least one jet
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of the jets sorted by pt                          *
+ #*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt 
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ #*********************************************************************
+ # Control the Ht(k)=Sum of k leading jets                            *
+ #*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+ -1.0	= ht2max ! maximum Ht for the two leading jets
+ -1.0	= ht3max ! maximum Ht for the three leading jets
+ -1.0	= ht4max ! maximum Ht for the four leading jets
+ #*********************************************************************
+ # WBF cuts                                                           *
+ #*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+   True  = use_syst      ! Enable systematics studies
+
+#**************************************
+# Manually added by Sihyun Jeon
+#**************************************
+  False	= cut_decays ! Cut decay products 
+  False	= pdfwgt ! for ickkw=1, perform pdf reweighting

--- a/bin/Starlight/macros/convert_SL2LHE.cpp
+++ b/bin/Starlight/macros/convert_SL2LHE.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include "Math/Vector4D.h"
 #include "TDatabasePDG.h"
+#include "TSystem.h"
 
 
 int getMomPdgID(const int& chnId)
@@ -33,6 +34,7 @@ int getMomPdgID(const int& chnId)
 
 void convert_SL2LHE(const std::string& inFileName, const double& beamE1, const double& beamE2, const int& chnId)
 {
+  gSystem->Unsetenv("CLING_PREBUILT_MODULE_PATH");
   // Open input file
   std::ifstream inFile(inFileName);
   if (not inFile.is_open())

--- a/bin/UPCgen/macros/convert_UGROOT2LHE.cpp
+++ b/bin/UPCgen/macros/convert_UGROOT2LHE.cpp
@@ -5,10 +5,12 @@
 #include "TFile.h"
 #include "TTreeReader.h"
 #include "TTreeReaderValue.h"
+#include "TSystem.h"
 
 
 void convert_UGROOT2LHE(const std::string& inFileName, const double& beamE1, const double& beamE2)
 {
+  gSystem->Unsetenv("CLING_PREBUILT_MODULE_PATH");
   // Open input file
   TFile inFile(inFileName.c_str(), "READ");
   if (not inFile.IsOpen())

--- a/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
+++ b/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_10_50_NLO_FXFX-fragment.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc12/dyellell012j_5f_NLO_FXFX_M10to50_el8_amd64_gcc12_CMSSW_14_1_7_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/dyellell012j_5f_NLO_FXFX_M10to50
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
+++ b/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_DY012JToLL_M_50_NLO_FXFX-fragment.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc12/dyellell012j_5f_NLO_FXFX_el8_amd64_gcc12_CMSSW_14_1_7_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/dyellell012j_5f_NLO_FXFX
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0',
+            'BeamRemnants:primordialKThard=2.13'#kT for 5.36 TeV from GEN-22-001 slope
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
+++ b/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_TT012J_NLO_FXFX-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc12/tt012j_5f_ckm_NLO_FXFX_NNLO3p1_el8_amd64_gcc12_CMSSW_14_1_7_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/tt012j_5f_ckm_NLO_FXFX_NNLO3p1
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 40.',
+            'JetMatching:qCutME = 20.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_W012JToLNu_NLO_FXFX-fragment.py
+++ b/genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO/MADGRAPH_W012JToLNu_NLO_FXFX-fragment.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/RunIII/5p36TeV/MadGraph5_aMCatNLO/el8_amd64_gcc12/wellnu012j_5f_NLO_FXFX_el8_amd64_gcc12_CMSSW_14_1_7_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
+    generateConcurrently = cms.untracked.bool(False)
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/master/bin/MadGraph5_aMCatNLO/cards/production/5p36TeV/wellnu012j_5f_NLO_FXFX
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCut = 30.',
+            'JetMatching:qCutME = 10.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 2',
+            'TimeShower:mMaxGamma = 4.0'
+        ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'processParameters',
+            'pythia8PSweightsSettings'
+        )
+    ),
+    comEnergy = cms.double(5360.),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR adds the genfragments for official pp reference 5.36 TeV (Run3) production of MadGraph generator in the directory: genfragments/ppRef_5p36TeV/MadGraph5_aMCatNLO .

The genfragments are created using as templates the central production MadGraph genfragments for RunIII2024Summer24 defined in https://github.com/cms-PdmV/GridpackFiles/tree/master/Cards/MadGraph5_aMCatNLO .

@sarteagae @DickyChant @bbilin 