### PR TITLE
New cards for DY1jToEE in the mass range 4-50 GeV

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_customizecards.dat
@@ -1,0 +1,22 @@
+# These inputs are based on fixing the PDG vlaues of mZ, mW, and G_fermi
+# The MC programs use a constant width scheme, whereas PDG values are sqrt(s) dependent.
+# We correct for this following Sect. 3.1 in https://arxiv.org/pdf/1606.02330.pdf
+
+set param_card SMINPUTS 1 128.82531590804655
+set param_card SMINPUTS 2 1.1663787e-05
+
+# Z boson
+set param_card mass 23 91.153509740726733
+set param_card DECAY 23 2.4932018986110700
+
+# W boson
+set param_card mass 24 79.906853549493746
+set param_card DECAY 24 2.085
+
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCTopWGSummaryPlots#Top_Quark_Mass
+# CMS combined result (Sep 2015)
+
+# top quark
+set param_card mass 6 172.5
+set param_card DECAY 6 1.311
+set param_card yukawa 6 172.5

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_proc_card.dat
@@ -1,0 +1,5 @@
+import model sm-ckm_no_b_mass
+
+generate p p > e+ e- j
+
+output DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f/DY1jToEE_MEE-4To50_PtE7_PtJ15_LO_5f_run_card.dat
@@ -1,0 +1,227 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#                                                                    *
+#   To display more options, you can type the command:               *
+#      update full_run_card                                          *
+#*********************************************************************
+#                                                                    
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+  tag_1     = run_tag ! name of the run 
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+#*********************************************************************
+  3000 = nevents ! Number of unweighted events requested 
+  0   = iseed   ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                3=photon from electron, 4=photon from muon          *
+#*********************************************************************
+     1        = lpp1    ! beam 1 type 
+     1        = lpp2    ! beam 2 type
+     6800     = ebeam1  ! beam 1 total energy in GeV
+     6800     = ebeam2  ! beam 2 total energy in GeV
+# To see polarised beam options: type "update beam_pol"
+
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+     'lhapdf'    = pdlabel     ! PDF set                                     
+     $DEFAULT_PDF_SETS    = lhaid     ! if pdlabel=lhapdf, this is the lhapdf number
+     $DEFAULT_PDF_MEMBERS = reweight_PDF
+# To see heavy ion options: type "update ion_pdf"
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+ False   = fixed_ren_scale  ! if .true. use fixed ren scale
+ False   = fixed_fac_scale  ! if .true. use fixed fac scale
+ 91.188  = scale            ! fixed ren scale
+ 91.188  = dsqrt_q2fact1    ! fixed fact scale for pdf1
+ 91.188  = dsqrt_q2fact2    ! fixed fact scale for pdf2
+ -1 = dynamical_scale_choice ! Choose one of the preselected dynamical choices
+ 1.0  = scalefact        ! scale factor for event-by-event scales
+#*********************************************************************
+# Type and output format
+#*********************************************************************
+  True    = gridpack  !True = setting up the grid pack
+  -1.0    = time_of_flight ! threshold (in mm) below which the invariant livetime is not written (-1 means not written)
+  average =  event_norm       ! average/sum. Normalization of the weight in the LHEF
+#*********************************************************************
+# Matching parameter (MLM only)
+#*********************************************************************
+ 0 = ickkw            ! 0 no matching, 1 MLM
+ 1.0 = alpsfact         ! scale factor for QCD emission vx
+ False = chcluster        ! cluster only according to channel diag
+ 5 = asrwgtflavor     ! highest quark flavor for a_s reweight
+ True  = auto_ptj_mjj  ! Automatic setting of ptj and mjj if xqcut >0
+                                   ! (turn off for VBF and single top processes)
+ 0   = xqcut   ! minimum kt jet measure between partons
+
+#***********************************************************************
+# Turn on either the ktdurham or ptlund cut to activate                *
+# CKKW(L) merging with Pythia8 [arXiv:1410.3012, arXiv:1109.4829]      *
+#***********************************************************************
+ -1.0  =  ktdurham
+  0.4  =  dparameter
+ -1.0  =  ptlund
+ 1, 2, 3, 4, 5, 6, 21  =  pdgs_for_merging_cut ! PDGs for two cuts above
+
+#*********************************************************************
+#
+#*********************************************************************
+# Phase-Space Optimization strategy (basic options)
+#*********************************************************************
+   0  = nhel          ! using helicities importance sampling or not.
+                             ! 0: sum over helicity, 1: importance sampling
+   1  = sde_strategy  ! default integration strategy (hep-ph/2021.xxxxx)
+                             ! 1 is old strategy (using amp square)
+			     ! 2 is new strategy (using only the denominator)
+# To see advanced option for Phase-Space optimization: type "update psoptim"			     
+#*********************************************************************
+# Generation bias, check the wiki page below for more information:   *
+#  'cp3.irmp.ucl.ac.be/projects/madgraph/wiki/LOEventGenerationBias' *
+#*********************************************************************
+ None = bias_module  ! Bias type of bias, [None, ptj_bias, -custom_folder-]
+ {} = bias_parameters ! Specifies the parameters of the module.
+#
+#*******************************                                                 
+# Parton level cuts definition *
+#*******************************                                     
+#                                                                    
+#
+#*********************************************************************
+# BW cutoff (M+/-bwcutoff*Gamma) ! Define on/off-shell for "$" and decay  
+#*********************************************************************
+  15.0  = bwcutoff      ! (M+/-bwcutoff*Gamma)
+#*********************************************************************
+# Standard Cuts                                                      *
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+  0.0  = pta       ! minimum pt for the photons
+ 15.0  = ptj       ! minimum pt for the jets
+  7.0  = ptl       ! minimum pt for the charged leptons
+ -1.0  = ptamax    ! maximum pt for the photons
+ -1.0  = ptjmax    ! maximum pt for the jets
+ -1.0  = ptlmax    ! maximum pt for the charged leptons
+ {} = pt_min_pdg ! pt cut for other particles (use pdg code). Applied on particle and anti-particle
+ {}	= pt_max_pdg ! pt cut for other particles (syntax e.g. {6: 100, 25: 50}) 
+#
+# For display option for energy cut in the partonic center of mass frame type 'update ecut'
+#
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+ -1.0 = etaa    ! max rap for the photons
+ -1.0 = etaj    ! max rap for the jets
+  1.5 = etal    ! max rap for the charged leptons
+  0.0 = etalmin ! min rap for the charged leptons
+ {} = eta_min_pdg ! rap cut for other particles (use pdg code). Applied on particle and anti-particle
+ {} = eta_max_pdg ! rap cut for other particles (syntax e.g. {6: 2.5, 23: 5})
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+ 0.0 = draj    ! min distance between gamma and jet 
+ 0.0 = dral    ! min distance between gamma and lepton 
+ 0.0 = drjj    ! min distance between jets
+ 0.0 = drll    ! min distance between leptons 
+ 0.0 = drjl    ! min distance between jet and lepton
+ -1.0  = drajmax ! max distance between gamma and jet
+ -1.0  = dralmax ! maxdistance between gamma and lepton 
+ -1.0  = drjjmax ! max distance between jets 
+ -1.0  = drllmax ! max distance between leptons
+ -1.0  = drjlmax ! max distance between jet and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+#*********************************************************************
+  0.0  = mmjj    ! min invariant mass of a jet pair
+ -1.0  = mmjjmax ! max invariant mass of a jet pair
+  4.0  = mmll    ! min invariant mass of l+l- (same flavour) lepton pair
+  50.0  = mmllmax ! max invariant mass of l+l- (same flavour) lepton pair
+ {} = mxx_min_pdg ! min invariant mass of a pair of particles X/X~ (e.g. {6:250})
+ {'default': False} = mxx_only_part_antipart ! if True the invariant mass is applied only 
+                       ! to pairs of particle/antiparticle and not to pairs of the same pdg codes.  
+ #*********************************************************************
+ # Minimum and maximum invariant mass for all letpons                 *
+ #*********************************************************************
+ 0.0   = mmnl    ! min invariant mass for all letpons (l+- and vl) 
+ -1.0  = mmnlmax ! max invariant mass for all letpons (l+- and vl) 
+ #*********************************************************************
+ # Minimum and maximum pt for 4-momenta sum of leptons / neutrino     *
+ #  for pair of lepton includes only same flavor, opposite charge
+ #*********************************************************************
+ 0.0   = ptllmin  ! Minimum pt for 4-momenta sum of leptons(l and vl)
+ -1.0  = ptllmax  ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+ 0.0  = xptj ! minimum pt for at least one jet
+ 0.0  = xptl ! minimum pt for at least one charged lepton 
+ #*********************************************************************
+ # Control the pt's of the jets sorted by pt                          *
+ #*********************************************************************
+ 0.0   = ptj1min ! minimum pt for the leading jet in pt
+ 0.0   = ptj2min ! minimum pt for the second jet in pt
+ 0.0   = ptj3min ! minimum pt for the third jet in pt
+ 0.0   = ptj4min ! minimum pt for the fourth jet in pt
+ -1.0  = ptj1max ! maximum pt for the leading jet in pt 
+ -1.0  = ptj2max ! maximum pt for the second jet in pt
+ -1.0  = ptj3max ! maximum pt for the third jet in pt 
+ -1.0  = ptj4max ! maximum pt for the fourth jet in pt
+ 0   = cutuse  ! reject event if fails any (0) / all (1) jet pt cuts
+ #*********************************************************************
+ # Control the pt's of leptons sorted by pt                           *
+ #*********************************************************************
+ 0.0   = ptl1min ! minimum pt for the leading lepton in pt
+ 0.0   = ptl2min ! minimum pt for the second lepton in pt
+ -1.0  = ptl1max ! maximum pt for the leading lepton in pt 
+ -1.0  = ptl2max ! maximum pt for the second lepton in pt
+ #*********************************************************************
+ # Control the Ht(k)=Sum of k leading jets                            *
+ #*********************************************************************
+ 0.0   = htjmin ! minimum jet HT=Sum(jet pt)
+ -1.0  = htjmax ! maximum jet HT=Sum(jet pt)
+ 0.0   = ihtmin  !inclusive Ht for all partons (including b)
+ -1.0  = ihtmax  !inclusive Ht for all partons (including b)
+  0.0	= ht2min ! minimum Ht for the two leading jets
+  0.0	= ht3min ! minimum Ht for the three leading jets
+  0.0	= ht4min ! minimum Ht for the four leading jets
+ -1.0	= ht2max ! maximum Ht for the two leading jets
+ -1.0	= ht3max ! maximum Ht for the three leading jets
+ -1.0	= ht4max ! maximum Ht for the four leading jets
+ #*********************************************************************
+ # WBF cuts                                                           *
+ #*********************************************************************
+ 0.0   = xetamin ! minimum rapidity for two jets in the WBF case  
+ 0.0   = deltaeta ! minimum rapidity for two jets in the WBF case 
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+ 5 = maxjetflavor    ! Maximum jet pdg code
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: Do not use for interference type of computation           *
+#*********************************************************************
+  False = use_syst   ! Enable systematics studies
+
+#**************************************
+# Manually added by Sihyun Jeon
+#**************************************
+  False	= cut_decays ! Cut decay products 
+  False	= pdfwgt ! for ickkw=1, perform pdf reweighting


