### PR TITLE
include MadLoopParams card if it exists

### DIFF
--- a/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
+++ b/bin/MadGraph5_aMCatNLO/gridpack_generation.sh
@@ -275,7 +275,7 @@ make_gridpack () {
           #get needed BSM model
           if [[ $model = *[!\ ]* ]]; then
             echo "Loading extra model $model"
-            wget --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/$model	
+            wget --no-check-certificate https://cms-project-generators.web.cern.ch/cms-project-generators/$model
             cd models
             if [[ $model == *".zip"* ]]; then
               unzip ../$model
@@ -522,6 +522,11 @@ make_gridpack () {
       if [ -e $CARDSDIR/${name}_madspin_card.dat ]; then
         cp $CARDSDIR/${name}_madspin_card.dat ./Cards/madspin_card.dat
       fi
+
+      if [ -e $CARDSDIR/${name}_MadLoopParams.dat ]; then
+        cp $CARDSDIR/${name}_MadLoopParams.dat ./Cards/MadLoopParams.dat
+      fi
+
       
       echo "shower=OFF" > makegrid.dat
       echo "reweight=OFF" >> makegrid.dat
@@ -577,7 +582,11 @@ make_gridpack () {
       #######################
     
       echo "starting LO mode"
-    
+      if [ -e $CARDSDIR/${name}_MadLoopParams.dat ]; then
+        cp $CARDSDIR/${name}_MadLoopParams.dat ./Cards/MadLoopParams.dat
+      fi
+
+      
       echo "done" > makegrid.dat
       echo "set gridpack True" >> makegrid.dat
       if [ -e $CARDSDIR/${name}_customizecards.dat ]; then
@@ -585,7 +594,7 @@ make_gridpack () {
               echo "" >> makegrid.dat
       fi
       echo "done" >> makegrid.dat
-    
+
     #   set +e
       cat makegrid.dat | ./bin/generate_events pilotrun
       echo "finished pilot run"


### PR DESCRIPTION
Some BSM models requires MadLoopParams card when running madgraph. This modification checks if a xxxx__MadLoopParams.dat exists in the cards directory (together with other input cards, such as run card, proc_card, etc), if it exists, copy it over to the Cards directory before creating gridpacks. 

This update has been tested with the Type-I 2HDM+a model with the process card [here](https://github.com/syuvivida/DM/blob/HHMET/2HDMaTypeI/inclusiveDecay/Cards/proc_card_mg5.dat).