### PR TITLE
ttbar cards for Run III production

### DIFF
--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_AllHadronic_13p6TeV
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_AllHadronic_13p6TeV
@@ -1,0 +1,63 @@
+(run){
+  % general setting
+  EVENTS 1000; ERROR 0.99;
+  EVENT_MODE HepMC;
+
+  % scales, tags for scale variations
+  FSF:=1.; RSF:=1.; QSF:=1.;
+  SCALES STRICT_METS{FSF*MU_F2}{RSF*MU_R2}{QSF*MU_Q2};
+  SCALE_VARIATIONS 0.25,0.25 0.25,1. 1.,0.25 1.,1. 1.,4. 4.,1. 4.,4.;
+  CORE_SCALE QCD;
+  EXCLUSIVE_CLUSTER_MODE 1;
+  METS_BBAR_MODE 5;
+  NLO_CSS_PSMODE=1;
+  NLO_SUBTRACTION_SCHEME=2;
+
+  % tags for process setup
+  NJET:=4; LJET:=2,3; QCUT:=30.;
+
+  % me generator settings
+  ME_SIGNAL_GENERATOR Comix Amegic LOOPGEN;
+  EVENT_GENERATION_MODE Unweighted;
+  OVERWEIGHT_THRESHOLD = 10;
+  HEPMC_USE_NAMED_WEIGHTS=1;
+  LOOPGEN:=OpenLoops;
+  OL_PARAMETERS preset 2 ew_renorm_scheme 1;
+  ASSOCIATED_CONTRIBUTIONS_VARIATIONS=EW EW|LO1 EW|LO1|LO2 EW|LO1|LO2|LO3;
+  INTEGRATION_ERROR=0.05;
+
+  % collider setup
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+  PDF_VARIATIONS=NNPDF30_nnlo_as_0118[all]
+
+  % decays
+  HARD_DECAYS On;
+  HARD_SPIN_CORRELATIONS 1;
+  HDH_STATUS[24,12,-11]=0
+  HDH_STATUS[24,14,-13]=0
+  HDH_STATUS[24,16,-15]=0
+  HDH_STATUS[-24,-12,11]=0
+  HDH_STATUS[-24,-14,13]=0
+  HDH_STATUS[-24,-16,15]=0
+  STABLE[24] 0; STABLE[6] 0; WIDTH[6] 0;
+
+  NLO_SMEAR_THRESHOLD 1;
+  NLO_SMEAR_POWER 2;
+}(run)
+
+(processes){
+  Process : 93 93 ->  6 -6 93{NJET};
+  Order (*,0); CKKW sqr(QCUT/E_CMS);
+  NLO_QCD_Mode MC@NLO {LJET};
+  ME_Generator Amegic {LJET};
+  RS_ME_Generator Comix {LJET};
+  Loop_Generator LOOPGEN {LJET};
+  Associated_Contributions EW|LO1|LO2|LO3 {LJET};
+  Enhance_Function VAR{pow(max(sqrt(H_T2)-PPerp(p[2])-PPerp(p[3]),(PPerp(p[2])+PPerp(p[3]))/2)/30.0,2)} {3,4,5,6}
+  End process
+}(processes)

--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_Dilepton_13p6TeV
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_Dilepton_13p6TeV
@@ -1,0 +1,63 @@
+(run){
+  % general setting
+  EVENTS 1000; ERROR 0.99;
+  EVENT_MODE HepMC;
+
+  % scales, tags for scale variations
+  FSF:=1.; RSF:=1.; QSF:=1.;
+  SCALES STRICT_METS{FSF*MU_F2}{RSF*MU_R2}{QSF*MU_Q2};
+  SCALE_VARIATIONS 0.25,0.25 0.25,1. 1.,0.25 1.,1. 1.,4. 4.,1. 4.,4.;
+  CORE_SCALE QCD;
+  EXCLUSIVE_CLUSTER_MODE 1;
+  METS_BBAR_MODE 5;
+  NLO_CSS_PSMODE=1;
+  NLO_SUBTRACTION_SCHEME=2;
+
+  % tags for process setup
+  NJET:=4; LJET:=2,3; QCUT:=30.;
+
+  % me generator settings
+  ME_SIGNAL_GENERATOR Comix Amegic LOOPGEN;
+  EVENT_GENERATION_MODE Unweighted;
+  OVERWEIGHT_THRESHOLD = 10;
+  HEPMC_USE_NAMED_WEIGHTS=1;
+  LOOPGEN:=OpenLoops;
+  OL_PARAMETERS preset 2 ew_renorm_scheme 1;
+  ASSOCIATED_CONTRIBUTIONS_VARIATIONS=EW EW|LO1 EW|LO1|LO2 EW|LO1|LO2|LO3;
+  INTEGRATION_ERROR=0.05;
+
+  % collider setup
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+  PDF_VARIATIONS=NNPDF30_nnlo_as_0118[all]
+
+  % decays
+  HARD_DECAYS On;
+  HARD_SPIN_CORRELATIONS 1;
+  HDH_STATUS[24,12,-11]=2 
+  HDH_STATUS[24,14,-13]=2
+  HDH_STATUS[24,16,-15]=2
+  HDH_STATUS[-24,-12,11]=2
+  HDH_STATUS[-24,-14,13]=2
+  HDH_STATUS[-24,-16,15]=2
+  STABLE[24] 0; STABLE[6] 0; WIDTH[6] 0;
+
+  NLO_SMEAR_THRESHOLD 1;
+  NLO_SMEAR_POWER 2;
+}(run)
+
+(processes){
+  Process : 93 93 ->  6 -6 93{NJET};
+  Order (*,0); CKKW sqr(QCUT/E_CMS);
+  NLO_QCD_Mode MC@NLO {LJET};
+  ME_Generator Amegic {LJET};
+  RS_ME_Generator Comix {LJET};
+  Loop_Generator LOOPGEN {LJET};
+  Associated_Contributions EW|LO1|LO2|LO3 {LJET};
+  Enhance_Function VAR{pow(max(sqrt(H_T2)-PPerp(p[2])-PPerp(p[3]),(PPerp(p[2])+PPerp(p[3]))/2)/30.0,2)} {3,4,5,6}
+  End process
+}(processes)