### PR DESCRIPTION
These cards are prepared following the example of https://github.com/cms-sw/genproductions/pull/3860 , with a different requirement on the dielectron invariant mass, considered to be in the mass range between 4-50 GeV.
MC samples are meant to be used in the context of the development and validation of the new low mass diphoton and dielectron trigger for 2025.

FYI: @lathomas @missirol 

### Gridpack validation:
Generated gridpack has been tested with the command:
`./runcmsgrid.sh 10000 1`

The output reported below:
```
# original cross-section: 92.53359999999125
#     scale variation: +34.5% -28%
#     emission scale variation: + 0% - 0%
#     central scheme variation: +3.91% -4.1%
# PDF variation: +1.81% -1.81%
#
#PDF NNPDF31_nnlo_as_0118_mc: 92.5386 +0.854% -0.854%
#PDF NNPDF31_nlo_hessian_pdfas: 91.3377 + 2% - 2%
#PDF NNPDF40_nnlo_pdfas: 92.6222 +1.06% -1.06%
#PDF NNPDF40_nnlo_hessian_pdfas: 92.6812 +1.07% -1.07%
#PDF NNPDF40_nnlo_pch_as_01180: 91.4775 +0.803% -0.803%
#PDF CT18NNLO: 90.5513 +1.67% -3.01%
#PDF CT18ZNNLO: 91.9679 +1.97% -2.48%
#PDF MSHT20nnlo_as118: 90.173 +1.15% -1.57%
#PDF PDF4LHC21_40_pdfas: 90.7942 +1.92% -1.92%
#PDF HERAPDF20_NNLO_EIG: 95.1408 +0.939% -1.13%
#PDF ABMP16als118_5_nnlo: 93.2825 +1.07% -1.07%
# dynamical scheme # 1 : 95.3898 +31.4% -25.9% # \sum ET
# dynamical scheme # 2 : 95.3898 +31.4% -25.9% # \sum\sqrt{m^2+pt^2}
# dynamical scheme # 3 : 88.7361 +39.6% -31.3% # 0.5 \sum\sqrt{m^2+pt^2}
# dynamical scheme # 4 : 96.151 +29.8% -24.8% # \sqrt{\hat s}
# PDF 263000 : 104.82244626423176
```
