### PR TITLE
Fix DY lept eta dist & xsec

### DIFF
--- a/bin/MadGraph5_aMCatNLO/patches/0079-fix_asym_scale_choice.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0079-fix_asym_scale_choice.patch
@@ -1,0 +1,16 @@
+diff: MG5_aMC_v3_5_6/Template/NLO/MCatNLO/include/pineappl_maxproc.inc: No such file or directory
+diff: MG5_aMC_v3_5_6-patch/Template/NLO/MCatNLO/include/pineappl_maxproc.inc: No such file or directory
+diff -ruN MG5_aMC_v3_5_6/madgraph/iolibs/export_v4.py MG5_aMC_v3_5_6-patch/madgraph/iolibs/export_v4.py
+--- a/madgraph/iolibs/export_v4.py	2024-09-27 05:19:41.000000000 +0900
++++ b/madgraph/iolibs/export_v4.py	2025-03-17 17:39:13.000000000 +0900
+@@ -1779,7 +1779,7 @@
+                         if subproc_group:
+                             pdf_lines = pdf_lines + \
+                                         ("%s%d=PDG2PDF(LPP(IB(%d)),%d, IB(%d)," + \
+-                                         "XBK(IB(%d)),DSQRT(Q2FACT(IB(%d))))\n") % \
++                                         "XBK(IB(%d)),DSQRT(Q2FACT(%d)))\n") % \
+                                          (pdf_codes[initial_state],
+                                           i + 1, i + 1, pdgtopdf[initial_state],i+1,
+                                           i + 1, i + 1)
+diff: MG5_aMC_v3_5_6/vendor/SudGen/NNPDFDriver.f: No such file or directory
+diff: MG5_aMC_v3_5_6-patch/vendor/SudGen/NNPDFDriver.f: No such file or directory

--- a/bin/MadGraph5_aMCatNLO/patches/0080-fix_xsec_issue.patch
+++ b/bin/MadGraph5_aMCatNLO/patches/0080-fix_xsec_issue.patch
@@ -1,0 +1,48 @@
+diff -ruN MG5_aMC_v3_5_6/madgraph/interface/madevent_interface.py MG5_aMC_v3_5_6-patch/madgraph/interface/madevent_interface.py
+--- a/madgraph/interface/madevent_interface.py	2024-09-27 05:19:41.000000000 +0900
++++ b/madgraph/interface/madevent_interface.py	2025-05-06 13:12:11.000000000 +0900
+@@ -7056,6 +7056,7 @@
+         
+         for data in partials_info:
+             AllEvent.add(*data)
++            sum_xsec += data[1]
+ 
+         if not hasattr(self,'proc_characteristic'):
+             self.proc_characteristic = self.get_characteristics()
+diff -ruN MG5_aMC_v3_5_6/madgraph/various/lhe_parser.py MG5_aMC_v3_5_6-patch/madgraph/various/lhe_parser.py
+--- a/madgraph/various/lhe_parser.py	2024-09-27 05:19:42.000000000 +0900
++++ b/madgraph/various/lhe_parser.py	2025-05-06 13:12:32.000000000 +0900
+@@ -1025,12 +1025,12 @@
+                 from_init = True
+ 
+             if not from_init:
+-                if group in grouped_cross:
+-                    grouped_cross[group] += self.allcross[i]
+-                    grouped_error[group] += self.error[i]**2 
++                if int(group) in grouped_cross:
++                    grouped_cross[int(group)] += self.allcross[i]
++                    grouped_error[int(group)] += self.error[i]**2 
+                 else:
+-                    grouped_cross[group] = self.allcross[i]
+-                    grouped_error[group] = self.error[i]**2
++                    grouped_cross[int(group)] = self.allcross[i]
++                    grouped_error[int(group)] = self.error[i]**2
+             else:
+                 ban = banner_mod.Banner(ff.banner)
+                 for line in  ban['init'].split('\n'):
+@@ -1038,11 +1038,11 @@
+                     if len(splitline)==4:
+                         cross, error, _, group = splitline
+                         if int(group) in grouped_cross:
+-                            grouped_cross[group] += float(cross)
+-                            grouped_error[group] += float(error)**2                        
++                            grouped_cross[int(group)] += float(cross)
++                            grouped_error[int(group)] += float(error)**2                        
+                         else:
+-                            grouped_cross[group] = float(cross)
+-                            grouped_error[group] = float(error)**2                             
++                            grouped_cross[int(group)] = float(cross)
++                            grouped_error[int(group)] = float(error)**2                             
+         nb_group = len(grouped_cross)
+         
+         # compute the information for the first line 


### PR DESCRIPTION
Two updates on LO processes

0079-fix_asym_scale_choice: This patch fixes asymmetric parton scale choice which causes asymmetric lepton eta distribution. For more details, See https://indico.cern.ch/event/1541567/#preview:5406202 for more details.

0080-fix_xsec_issue: When a process contains more than ~100 subprocesses (e.g. Z + 3-jet), MG356 fails to add their cross sections. This problem has been occurred only at LO processes. See https://indico.cern.ch/event/1549042/#preview:5429120 for updated results.

