### PR TITLE
TTHH LO generation with dileptonic and semileptonic (including tau) final state

### DIFF
--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_proc_card.dat
@@ -1,0 +1,16 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+
+generate p p > t t~ h h, (t > w+ b, w+ > l+ vl), (t~ > w- b~, w- > l- vl~)
+output TTHH_DL_LO_includeTau -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_DL_LO_includeTau/TTHH_DL_LO_includeTau_run_card.dat
@@ -1,0 +1,274 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+tag_1 =  run_tag  ! name of the run
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+.false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+1000  =  nevents  ! Number of unweighted events requested
+0     =  iseed    ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+1     =  lpp1     ! beam 1 type
+1     =  lpp2     ! beam 2 type
+6800.0        =  ebeam1   ! beam 1 total energy in GeV
+6800.0        =  ebeam2   ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+0.0   =  polbeam1  ! beam polarization for beam 1
+0.0   =  polbeam2  ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+lhapdf        =  pdlabel      ! PDF set
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+.false.       =  fixed_ren_scale   ! if .true. use fixed ren scale
+.false.       =  fixed_fac_scale   ! if .true. use fixed fac scale
+91.188        =  scale             ! fixed ren scale
+91.188        =  dsqrt_q2fact1     ! fixed fact scale for pdf1
+91.188        =  dsqrt_q2fact2     ! fixed fact scale for pdf2
+-1    =  dynamical_scale_choice  ! Choose one of the preselected dynamical choices
+1.0   =  scalefact         ! scale factor for event-by-event scales
+#*********************************************************************
+# Time of flight information. (-1 means not run)
+#*********************************************************************
+-1.0  =  time_of_flight  ! threshold below which info is not written
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+0     =  ickkw             ! 0 no matching, 1 MLM, 2 CKKW matching
+1     =  highestmult       ! for ickkw=2, highest mult group
+1     =  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+1.0   =  alpsfact          ! scale factor for QCD emission vx
+.false.       =  chcluster         ! cluster only according to channel diag
+T =  pdfwgt            ! for ickkw=1, perform pdf reweighting
+5     =  asrwgtflavor      ! highest quark flavor for a_s reweight
+.true.        =  clusinfo          ! include clustering tag in output
+3.0   =  lhe_version        ! Change the way clustering information pass to shower.
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+.false.       =  auto_ptj_mjj   ! Automatic setting of ptj and mjj
+#**********************************************************
+#
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+15.0  =  bwcutoff       ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+.false.       =  cut_decays     ! Cut decay products
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+0     =  nhel           ! Number of helicities used per event
+#*******************
+# Standard Cuts
+#*******************
+#
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+0.01  =  ptj        ! minimum pt for the jets
+0.0   =  ptb        ! minimum pt for the b
+10.0  =  pta        ! minimum pt for the photons
+0.0   =  ptl        ! minimum pt for the charged leptons
+0.0   =  misset     ! minimum missing Et (sum of neutrino's momenta)
+0.0   =  ptheavy    ! minimum pt for one heavy final state
+-1.0  =  ptjmax     ! maximum pt for the jets
+-1.0  =  ptbmax     ! maximum pt for the b
+-1.0  =  ptamax     ! maximum pt for the photons
+-1.0  =  ptlmax     ! maximum pt for the charged leptons
+-1.0  =  missetmax  ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+0.0   =  ej      ! minimum E for the jets
+0.0   =  eb      ! minimum E for the b
+0.0   =  ea      ! minimum E for the photons
+0.0   =  el      ! minimum E for the charged leptons
+-1.0  =  ejmax  ! maximum E for the jets
+-1.0  =  ebmax  ! maximum E for the b
+-1.0  =  eamax  ! maximum E for the photons
+-1.0  =  elmax  ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+5.0   =  etaj     ! max rap for the jets
+-1.0  =  etab     ! max rap for the b
+-1.0  =  etaa     ! max rap for the photons
+-1.0  =  etal     ! max rap for the charged leptons
+0.0   =  etajmin  ! min rap for the jets
+0.0   =  etabmin  ! min rap for the b
+0.0   =  etaamin  ! min rap for the photons
+0.0   =  etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+0.0   =  drjj     ! min distance between jets
+0.0   =  drbb     ! min distance between b's
+0.0   =  drll     ! min distance between leptons
+0.0   =  draa     ! min distance between gammas
+0.0   =  drbj     ! min distance between b and jet
+0.1   =  draj     ! min distance between gamma and jet
+0.0   =  drjl     ! min distance between jet and lepton
+0.0   =  drab     ! min distance between gamma and b
+0.0   =  drbl     ! min distance between b and lepton
+0.1   =  dral     ! min distance between gamma and lepton
+-1.0  =  drjjmax  ! max distance between jets
+-1.0  =  drbbmax  ! max distance between b's
+-1.0  =  drllmax  ! max distance between leptons
+-1.0  =  draamax  ! max distance between gammas
+-1.0  =  drbjmax  ! max distance between b and jet
+-1.0  =  drajmax  ! max distance between gamma and jet
+-1.0  =  drjlmax  ! max distance between jet and lepton
+-1.0  =  drabmax  ! max distance between gamma and b
+-1.0  =  drblmax  ! max distance between b and lepton
+-1.0  =  dralmax  ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+0.0   =  mmjj     ! min invariant mass of a jet pair
+0.0   =  mmbb     ! min invariant mass of a b pair
+0.0   =  mmaa     ! min invariant mass of gamma gamma pair
+4.0   =  mmll     ! min invariant mass of l+l- (same flavour) lepton pair
+-1.0  =  mmjjmax  ! max invariant mass of a jet pair
+-1.0  =  mmbbmax  ! max invariant mass of a b pair
+-1.0  =  mmaamax  ! max invariant mass of gamma gamma pair
+-1.0  =  mmllmax  ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+0.0   =  mmnl     ! min invariant mass for all letpons (l+- and vl)
+-1.0  =  mmnlmax  ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+0.0   =  ptllmin   ! Minimum pt for 4-momenta sum of leptons(l and vl)
+-1.0  =  ptllmax   ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+0.0   =  xptj  ! minimum pt for at least one jet
+0.0   =  xptb  ! minimum pt for at least one b
+0.0   =  xpta  ! minimum pt for at least one photon
+0.0   =  xptl  ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+0.0   =  ptj1min  ! minimum pt for the leading jet in pt
+0.0   =  ptj2min  ! minimum pt for the second jet in pt
+0.0   =  ptj3min  ! minimum pt for the third jet in pt
+0.0   =  ptj4min  ! minimum pt for the fourth jet in pt
+-1.0  =  ptj1max  ! maximum pt for the leading jet in pt
+-1.0  =  ptj2max  ! maximum pt for the second jet in pt
+-1.0  =  ptj3max  ! maximum pt for the third jet in pt
+-1.0  =  ptj4max  ! maximum pt for the fourth jet in pt
+0     =  cutuse   ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+0.0   =  ptl1min  ! minimum pt for the leading lepton in pt
+0.0   =  ptl2min  ! minimum pt for the second lepton in pt
+0.0   =  ptl3min  ! minimum pt for the third lepton in pt
+0.0   =  ptl4min  ! minimum pt for the fourth lepton in pt
+-1.0  =  ptl1max  ! maximum pt for the leading lepton in pt
+-1.0  =  ptl2max  ! maximum pt for the second lepton in pt
+-1.0  =  ptl3max  ! maximum pt for the third lepton in pt
+-1.0  =  ptl4max  ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+0.0   =  htjmin  ! minimum jet HT=Sum(jet pt)
+-1.0  =  htjmax  ! maximum jet HT=Sum(jet pt)
+0.0   =  ihtmin   !inclusive Ht for all partons (including b)
+-1.0  =  ihtmax   !inclusive Ht for all partons (including b)
+0.0   =  ht2min  ! minimum Ht for the two leading jets
+0.0   =  ht3min  ! minimum Ht for the three leading jets
+0.0   =  ht4min  ! minimum Ht for the four leading jets
+-1.0  =  ht2max  ! maximum Ht for the two leading jets
+-1.0  =  ht3max  ! maximum Ht for the three leading jets
+-1.0  =  ht4max  ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+0.0   =  ptgmin  ! Min photon transverse momentum
+0.4   =  R0gamma  ! Radius of isolation code
+1.0   =  xn  ! n parameter of eq.(3.4) in hep-ph/9801442
+1.0   =  epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+True  =  isoEM  ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+0.0   =  xetamin  ! minimum rapidity for two jets in the WBF case
+0.0   =  deltaeta  ! minimum rapidity for two jets in the WBF case
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+-1.0  =   ktdurham
+0.4  =   dparameter
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+5     =  maxjetflavor     ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+0     =  xqcut    ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True  =  use_syst       ! Enable systematics studies
+#
+#**************************************

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_customizecards.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_customizecards.dat
@@ -1,0 +1,3 @@
+set param_card mass 6 172.5
+set param_card yukawa 6 172.5
+set param_card mass 25 125.0

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_proc_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_proc_card.dat
@@ -1,0 +1,17 @@
+set group_subprocesses Auto
+set ignore_six_quark_processes False
+set loop_color_flows False
+set gauge unitary
+set complex_mass_scheme False
+set max_npoint_for_channel 0
+import model sm-no_b_mass
+
+define l+ = e+ mu+ ta+
+define l- = e- mu- ta-
+define vl = ve vm vt
+define vl~ = ve~ vm~ vt~
+
+generate p p > t t~ h h, (t > w+ b, w+ > j j), (t~ > w- b~, w- > l- vl~) @1
+add process p p > t t~ h h, (t > w+ b, w+ > l+ vl), (t~ > w- b~, w- > j j) @2
+
+output TTHH_SL_LO_includeTau -nojpeg

--- a/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_run_card.dat
+++ b/bin/MadGraph5_aMCatNLO/cards/production/13p6TeV/TTHH_SL_LO_includeTau/TTHH_SL_LO_includeTau_run_card.dat
@@ -1,0 +1,274 @@
+#*********************************************************************
+#                       MadGraph5_aMC@NLO                            *
+#                                                                    *
+#                     run_card.dat MadEvent                          *
+#                                                                    *
+#  This file is used to set the parameters of the run.               *
+#                                                                    *
+#  Some notation/conventions:                                        *
+#                                                                    *
+#   Lines starting with a '# ' are info or comments                  *
+#                                                                    *
+#   mind the format:   value    = variable     ! comment             *
+#*********************************************************************
+#
+#*******************
+# Running parameters
+#*******************
+#
+#*********************************************************************
+# Tag name for the run (one word)                                    *
+#*********************************************************************
+tag_1 =  run_tag  ! name of the run
+#*********************************************************************
+# Run to generate the grid pack                                      *
+#*********************************************************************
+.false. =  gridpack   !True = setting up the grid pack
+#*********************************************************************
+# Number of events and rnd seed                                      *
+# Warning: Do not generate more than 1M events in a single run       *
+# If you want to run Pythia, avoid more than 50k events in a run.    *
+#*********************************************************************
+1000  =  nevents  ! Number of unweighted events requested
+0     =  iseed    ! rnd seed (0=assigned automatically=default))
+#*********************************************************************
+# Collider type and energy                                           *
+# lpp: 0=No PDF, 1=proton, -1=antiproton, 2=photon from proton,      *
+#                                         3=photon from electron     *
+#*********************************************************************
+1     =  lpp1     ! beam 1 type
+1     =  lpp2     ! beam 2 type
+6800.0        =  ebeam1   ! beam 1 total energy in GeV
+6800.0        =  ebeam2   ! beam 2 total energy in GeV
+#*********************************************************************
+# Beam polarization from -100 (left-handed) to 100 (right-handed)    *
+#*********************************************************************
+0.0   =  polbeam1  ! beam polarization for beam 1
+0.0   =  polbeam2  ! beam polarization for beam 2
+#*********************************************************************
+# PDF CHOICE: this automatically fixes also alpha_s and its evol.    *
+#*********************************************************************
+lhapdf        =  pdlabel      ! PDF set
+$DEFAULT_PDF_SETS = lhaid
+$DEFAULT_PDF_MEMBERS = reweight_PDF      ! if pdlabel=lhapdf, this is the lhapdf number
+#*********************************************************************
+# Renormalization and factorization scales                           *
+#*********************************************************************
+.false.       =  fixed_ren_scale   ! if .true. use fixed ren scale
+.false.       =  fixed_fac_scale   ! if .true. use fixed fac scale
+91.188        =  scale             ! fixed ren scale
+91.188        =  dsqrt_q2fact1     ! fixed fact scale for pdf1
+91.188        =  dsqrt_q2fact2     ! fixed fact scale for pdf2
+-1    =  dynamical_scale_choice  ! Choose one of the preselected dynamical choices
+1.0   =  scalefact         ! scale factor for event-by-event scales
+#*********************************************************************
+# Time of flight information. (-1 means not run)
+#*********************************************************************
+-1.0  =  time_of_flight  ! threshold below which info is not written
+#*********************************************************************
+# Matching - Warning! ickkw > 1 is still beta
+#*********************************************************************
+0     =  ickkw             ! 0 no matching, 1 MLM, 2 CKKW matching
+1     =  highestmult       ! for ickkw=2, highest mult group
+1     =  ktscheme          ! for ickkw=1, 1 Durham kT, 2 Pythia pTE
+1.0   =  alpsfact          ! scale factor for QCD emission vx
+.false.       =  chcluster         ! cluster only according to channel diag
+T =  pdfwgt            ! for ickkw=1, perform pdf reweighting
+5     =  asrwgtflavor      ! highest quark flavor for a_s reweight
+.true.        =  clusinfo          ! include clustering tag in output
+3.0   =  lhe_version        ! Change the way clustering information pass to shower.
+#*********************************************************************
+#**********************************************************
+#
+#**********************************************************
+# Automatic ptj and mjj cuts if xqcut > 0
+# (turn off for VBF and single top processes)
+#**********************************************************
+.false.       =  auto_ptj_mjj   ! Automatic setting of ptj and mjj
+#**********************************************************
+#
+#**********************************
+# BW cutoff (M+/-bwcutoff*Gamma)
+#**********************************
+15.0  =  bwcutoff       ! (M+/-bwcutoff*Gamma)
+#**********************************************************
+# Apply pt/E/eta/dr/mij/kt_durham cuts on decay products or not
+# (note that etmiss/ptll/ptheavy/ht/sorted cuts always apply)
+#*************************************************************
+.false.       =  cut_decays     ! Cut decay products
+#*************************************************************
+# Number of helicities to sum per event (0 = all helicities)
+# 0 gives more stable result, but longer run time (needed for
+# long decay chains e.g.).
+# Use >=2 if most helicities contribute, e.g. pure QCD.
+#*************************************************************
+0     =  nhel           ! Number of helicities used per event
+#*******************
+# Standard Cuts
+#*******************
+#
+#*********************************************************************
+# Minimum and maximum pt's (for max, -1 means no cut)                *
+#*********************************************************************
+0.01  =  ptj        ! minimum pt for the jets
+0.0   =  ptb        ! minimum pt for the b
+10.0  =  pta        ! minimum pt for the photons
+0.0   =  ptl        ! minimum pt for the charged leptons
+0.0   =  misset     ! minimum missing Et (sum of neutrino's momenta)
+0.0   =  ptheavy    ! minimum pt for one heavy final state
+-1.0  =  ptjmax     ! maximum pt for the jets
+-1.0  =  ptbmax     ! maximum pt for the b
+-1.0  =  ptamax     ! maximum pt for the photons
+-1.0  =  ptlmax     ! maximum pt for the charged leptons
+-1.0  =  missetmax  ! maximum missing Et (sum of neutrino's momenta)
+#*********************************************************************
+# Minimum and maximum E's (in the center of mass frame)              *
+#*********************************************************************
+0.0   =  ej      ! minimum E for the jets
+0.0   =  eb      ! minimum E for the b
+0.0   =  ea      ! minimum E for the photons
+0.0   =  el      ! minimum E for the charged leptons
+-1.0  =  ejmax  ! maximum E for the jets
+-1.0  =  ebmax  ! maximum E for the b
+-1.0  =  eamax  ! maximum E for the photons
+-1.0  =  elmax  ! maximum E for the charged leptons
+#*********************************************************************
+# Maximum and minimum absolute rapidity (for max, -1 means no cut)   *
+#*********************************************************************
+5.0   =  etaj     ! max rap for the jets
+-1.0  =  etab     ! max rap for the b
+-1.0  =  etaa     ! max rap for the photons
+-1.0  =  etal     ! max rap for the charged leptons
+0.0   =  etajmin  ! min rap for the jets
+0.0   =  etabmin  ! min rap for the b
+0.0   =  etaamin  ! min rap for the photons
+0.0   =  etalmin  ! main rap for the charged leptons
+#*********************************************************************
+# Minimum and maximum DeltaR distance                                *
+#*********************************************************************
+0.0   =  drjj     ! min distance between jets
+0.0   =  drbb     ! min distance between b's
+0.0   =  drll     ! min distance between leptons
+0.0   =  draa     ! min distance between gammas
+0.0   =  drbj     ! min distance between b and jet
+0.1   =  draj     ! min distance between gamma and jet
+0.0   =  drjl     ! min distance between jet and lepton
+0.0   =  drab     ! min distance between gamma and b
+0.0   =  drbl     ! min distance between b and lepton
+0.1   =  dral     ! min distance between gamma and lepton
+-1.0  =  drjjmax  ! max distance between jets
+-1.0  =  drbbmax  ! max distance between b's
+-1.0  =  drllmax  ! max distance between leptons
+-1.0  =  draamax  ! max distance between gammas
+-1.0  =  drbjmax  ! max distance between b and jet
+-1.0  =  drajmax  ! max distance between gamma and jet
+-1.0  =  drjlmax  ! max distance between jet and lepton
+-1.0  =  drabmax  ! max distance between gamma and b
+-1.0  =  drblmax  ! max distance between b and lepton
+-1.0  =  dralmax  ! maxdistance between gamma and lepton
+#*********************************************************************
+# Minimum and maximum invariant mass for pairs                       *
+# WARNING: for four lepton final state mmll cut require to have      *
+#          different lepton masses for each flavor!                  *
+#*********************************************************************
+0.0   =  mmjj     ! min invariant mass of a jet pair
+0.0   =  mmbb     ! min invariant mass of a b pair
+0.0   =  mmaa     ! min invariant mass of gamma gamma pair
+4.0   =  mmll     ! min invariant mass of l+l- (same flavour) lepton pair
+-1.0  =  mmjjmax  ! max invariant mass of a jet pair
+-1.0  =  mmbbmax  ! max invariant mass of a b pair
+-1.0  =  mmaamax  ! max invariant mass of gamma gamma pair
+-1.0  =  mmllmax  ! max invariant mass of l+l- (same flavour) lepton pair
+#*********************************************************************
+# Minimum and maximum invariant mass for all letpons                 *
+#*********************************************************************
+0.0   =  mmnl     ! min invariant mass for all letpons (l+- and vl)
+-1.0  =  mmnlmax  ! max invariant mass for all letpons (l+- and vl)
+#*********************************************************************
+# Minimum and maximum pt for 4-momenta sum of leptons                *
+#*********************************************************************
+0.0   =  ptllmin   ! Minimum pt for 4-momenta sum of leptons(l and vl)
+-1.0  =  ptllmax   ! Maximum pt for 4-momenta sum of leptons(l and vl)
+#*********************************************************************
+# Inclusive cuts                                                     *
+#*********************************************************************
+0.0   =  xptj  ! minimum pt for at least one jet
+0.0   =  xptb  ! minimum pt for at least one b
+0.0   =  xpta  ! minimum pt for at least one photon
+0.0   =  xptl  ! minimum pt for at least one charged lepton
+#*********************************************************************
+# Control the pt's of the jets sorted by pt                          *
+#*********************************************************************
+0.0   =  ptj1min  ! minimum pt for the leading jet in pt
+0.0   =  ptj2min  ! minimum pt for the second jet in pt
+0.0   =  ptj3min  ! minimum pt for the third jet in pt
+0.0   =  ptj4min  ! minimum pt for the fourth jet in pt
+-1.0  =  ptj1max  ! maximum pt for the leading jet in pt
+-1.0  =  ptj2max  ! maximum pt for the second jet in pt
+-1.0  =  ptj3max  ! maximum pt for the third jet in pt
+-1.0  =  ptj4max  ! maximum pt for the fourth jet in pt
+0     =  cutuse   ! reject event if fails any (0) / all (1) jet pt cuts
+#*********************************************************************
+# Control the pt's of leptons sorted by pt                           *
+#*********************************************************************
+0.0   =  ptl1min  ! minimum pt for the leading lepton in pt
+0.0   =  ptl2min  ! minimum pt for the second lepton in pt
+0.0   =  ptl3min  ! minimum pt for the third lepton in pt
+0.0   =  ptl4min  ! minimum pt for the fourth lepton in pt
+-1.0  =  ptl1max  ! maximum pt for the leading lepton in pt
+-1.0  =  ptl2max  ! maximum pt for the second lepton in pt
+-1.0  =  ptl3max  ! maximum pt for the third lepton in pt
+-1.0  =  ptl4max  ! maximum pt for the fourth lepton in pt
+#*********************************************************************
+# Control the Ht(k)=Sum of k leading jets                            *
+#*********************************************************************
+0.0   =  htjmin  ! minimum jet HT=Sum(jet pt)
+-1.0  =  htjmax  ! maximum jet HT=Sum(jet pt)
+0.0   =  ihtmin   !inclusive Ht for all partons (including b)
+-1.0  =  ihtmax   !inclusive Ht for all partons (including b)
+0.0   =  ht2min  ! minimum Ht for the two leading jets
+0.0   =  ht3min  ! minimum Ht for the three leading jets
+0.0   =  ht4min  ! minimum Ht for the four leading jets
+-1.0  =  ht2max  ! maximum Ht for the two leading jets
+-1.0  =  ht3max  ! maximum Ht for the three leading jets
+-1.0  =  ht4max  ! maximum Ht for the four leading jets
+#***********************************************************************
+# Photon-isolation cuts, according to hep-ph/9801442                   *
+# When ptgmin=0, all the other parameters are ignored                  *
+# When ptgmin>0, pta and draj are not going to be used                 *
+#***********************************************************************
+0.0   =  ptgmin  ! Min photon transverse momentum
+0.4   =  R0gamma  ! Radius of isolation code
+1.0   =  xn  ! n parameter of eq.(3.4) in hep-ph/9801442
+1.0   =  epsgamma  ! epsilon_gamma parameter of eq.(3.4) in hep-ph/9801442
+True  =  isoEM  ! isolate photons from EM energy (photons and leptons)
+#*********************************************************************
+# WBF cuts                                                           *
+#*********************************************************************
+0.0   =  xetamin  ! minimum rapidity for two jets in the WBF case
+0.0   =  deltaeta  ! minimum rapidity for two jets in the WBF case
+#*********************************************************************
+# KT DURHAM CUT                                                      *
+#*********************************************************************
+-1.0  =   ktdurham
+0.4  =   dparameter
+#*********************************************************************
+# maximal pdg code for quark to be considered as a light jet         *
+# (otherwise b cuts are applied)                                     *
+#*********************************************************************
+5     =  maxjetflavor     ! Maximum jet pdg code
+#*********************************************************************
+# Jet measure cuts                                                   *
+#*********************************************************************
+0     =  xqcut    ! minimum kt jet measure between partons
+#*********************************************************************
+#
+#*********************************************************************
+# Store info for systematics studies                                 *
+# WARNING: If use_syst is T, matched Pythia output is                *
+#          meaningful ONLY if plotted taking matchscale              *
+#          reweighting into account!                                 *
+#*********************************************************************
+True  =  use_syst       ! Enable systematics studies
+#
+#**************************************


### PR DESCRIPTION
The cards including the tau leptons in the final state are uploaded following the previous merge request https://github.com/cms-sw/genproductions/pull/3863.
The cards guides the decay of the top pairs in dileptons (e mu tau) and semileptons respectively. The Higgs boson decay is handled by pythia with decay restrictions in corresponding fragments as before. 
In usage of the corresponding gridpacks, the fragments like HHto2B2V_dipoleRecoilOn-TuneCP5_13p6TeV_madgraph-pythia8.py fragment without restrictions on the tau leptons will decay the tau leptons to any final states. Thus the leptonic decay of top will include hadronic tau final state, but not only e/mu. In most of the scenario, the DL and SL generated samples is designed to be used together. 
The gridpack production and the crab generation using the gridpack and official fragment has been tested.