--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_SemileptonM_13p6TeV
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_SemileptonM_13p6TeV
@@ -1,0 +1,63 @@
+(run){
+  % general setting
+  EVENTS 1000; ERROR 0.99;
+  EVENT_MODE HepMC;
+
+  % scales, tags for scale variations
+  FSF:=1.; RSF:=1.; QSF:=1.;
+  SCALES STRICT_METS{FSF*MU_F2}{RSF*MU_R2}{QSF*MU_Q2};
+  SCALE_VARIATIONS 0.25,0.25 0.25,1. 1.,0.25 1.,1. 1.,4. 4.,1. 4.,4.;
+  CORE_SCALE QCD;
+  EXCLUSIVE_CLUSTER_MODE 1;
+  METS_BBAR_MODE 5;
+  NLO_CSS_PSMODE=1;
+  NLO_SUBTRACTION_SCHEME=2;
+
+  % tags for process setup
+  NJET:=4; LJET:=2,3; QCUT:=30.;
+
+  % me generator settings
+  ME_SIGNAL_GENERATOR Comix Amegic LOOPGEN;
+  EVENT_GENERATION_MODE Unweighted;
+  OVERWEIGHT_THRESHOLD = 10;
+  HEPMC_USE_NAMED_WEIGHTS=1;
+  LOOPGEN:=OpenLoops;
+  OL_PARAMETERS preset 2 ew_renorm_scheme 1;
+  ASSOCIATED_CONTRIBUTIONS_VARIATIONS=EW EW|LO1 EW|LO1|LO2 EW|LO1|LO2|LO3;
+  INTEGRATION_ERROR=0.05;
+
+  % collider setup
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+  PDF_VARIATIONS=NNPDF30_nnlo_as_0118[all]
+
+  % decays
+  HARD_DECAYS On;
+  HARD_SPIN_CORRELATIONS 1;
+  HDH_STATUS[24,12,-11]=0
+  HDH_STATUS[24,14,-13]=0
+  HDH_STATUS[24,16,-15]=0
+  HDH_STATUS[-24,-12,11]=2
+  HDH_STATUS[-24,-14,13]=2
+  HDH_STATUS[-24,-16,15]=2
+  STABLE[24] 0; STABLE[6] 0; WIDTH[6] 0;
+
+  NLO_SMEAR_THRESHOLD 1;
+  NLO_SMEAR_POWER 2;
+}(run)
+
+(processes){
+  Process : 93 93 ->  6 -6 93{NJET};
+  Order (*,0); CKKW sqr(QCUT/E_CMS);
+  NLO_QCD_Mode MC@NLO {LJET};
+  ME_Generator Amegic {LJET};
+  RS_ME_Generator Comix {LJET};
+  Loop_Generator LOOPGEN {LJET};
+  Associated_Contributions EW|LO1|LO2|LO3 {LJET};
+  Enhance_Function VAR{pow(max(sqrt(H_T2)-PPerp(p[2])-PPerp(p[3]),(PPerp(p[2])+PPerp(p[3]))/2)/30.0,2)} {3,4,5,6}
+  End process
+}(processes)

