### PR TITLE
add CRMC generator

### DIFF
--- a/bin/CRMC/genfragments/gen_fragment.py
+++ b/bin/CRMC/genfragments/gen_fragment.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring(PATH_TO_TARBALL),
+    nEvents = cms.untracked.uint32(1),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        process_off = cms.vstring(
+            'ProcessLevel:all = off',
+        ),
+        parameterSets = cms.vstring('process_off')
+    ),
+    comEnergy = cms.double(BEAM_ENERGY),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/bin/CRMC/genfragments/gen_fragment.py
+++ b/bin/CRMC/genfragments/gen_fragment.py
@@ -10,10 +10,11 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
 
 generator = cms.EDFilter("Pythia8HadronizerFilter",
     PythiaParameters = cms.PSet(
-        process_off = cms.vstring(
+        skip_hadronization = cms.vstring(
             'ProcessLevel:all = off',
+            'Check:event = off'
         ),
-        parameterSets = cms.vstring('process_off')
+        parameterSets = cms.vstring('skip_hadronization')
     ),
     comEnergy = cms.double(BEAM_ENERGY),
     filterEfficiency = cms.untracked.double(1.0),

--- a/bin/CRMC/gridpack_generation.sh
+++ b/bin/CRMC/gridpack_generation.sh
@@ -59,7 +59,7 @@ install_crmc(){
 
 make_tarball(){
     #Set tarball name
-    TARBALL=crmc_${generator}_pO_${SCRAM_ARCH}_${CMSSW_VERSION}_tarball.tgz
+    TARBALL=crmc_${generator}_${SCRAM_ARCH}_${CMSSW_VERSION}_tarball.tgz
 
     echo "Creating tarball"
     cd ${WORKDIR}

--- a/bin/CRMC/gridpack_generation.sh
+++ b/bin/CRMC/gridpack_generation.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+fail_exit() { echo "$@"; exit 1; }
+
+create_setup(){
+    echo "Using scram_arch: ${SCRAM_ARCH}"
+    echo "Using cmssw_version: ${CMSSW_VERSION}"
+
+    GENDIR=${PRODDIR}/tarball_$RANDOM
+    [[ -d "${GENDIR}" ]] && rm -rf ${GENDIR}
+    mkdir -p ${GENDIR} && cd ${GENDIR}
+
+    #Set up environment and working directory 
+    export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+    source ${VO_CMS_SW_DIR}/cmsset_default.sh
+    scram project -n ${CMSSW_VERSION} CMSSW ${CMSSW_VERSION} 
+    cd ${CMSSW_VERSION} && mkdir -p work && cd work
+    eval `scram runtime -sh`
+    WORKDIR=`pwd -P`
+
+    #Copy relevant scripts and code
+    cp ${PRODDIR}/runcmsgrid_crmc.sh ${WORKDIR}/runcmsgrid.sh
+    chmod 755 ${WORKDIR}/runcmsgrid.sh
+}
+
+install_crmc(){
+    CRMC_VER=v2.2.0
+    CRMC=crmc-${CRMC_VER}
+    cd ${WORKDIR}
+
+    echo "Downloading "${CRMC}
+    CRMCDIR=${WORKDIR}/crmc_v${CRMC//[!0-9]/}
+    wget --no-verbose --no-check-certificate https://gitlab.iap.kit.edu/AirShowerPhysics/crmc/-/archive/${CRMC_VER}/${CRMC}.tar.gz
+    tar -xzf ${CRMC}.tar.gz && mv ${CRMC} ${CRMCDIR}
+    rm -f ${CRMC}.tar.gz
+
+    echo "Compiling ${CRMC}"
+    cd ${CRMCDIR}
+    source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME
+    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
+    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${CRMCDIR}/install -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
+    ${CMAKE} --build BUILD --target install --parallel $(nproc)
+    rm -rf BUILD install
+
+
+    #Set installation parameters
+    sed -i 's/SCRAM_ARCH_VERSION_REPLACE/'${SCRAM_ARCH}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/CMSSW_VERSION_REPLACE/'${CMSSW_VERSION}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/GENERATOR_REPLACE/'${generator}'/g' ${WORKDIR}/runcmsgrid.sh
+    sed -i 's/CRMCDIR_REPLACE/'${CRMCDIR##*/}'/g' ${WORKDIR}/runcmsgrid.sh
+}
+
+
+make_tarball(){
+    #Set tarball name
+    TARBALL=crmc_${generator}_pO_${SCRAM_ARCH}_${CMSSW_VERSION}_tarball.tgz
+
+    echo "Creating tarball"
+    cd ${WORKDIR}
+    tar -czf ${TARBALL} ${CRMCDIR##*/} runcmsgrid.sh
+    mv ${WORKDIR}/${TARBALL} ${PRODDIR}/
+    echo "Tarball created successfully at ${PRODDIR}/${TARBALL}"
+}
+
+#Set main directory
+PRODDIR=`pwd`
+if [[ ! -f "${PRODDIR}/gridpack_generation.sh" ]] ; then
+    echo "Cannot locate gridpack_generation.sh in current path"
+    exit 1
+fi
+
+#First you need to set the generator:
+generator=${1}
+
+#Set scram_arch
+if [ -n "$2" ]; then
+    SCRAM_ARCH=${2}
+else
+    # sync default cmssw with the current OS
+    export SYSTEM_RELEASE=`cat /etc/redhat-release`
+    if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+        SCRAM_ARCH=slc6_amd64_gcc700
+    elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+        SCRAM_ARCH=slc7_amd64_gcc11
+    elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
+        SCRAM_ARCH=el8_amd64_gcc11
+    elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
+        SCRAM_ARCH=el9_amd64_gcc11
+    else
+        echo "No default scram_arch for current OS"
+        exit 1
+    fi
+fi
+export SCRAM_ARCH=${SCRAM_ARCH}
+
+#Set cmssw
+if [ -n "$3" ]; then
+    CMSSW_VERSION=${3}
+else
+    if [[ $SYSTEM_RELEASE == *"release 6"* ]]; then
+        CMSSW_VERSION=CMSSW_10_3_5
+    elif [[ $SYSTEM_RELEASE == *"release 7"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_18
+    elif [[ $SYSTEM_RELEASE == *"release 8"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_18_HeavyIon
+    elif [[ $SYSTEM_RELEASE == *"release 9"* ]]; then
+        CMSSW_VERSION=CMSSW_13_0_18
+    else
+        echo "No default CMSSW for current OS"
+        exit 1
+    fi
+fi
+export CMSSW_VERSION=${CMSSW_VERSION}
+
+if [ -z ${generator} ]; then
+    echo "generator was not selected"
+fi
+    
+#Create set up
+create_setup
+
+#Install crmc
+install_crmc
+
+#Create tarball
+make_tarball
+
+#Clean up
+echo "Removing "${GENDIR}
+rm -rf ${GENDIR}
+
+echo "End of job on " `date`
+exit 0

--- a/bin/CRMC/gridpack_generation.sh
+++ b/bin/CRMC/gridpack_generation.sh
@@ -37,6 +37,12 @@ install_crmc(){
     echo "Compiling ${CRMC}"
     cd ${CRMCDIR}
     source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME
+    # FIXME - hack to change beam mother index from -1 to 0
+    sed -i '1684s/.*/        jmohep(1,nhep)=0/' src/epos/epos-bas.f
+    sed -i '1685s/.*/        jmohep(2,nhep)=0/' src/epos/epos-bas.f
+    sed -i '1712s/.*/        jmohep(1,nhep)=0/' src/epos/epos-bas.f
+    sed -i '1713s/.*/        jmohep(2,nhep)=0/' src/epos/epos-bas.f
+    sed -i 's/AB-->/AB->/g' /src/epos/epos-bas.f #FIXME    
     CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
     ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${CRMCDIR}/install -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
     ${CMAKE} --build BUILD --target install --parallel $(nproc)

--- a/bin/CRMC/gridpack_generation.sh
+++ b/bin/CRMC/gridpack_generation.sh
@@ -42,7 +42,9 @@ install_crmc(){
     sed -i '1685s/.*/        jmohep(2,nhep)=0/' src/epos/epos-bas.f
     sed -i '1712s/.*/        jmohep(1,nhep)=0/' src/epos/epos-bas.f
     sed -i '1713s/.*/        jmohep(2,nhep)=0/' src/epos/epos-bas.f
-    sed -i 's/AB-->/AB->/g' /src/epos/epos-bas.f #FIXME    
+    # FIXME - hack to modify comments to fit xml format
+    sed -i 's/AB-->/AB->/g' src/epos/epos-bas.f
+       
     CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
     ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${CRMCDIR}/install -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
     ${CMAKE} --build BUILD --target install --parallel $(nproc)

--- a/bin/CRMC/run_generic_tarball_cvmfs.sh
+++ b/bin/CRMC/run_generic_tarball_cvmfs.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+#script to run generic lhe generation tarballs
+#kept as simply as possible to minimize need
+#to update the cmssw release
+#(all the logic goes in the run script inside the tarball
+# on frontier)
+#J.Bendavid
+
+#exit on first error
+set -e
+
+echo "   ______________________________________     "
+echo "         Running Generic Tarball/Gridpack     "
+echo "   ______________________________________     "
+
+path=${1}
+echo "gridpack tarball path = $path"
+
+nevt=${2}
+echo "%MSG-MG5 number of events requested = $nevt"
+
+rnum=${3}
+echo "%MSG-MG5 random seed used for the run = $rnum"
+
+ncpu=${4}
+echo "%MSG-MG5 thread count requested = $ncpu"
+
+echo "%MSG-MG5 residual/optional arguments = ${@:5}"
+
+if [ -n "${5}" ]; then
+  use_gridpack_env=${5}
+  echo "%MSG-MG5 use_gridpack_env = $use_gridpack_env"
+fi
+
+if [ -n "${6}" ]; then
+  scram_arch_version=${6}
+  echo "%MSG-MG5 override scram_arch_version = $scram_arch_version"
+fi
+
+if [ -n "${7}" ]; then
+  cmssw_version=${7}
+  echo "%MSG-MG5 override cmssw_version = $cmssw_version"
+fi
+
+LHEWORKDIR=`pwd`
+
+if [ "$use_gridpack_env" = false -a -n "$scram_arch_version" -a -n  "$cmssw_version" ]; then
+  echo "%MSG-MG5 CMSSW version = $cmssw_version"
+  export SCRAM_ARCH=${scram_arch_version}
+  scramv1 project CMSSW ${cmssw_version}
+  cd ${cmssw_version}/src
+  eval `scramv1 runtime -sh`
+  cd $LHEWORKDIR
+fi
+
+if [[ -d lheevent ]]
+    then
+    echo 'lheevent directory found'
+    echo 'Setting up the environment'
+    rm -rf lheevent
+fi
+mkdir lheevent; cd lheevent
+
+#untar the tarball directly from cvmfs
+if [[ ! -f "${path}" ]]; then
+    path=${LHEWORKDIR}/${path##*/}
+fi
+tar -xaf ${path} 
+
+# If TMPDIR is unset, set it to the condor scratch area if present
+# and fallback to /tmp
+export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
+
+# define singularity
+if [ "$use_gridpack_env" != false ]; then
+    if [ -n "$scram_arch_version" ]; then
+        sing=$(echo ${scram_arch_version} | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    elif egrep -q "scram_arch_version=[^$]" runcmsgrid.sh; then
+        sing=$(grep "scram_arch_version=[^$]" runcmsgrid.sh | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    fi
+    if [ -n "${sing}" ]; then
+        sing="cmssw-el"${sing}" --"
+    fi
+fi
+
+#generate events
+${sing} ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+
+mv cmsgrid_final.lhe $LHEWORKDIR/
+
+cd $LHEWORKDIR
+
+#cleanup working directory (save space on worker node for edm output)
+rm -rf lheevent
+
+exit 0

--- a/bin/CRMC/runcmsgrid_crmc.sh
+++ b/bin/CRMC/runcmsgrid_crmc.sh
@@ -7,7 +7,6 @@ reinstall_crmc(){
     CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
     cd ${LHEWORKDIR}/${CRMCDIR}
     source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME
-    sed -i 's/AB-->/AB->/g'  ${LHEWORKDIR}/${CRMCDIR}/src/epos/epos-bas.f #FIXME
     ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${LHEWORKDIR}/${CRMCDIR}/build -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
     ${CMAKE} --build BUILD --target install --parallel $(nproc)
 }

--- a/bin/CRMC/runcmsgrid_crmc.sh
+++ b/bin/CRMC/runcmsgrid_crmc.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+fail_exit() { echo "$@"; exit 1; }
+
+reinstall_crmc(){
+    echo "Compiling CRMC"
+    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
+    cd ${LHEWORKDIR}/${CRMCDIR}
+    source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME
+    sed -i 's/AB-->/AB->/g'  ${LHEWORKDIR}/${CRMCDIR}/src/epos/epos-bas.f #FIXME
+    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${LHEWORKDIR}/${CRMCDIR}/build -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
+    ${CMAKE} --build BUILD --target install --parallel $(nproc)
+}
+
+run_crmc(){
+    echo "*** STARTING PRODUCTION ***"
+    cd ${LHEWORKDIR}/${CRMCDIR}/build/bin
+    cp ${LHEWORKDIR}/${CRMCDIR}/build/etc/crmc.param .
+    sed -i "s/MinDecayLength  1./MinDecayLength  100./" crmc.param
+    
+    generator=GENERATOR_REPLACE
+    if [ "$generator" = 'eposlhcr' ]; then
+      ./crmc -m 0 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'sibyll' ]; then
+      ./crmc -m 6 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'dpmjetIII.19' ]; then
+      ./crmc -m 12 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'qgsjetIII' ]; then
+      echo unpack qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      ./crmc -m 13 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    fi
+    mv cmsgrid_final.lhe ${LHEWORKDIR}/cmsgrid_final.lhe
+    echo "***MC GENERATION COMPLETED***"
+}
+
+echo "   ______________________________________     "
+echo "         Running crmc                    "
+echo "   ______________________________________     "
+
+nevt=${1}
+echo "%MSG-CRMC number of events requested = $nevt"
+
+rnum=${2}
+echo "%MSG-CRMC random seed used for the run = $rnum"
+
+ncpu=${3}
+echo "%MSG-CRMC number of cputs for the run = $ncpu"
+
+LHEWORKDIR=`pwd -P`
+
+use_gridpack_env=false # using LCG for now, FIXME
+if [ "$4" = false ]; then
+    use_gridpack_env=$4
+fi
+
+if [ "$use_gridpack_env" = true ]; then
+    if [[ "$5" == *[_]* ]]; then
+        scram_arch_version=${5}
+    else
+        scram_arch_version=SCRAM_ARCH_VERSION_REPLACE
+    fi
+    echo "%MSG-CRMC SCRAM_ARCH version = $scram_arch_version"
+
+    if [[ "$6" == CMSSW_* ]]; then
+        cmssw_version=${6}
+    else
+        cmssw_version=CMSSW_VERSION_REPLACE
+    fi
+    echo "%MSG-CRMC CMSSW version = $cmssw_version"
+
+    export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+    source $VO_CMS_SW_DIR/cmsset_default.sh
+
+    eval `scramv1 unsetenv -sh`
+    export SCRAM_ARCH=${scram_arch_version}
+    scramv1 project CMSSW ${cmssw_version}
+    cd ${cmssw_version}/src
+    eval `scramv1 runtime -sh`
+fi
+
+cd $LHEWORKDIR
+
+CRMCDIR=CRMCDIR_REPLACE
+
+#Install CRMC generator locally
+reinstall_crmc
+
+#Run CRMC generator
+run_crmc
+
+#Perform test
+xmllint --stream --noout ${LHEWORKDIR}/cmsgrid_final.lhe > /dev/null 2>&1; test $? -eq 0 || fail_exit "xmllint integrity check failed on cmsgrid_final.lhe"
+
+echo "Output ready with cmsgrid_final.lhe at $LHEWORKDIR"
+echo "End of job on "`date`
+exit 0

--- a/bin/CRMC/runcmsgrid_crmc.sh
+++ b/bin/CRMC/runcmsgrid_crmc.sh
@@ -4,17 +4,18 @@ fail_exit() { echo "$@"; exit 1; }
 
 reinstall_crmc(){
     echo "Compiling CRMC"
-    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
     cd ${LHEWORKDIR}/${CRMCDIR}
-    source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME
-    ${CMAKE} -S . -B BUILD -DCMAKE_INSTALL_PREFIX=${LHEWORKDIR}/${CRMCDIR}/build -DCRMC_QGSJETIII=ON -DCRMC_SIBYLL=ON -DCRMC_DPMJET19=ON
+    source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME   
+    
+    CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
+    ${CMAKE} -S . -B BUILD CMAKE_ARGS_REPLACE
     ${CMAKE} --build BUILD --target install --parallel $(nproc)
 }
 
 run_crmc(){
     echo "*** STARTING PRODUCTION ***"
-    cd ${LHEWORKDIR}/${CRMCDIR}/build/bin
-    cp ${LHEWORKDIR}/${CRMCDIR}/build/etc/crmc.param .
+    cd ${LHEWORKDIR}/${CRMCDIR}/install/bin
+    cp ${LHEWORKDIR}/${CRMCDIR}/install/etc/crmc.param .
     sed -i "s/MinDecayLength  1./MinDecayLength  100./" crmc.param
     
     generator=GENERATOR_REPLACE
@@ -28,6 +29,15 @@ run_crmc(){
     elif [ "$generator" = 'eposlhcr_NeNe' ]; then
       ./crmc -m 0 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
     
+    elif [ "$generator" = 'eposnhs_pO' ]; then
+      ./crmc -m 1 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'eposnhs_Op' ]; then
+      ./crmc -m 1 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'eposnhs_OO' ]; then
+      ./crmc -m 1 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'eposnhs_NeNe' ]; then
+      ./crmc -m 1 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+
     elif [ "$generator" = 'sibyll_pO' ]; then
       ./crmc -m 6 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
     elif [ "$generator" = 'sibyll_Op' ]; then
@@ -48,19 +58,19 @@ run_crmc(){
 
     elif [ "$generator" = 'qgsjetIII_pO' ]; then
       echo unpack qgsdat-III.lzma
-      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/install/share/crmc/qgsdat-III.lzma
       ./crmc -m 13 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
     elif [ "$generator" = 'qgsjetIII_Op' ]; then
       echo unpack qgsdat-III.lzma
-      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/install/share/crmc/qgsdat-III.lzma
       ./crmc -m 13 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
     elif [ "$generator" = 'qgsjetIII_OO' ]; then
       echo unpack qgsdat-III.lzma
-      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/install/share/crmc/qgsdat-III.lzma
       ./crmc -m 13 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
     elif [ "$generator" = 'qgsjetIII_NeNe' ]; then
       echo unpack qgsdat-III.lzma
-      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/install/share/crmc/qgsdat-III.lzma
       ./crmc -m 13 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
       
     fi

--- a/bin/CRMC/runcmsgrid_crmc.sh
+++ b/bin/CRMC/runcmsgrid_crmc.sh
@@ -5,7 +5,7 @@ fail_exit() { echo "$@"; exit 1; }
 reinstall_crmc(){
     echo "Compiling CRMC"
     cd ${LHEWORKDIR}/${CRMCDIR}
-    source /cvmfs/sft.cern.ch/lcg/views/LCG_104/x86_64-el9-gcc13-opt/setup.sh # using LCG for now, FIXME   
+    source /cvmfs/sft.cern.ch/lcg/views/LCG_107/x86_64-el8-gcc11-opt/setup.sh # using LCG for now, FIXME   
     
     CMAKE=$([[ $(cmake --version | grep -cE *"n ([3-9]\.)")>0 ]] && echo "cmake" || echo "cmake3")
     ${CMAKE} -S . -B BUILD CMAKE_ARGS_REPLACE

--- a/bin/CRMC/runcmsgrid_crmc.sh
+++ b/bin/CRMC/runcmsgrid_crmc.sh
@@ -18,16 +18,51 @@ run_crmc(){
     sed -i "s/MinDecayLength  1./MinDecayLength  100./" crmc.param
     
     generator=GENERATOR_REPLACE
-    if [ "$generator" = 'eposlhcr' ]; then
+    
+    if [ "$generator" = 'eposlhcr_pO' ]; then
       ./crmc -m 0 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
-    elif [ "$generator" = 'sibyll' ]; then
+    elif [ "$generator" = 'eposlhcr_Op' ]; then
+      ./crmc -m 0 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'eposlhcr_OO' ]; then
+      ./crmc -m 0 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'eposlhcr_NeNe' ]; then
+      ./crmc -m 0 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    
+    elif [ "$generator" = 'sibyll_pO' ]; then
       ./crmc -m 6 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
-    elif [ "$generator" = 'dpmjetIII.19' ]; then
+    elif [ "$generator" = 'sibyll_Op' ]; then
+      ./crmc -m 6 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'sibyll_OO' ]; then
+      ./crmc -m 6 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'sibyll_NeNe' ]; then
+      ./crmc -m 6 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+
+    elif [ "$generator" = 'dpmjetIII.19_pO' ]; then
       ./crmc -m 12 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
-    elif [ "$generator" = 'qgsjetIII' ]; then
+    elif [ "$generator" = 'dpmjetIII.19_Op' ]; then
+      ./crmc -m 12 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'dpmjetIII.19_OO' ]; then
+      ./crmc -m 12 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'dpmjetIII.19_NeNe' ]; then
+      ./crmc -m 12 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+
+    elif [ "$generator" = 'qgsjetIII_pO' ]; then
       echo unpack qgsdat-III.lzma
       xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
       ./crmc -m 13 -i 1 -p 6800 -I 80160 -P -3400 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'qgsjetIII_Op' ]; then
+      echo unpack qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      ./crmc -m 13 -i 80160 -p 3400 -I 1 -P -6800 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'qgsjetIII_OO' ]; then
+      echo unpack qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      ./crmc -m 13 -i 80160 -p 5360 -I 80160 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+    elif [ "$generator" = 'qgsjetIII_NeNe' ]; then
+      echo unpack qgsdat-III.lzma
+      xz --format=lzma --decompress ${LHEWORKDIR}/${CRMCDIR}/build/share/crmc/qgsdat-III.lzma
+      ./crmc -m 13 -i 100200 -p 5360 -I 100200 -P -5360 -o lhe -n $nevt -s $rnum -f cmsgrid_final.lhe
+      
     fi
     mv cmsgrid_final.lhe ${LHEWORKDIR}/cmsgrid_final.lhe
     echo "***MC GENERATION COMPLETED***"


### PR DESCRIPTION
This PR adds gridpack generator for CosmicRayMonteCarlo (CRMC) capable of generating hadron collisions using four different event generators: EPOS LHC-R, Sibyll_2.3e, DPMJet-III_2019.1, QGSJETIII

The current version is using [crmc-v2.2.1](https://gitlab.iap.kit.edu/AirShowerPhysics/crmc/-/releases/v2.2.1), which has been available since 29-Apr 2025 and suited for pO/OO collisions at the LHC.

NOTE: 
* Sibyll and QGSJET are asymmetric generators (pO will be different from Op) as they designed for air showers and don't treat target remnants which as momentum 0 in lab frame. 
* Sibyll is limited to pA with A<19
* QGSJET were never designed for HI collisions (no final state interactions)

Usage:
```
./gridpack_generation.sh GEN_COL el9_amd64_gcc12 CMSSW_15_0_0_pre2
```
where 
`GEN=[eposlhcr, sibyll, dpmjetIII.19, qgsjetIII]` is the generator type
`COL=[pO, Op, OO, NeNe]` is the collisions type

The beam energy is hardcoded:
pO collisions E_beam = 6.8 ZTeV
OO/NeNe collisions E_beam = 5.36 ZTeV

 