### PR TITLE
Upload VBFHH2B2Tau fragment fixing tau modelling issue

### DIFF
--- a/genfragments/ThirteenPointSixTeV/Higgs/HH/HHto2B2Tau_dipoleRecoilOn-TuneCP5_13p6TeV_madgraph-pythia8_FixTauModelling.py
+++ b/genfragments/ThirteenPointSixTeV/Higgs/HH/HHto2B2Tau_dipoleRecoilOn-TuneCP5_13p6TeV_madgraph-pythia8_FixTauModelling.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentHadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'TauDecays:externalMode = 2', # Fix tau modelling issue
+            '25:m0 = 125.0',
+            '25:onMode = off',
+            '25:onIfMatch = 5 -5',
+            '25:onIfMatch = 15 -15',
+            'ResonanceDecayFilter:filter = on',
+            'ResonanceDecayFilter:exclusive = on',
+            'ResonanceDecayFilter:mothers = 25',
+            'ResonanceDecayFilter:daughters = 5,5,15,15',
+            'SpaceShower:dipoleRecoil = on',
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters'
+                                    )
+        )
+                         )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
This PR uploads a new VBFHH2B2Tau fragment fixing the amc@nlo + pythia spin modelling issue that affects the decays of the taus as reported in [this presentation by Lucas](https://indico.cern.ch/event/1563348/contributions/6585336/attachments/3095184/5483157/Lucas_GEN_30June.pdf).

The fix applied is the same that has been used for the ongoing [DY re-production](https://cms-pdmv-prod.web.cern.ch/mcm/mccms?prepid=TAU-2025Jun25-0000*&page=0&shown=127).