--- a/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_SemileptonP_13p6TeV
+++ b/bin/Sherpa/cards/production/13p6TeV/Run.dat_ttbar_SemileptonP_13p6TeV
@@ -1,0 +1,63 @@
+(run){
+  % general setting
+  EVENTS 1000; ERROR 0.99;
+  EVENT_MODE HepMC;
+
+  % scales, tags for scale variations
+  FSF:=1.; RSF:=1.; QSF:=1.;
+  SCALES STRICT_METS{FSF*MU_F2}{RSF*MU_R2}{QSF*MU_Q2};
+  SCALE_VARIATIONS 0.25,0.25 0.25,1. 1.,0.25 1.,1. 1.,4. 4.,1. 4.,4.;
+  CORE_SCALE QCD;
+  EXCLUSIVE_CLUSTER_MODE 1;
+  METS_BBAR_MODE 5;
+  NLO_CSS_PSMODE=1;
+  NLO_SUBTRACTION_SCHEME=2;
+
+  % tags for process setup
+  NJET:=4; LJET:=2,3; QCUT:=30.;
+
+  % me generator settings
+  ME_SIGNAL_GENERATOR Comix Amegic LOOPGEN;
+  EVENT_GENERATION_MODE Unweighted;
+  OVERWEIGHT_THRESHOLD = 10;
+  HEPMC_USE_NAMED_WEIGHTS=1;
+  LOOPGEN:=OpenLoops;
+  OL_PARAMETERS preset 2 ew_renorm_scheme 1;
+  ASSOCIATED_CONTRIBUTIONS_VARIATIONS=EW EW|LO1 EW|LO1|LO2 EW|LO1|LO2|LO3;
+  INTEGRATION_ERROR=0.05;
+
+  % collider setup
+  BEAM_1 2212; BEAM_ENERGY_1 6800.;
+  BEAM_2 2212; BEAM_ENERGY_2 6800.;
+  PDF_LIBRARY     LHAPDFSherpa;
+  PDF_SET         NNPDF30_nnlo_as_0118;
+  PDF_SET_VERSION 0;
+  PDF_GRID_PATH   PDFsets;
+  PDF_VARIATIONS=NNPDF30_nnlo_as_0118[all]
+
+  % decays
+  HARD_DECAYS On;
+  HARD_SPIN_CORRELATIONS 1;
+  HDH_STATUS[24,12,-11]=2 
+  HDH_STATUS[24,14,-13]=2
+  HDH_STATUS[24,16,-15]=2
+  HDH_STATUS[-24,-12,11]=0
+  HDH_STATUS[-24,-14,13]=0
+  HDH_STATUS[-24,-16,15]=0
+  STABLE[24] 0; STABLE[6] 0; WIDTH[6] 0;
+
+  NLO_SMEAR_THRESHOLD 1;
+  NLO_SMEAR_POWER 2;
+}(run)
+
+(processes){
+  Process : 93 93 ->  6 -6 93{NJET};
+  Order (*,0); CKKW sqr(QCUT/E_CMS);
+  NLO_QCD_Mode MC@NLO {LJET};
+  ME_Generator Amegic {LJET};
+  RS_ME_Generator Comix {LJET};
+  Loop_Generator LOOPGEN {LJET};
+  Associated_Contributions EW|LO1|LO2|LO3 {LJET};
+  Enhance_Function VAR{pow(max(sqrt(H_T2)-PPerp(p[2])-PPerp(p[3]),(PPerp(p[2])+PPerp(p[3]))/2)/30.0,2)} {3,4,5,6}
+  End process
+}(processes)


### PR DESCRIPTION
Run-III Sherpa cards for ttbar production in all channels (dilepton, semilepton, all hadronic) following the discussion on the ongoing Run-II sample (see https://github.com/cms-sw/genproductions/pull/3867)

See also talk at GEN group [here](https://indico.cern.ch/event/1523797/contributions/6411006/attachments/3028502/5346126/sherpa.pdf)

The dilepton and all-hadron channels have been validated using 13 TeV data as well, after the changes in the Run-II request. A few plots follow below:

Dilepton channel:

![d01-x01-y01](https://github.com/user-attachments/assets/f8266b50-d06c-4e58-ab4d-32dc62e4cd91)
![d08-x01-y01](https://github.com/user-attachments/assets/79863c20-52ef-493a-9b1e-40889ac3e08d)
![d16-x01-y01](https://github.com/user-attachments/assets/d9c7b96c-4855-4425-b80c-ec9f20a2dacf)
![d17-x01-y01](https://github.com/user-attachments/assets/417867a5-1897-43fc-9aa9-b4b28ce6cf2e)

All-hadronic channel:
![d06-x01-y01](https://github.com/user-attachments/assets/f8eadbca-8fa2-4c89-a020-ace146abcec5)
![d07-x01-y01](https://github.com/user-attachments/assets/617443ec-6cf9-43c2-8241-d43b61aa00e4)
![d02-x01-y01](https://github.com/user-attachments/assets/58a70991-350f-4c8a-8515-04987772fb33)
![d54-x01-y01](https://github.com/user-attachments/assets/c5c4e723-a8ec-4a8d-90b3-a3660e454f11)

Best,
Javier.